### PR TITLE
[editor]: improve how insertion of parens is handled

### DIFF
--- a/src/editor/__tests__/editor-reducer.test.ts
+++ b/src/editor/__tests__/editor-reducer.test.ts
@@ -497,26 +497,378 @@ describe("reducer", () => {
         });
 
         describe("parens", () => {
-            it("'(' should insert a parens node", () => {
-                const math = Util.row("12");
-                const cursor = {
-                    path: [],
-                    prev: 0,
-                    next: 1,
-                };
+            describe("starting with '('", () => {
+                it("should insert a '(' at the start and a pending ')' at the end", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: null,
+                        next: 0,
+                    };
 
-                const state: State = {math, cursor};
-                const newState = reducer(state, {type: "("});
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: "("});
 
-                expect(Editor.stripIDs(newState.math)).toEqual(
-                    Editor.stripIDs(
-                        row([glyph("1"), Util.parens(""), glyph("2")]),
-                    ),
-                );
-                expect(newState.cursor).toEqual({
-                    path: [1],
-                    prev: null,
-                    next: null,
+                    const newMath = Util.row("(1+2)");
+                    // @ts-ignore
+                    newMath.children[4].value.pending = true;
+
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 0,
+                        next: 1,
+                    });
+                });
+
+                it("should insert a '(' in the middle and a pending ')' at the end", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: 0,
+                        next: 1,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: "("});
+
+                    const newMath = Util.row("1(+2)");
+                    // @ts-ignore
+                    newMath.children[4].value.pending = true;
+
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 1,
+                        next: 2,
+                    });
+                });
+
+                it("should insert a '(' at the end and a pending ')' after it", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: 2,
+                        next: null,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: "("});
+
+                    const newMath = Util.row("1+2()");
+                    // @ts-ignore
+                    newMath.children[4].value.pending = true;
+
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    // TODO: it would be nice if this could be specified by including a '|'
+                    // in the Editor AST.
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 3,
+                        next: 4,
+                    });
+                });
+            });
+
+            describe("completing with ')'", () => {
+                it("in the middle", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: null,
+                        next: 0,
+                    };
+
+                    const state: State = {math, cursor};
+                    let newState;
+                    newState = reducer(state, {type: "("});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: ")"});
+
+                    const newMath = Util.row("(1+)2");
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 3,
+                        next: 4,
+                    });
+                });
+
+                it("just before the ')'", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: null,
+                        next: 0,
+                    };
+
+                    const state: State = {math, cursor};
+                    let newState;
+                    newState = reducer(state, {type: "("});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: ")"});
+
+                    const newMath = Util.row("(1+2)");
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 4,
+                        next: null,
+                    });
+                });
+
+                it("just after the ')'", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: null,
+                        next: 0,
+                    };
+
+                    const state: State = {math, cursor};
+                    let newState;
+                    newState = reducer(state, {type: "("});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: "ArrowRight"});
+                    newState = reducer(newState, {type: ")"});
+
+                    const newMath = Util.row("(1+2)");
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 4,
+                        next: null,
+                    });
+                });
+            });
+
+            describe("starting with ')'", () => {
+                it("should insert a ')' at the end and a pending '(' at the start", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: 2,
+                        next: null,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: ")"});
+
+                    const newMath = Util.row("(1+2)");
+                    // @ts-ignore
+                    newMath.children[0].value.pending = true;
+
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 4,
+                        next: null,
+                    });
+                });
+
+                it("should insert a ')' in the middle and a pending '(' at the start", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: 1,
+                        next: 2,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: ")"});
+
+                    const newMath = Util.row("(1+)2");
+                    // @ts-ignore
+                    newMath.children[0].value.pending = true;
+
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 3,
+                        next: 4,
+                    });
+                });
+
+                it("should insert a ')' at the start and a pending '(' before it", () => {
+                    const math = Util.row("1+2");
+                    const cursor = {
+                        path: [],
+                        prev: null,
+                        next: 0,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: ")"});
+
+                    const newMath = Util.row("()1+2");
+                    // @ts-ignore
+                    newMath.children[0].value.pending = true;
+
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 1,
+                        next: 2,
+                    });
+                });
+
+                describe("completing with '('", () => {
+                    it("in the middle", () => {
+                        const math = Util.row("1+2");
+                        const cursor = {
+                            path: [],
+                            prev: 2,
+                            next: null,
+                        };
+
+                        const state: State = {math, cursor};
+                        let newState;
+                        newState = reducer(state, {type: ")"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "("});
+
+                        const newMath = Util.row("1(+2)");
+                        expect(Editor.stripIDs(newState.math)).toEqual(
+                            Editor.stripIDs(newMath),
+                        );
+                        expect(newState.cursor).toEqual({
+                            path: [],
+                            prev: 1,
+                            next: 2,
+                        });
+                    });
+
+                    it("just after the '('", () => {
+                        const math = Util.row("1+2");
+                        const cursor = {
+                            path: [],
+                            prev: 2,
+                            next: null,
+                        };
+
+                        const state: State = {math, cursor};
+                        let newState;
+                        newState = reducer(state, {type: ")"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "("});
+
+                        const newMath = Util.row("(1+2)");
+                        expect(Editor.stripIDs(newState.math)).toEqual(
+                            Editor.stripIDs(newMath),
+                        );
+                        expect(newState.cursor).toEqual({
+                            path: [],
+                            prev: 0,
+                            next: 1,
+                        });
+                    });
+
+                    it("just before the '('", () => {
+                        const math = Util.row("1+2");
+                        const cursor = {
+                            path: [],
+                            prev: 2,
+                            next: null,
+                        };
+
+                        const state: State = {math, cursor};
+                        let newState;
+                        newState = reducer(state, {type: ")"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "ArrowLeft"});
+                        newState = reducer(newState, {type: "("});
+
+                        const newMath = Util.row("(1+2)");
+                        expect(Editor.stripIDs(newState.math)).toEqual(
+                            Editor.stripIDs(newMath),
+                        );
+                        expect(newState.cursor).toEqual({
+                            path: [],
+                            prev: 0,
+                            next: 1,
+                        });
+                    });
+                });
+            });
+
+            describe("inserting inside of an existing set of parens", () => {
+                it("a(1+2)b -> a(1(+2)b -> a(1(+2))b", () => {
+                    const math = Util.row("a(1+2)b");
+                    const cursor = {
+                        path: [],
+                        prev: 2,
+                        next: 3,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: "("});
+
+                    const newMath = Util.row("a(1(+2))b");
+                    // @ts-ignore
+                    newMath.children[6].value.pending = true;
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 3,
+                        next: 4,
+                    });
+                });
+
+                it("a(1+2)b -> a(1+)2)b -> a((1+)2)b", () => {
+                    const math = Util.row("a(1+2)b");
+                    const cursor = {
+                        path: [],
+                        prev: 3,
+                        next: 4,
+                    };
+
+                    const state: State = {math, cursor};
+                    const newState = reducer(state, {type: ")"});
+
+                    const newMath = Util.row("a((1+)2)b");
+                    // @ts-ignore
+                    newMath.children[2].value.pending = true;
+                    expect(Editor.stripIDs(newState.math)).toEqual(
+                        Editor.stripIDs(newMath),
+                    );
+                    expect(newState.cursor).toEqual({
+                        path: [],
+                        prev: 5,
+                        next: 6,
+                    });
                 });
             });
         });

--- a/src/editor/editor-reducer.ts
+++ b/src/editor/editor-reducer.ts
@@ -800,12 +800,9 @@ const leftParens = (currentNode: HasChildren, draft: State): void => {
                 openingParen,
             );
 
-            // Move the cursor to the left one again.
-            draft.cursor.next =
-                cursor.next != null
-                    ? cursor.next - 1
-                    : currentNode.children.length - 1;
-            draft.cursor.prev = cursor.prev != null ? cursor.prev - 1 : null;
+            const prev = Math.max(0, draft.cursor.prev - 1);
+            draft.cursor.prev = prev;
+            draft.cursor.next = prev + 1;
             return;
         }
     }
@@ -871,7 +868,6 @@ const rightParens = (currentNode: HasChildren, draft: State): void => {
         i < currentNode.children.length;
         i++
     ) {
-        console.log(`i = ${i}`);
         const child = currentNode.children[i];
         // handle a pending closing paren to the right
         if (
@@ -885,7 +881,7 @@ const rightParens = (currentNode: HasChildren, draft: State): void => {
                 Math.min(newChildren.length, draft.cursor.prev),
                 closingParen,
             );
-            if (draft.cursor.prev > currentNode.children.length - 1) {
+            if (draft.cursor.prev >= currentNode.children.length - 1) {
                 draft.cursor.prev = currentNode.children.length - 1;
                 draft.cursor.next = null;
             }

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -114,6 +114,7 @@ export function atom<T>(value: T): Atom<T, number> {
 export type Glyph = {
     kind: "glyph";
     char: string;
+    pending?: boolean;
 };
 
 export const glyph = (char: string): Atom<Glyph, number> =>


### PR DESCRIPTION
In particular, instead of inserting a specific `parens` node we now insert `(` and `)` glyphs.  The matching paren to the one inserted by the user will appear at the opposite end of the row where the cursor is and will be in a pending state until its exact location is confirmed by the user.