### PR TITLE
[editor]: render pending parens and handle editing them correctly

### DIFF
--- a/src/components/math-renderer.tsx
+++ b/src/components/math-renderer.tsx
@@ -7,7 +7,13 @@ type GlyphProps = {glyph: Layout.Glyph; x: number; y: number};
 
 const Glyph: React.SFC<GlyphProps> = ({glyph, x, y}) => {
     return (
-        <text x={x} y={y} fontFamily="comic sans ms" fontSize={glyph.size}>
+        <text
+            x={x}
+            y={y}
+            fontFamily="comic sans ms"
+            fontSize={glyph.size}
+            fill={glyph.pending ? "#CCC" : "black"}
+        >
             {glyph.char}
         </text>
     );
@@ -52,8 +58,6 @@ const HBox: React.SFC<BoxProps> = ({box, cursor, x = 0, y = 0}) => {
 
     const showCursor = cursor && cursor.parent === box.id;
     const selection = cursor && cursor.selection;
-
-    console.log(`HBox.id = ${box.id}`);
 
     const result = box.content.map((node, index) => {
         let result: React.ReactElement | null = null;

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -100,8 +100,8 @@ export type Glyph = {
     pending?: boolean;
 };
 
-export const glyph = (char: string): Atom<Glyph, number> =>
-    atom({kind: "glyph", char});
+export const glyph = (char: string, pending?: boolean): Atom<Glyph, number> =>
+    atom({kind: "glyph", char, pending});
 
 export function stripIDs<T>(root: Node<T>): NodeWithID<T, void> {
     switch (root.type) {

--- a/src/typesetting/layout.ts
+++ b/src/typesetting/layout.ts
@@ -34,6 +34,7 @@ export type Glyph = {
     char: string;
     size: number;
     metrics: FontMetrics;
+    pending?: boolean;
 };
 
 export type Kern = {

--- a/src/typesetting/typeset.ts
+++ b/src/typesetting/typeset.ts
@@ -51,6 +51,9 @@ const typeset = (fontMetrics: FontMetrics) => (baseFontSize: number) => (
                     return box;
                 } else {
                     glyph.id = child.id;
+                    if (glyph.type === "Glyph") {
+                        glyph.pending = child.value.pending;
+                    }
                     return glyph;
                 }
             }


### PR DESCRIPTION
This PR includes the following changes:
- [x] render pending parenthesis as grey instead of black
- [x] deleting a closing paren will insert a new pending paren at the end of the row or before the first mismatched closing paren (excluding characters before the insertion point)
- [x] deleting a opening paren will delete it and the matching closing paren
- [x] inserting a character before or after a pending paren will accept it