### PR TITLE
[infra]: report coverage on all files in 'src' directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,10 @@
   "jest": {
     "transform": {
       "^.+\\.[t|j]sx?$": "babel-jest"
-    }
+    },
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tssx}"
+    ]
   },
   "typeCoverage": {
     "atLeast": 99


### PR DESCRIPTION
Before this change, jest was only reporting coverage on files that were being used in at least one test.  Since there are a few files without any tests, the report wasn't accurate.  Now it is.