### PR TITLE
Improve substeps

### DIFF
--- a/src/semantic/semantic.ts
+++ b/src/semantic/semantic.ts
@@ -165,15 +165,21 @@ export type NumericExpression =  // numbers
     | Infinity
     | Pi
     | Ident
-    | Ellipsis // n-ary
+    | Ellipsis
+
+    // n-ary
     | Add
     | Mul
-    | Func // binary
+    | Func
+
+    // binary
     | Div
     | Mod
     | Root
     | Exp
-    | Log // unary
+    | Log
+
+    // unary
     | Neg
     | Abs
     | Sum
@@ -283,21 +289,29 @@ export type NotIn = {
 };
 
 export type LogicExpression =
-    | Ident // values
+    | Ident
+
+    // values
     | True
-    | False // operations
+    | False
+
+    // operations
     | And
     | Or
     | Not
     | Xor
     | Implies
-    | Iff // relations, result in a Expression which may be evaluated to True or False
+    | Iff
+
+    // relations, result in a Expression which may be evaluated to True or False
     | Eq
     | Neq
     | Lt
     | Lte
     | Gt
-    | Gte // set relations
+    | Gte
+
+    // set relations
     | In
     | NotIn
     | Subset
@@ -374,11 +388,15 @@ export type Complexes = {
 
 export type SetExpression =
     | Set
-    | EmptySet // set operations
+
+    // set operations
+    | EmptySet
     | Union
     | Intersection
     | SetDiff
-    | CartesianProduct // number sets
+
+    // number sets
+    | CartesianProduct
     | Naturals
     | Integers
     | Rationals

--- a/src/step-checker/__tests__/fraction-checker.test.ts
+++ b/src/step-checker/__tests__/fraction-checker.test.ts
@@ -2,6 +2,10 @@ import {parse} from "../../text/text-parser";
 
 import StepChecker, {Result} from "../step-checker";
 
+import serializer from "../../semantic/semantic-serializer";
+
+expect.addSnapshotSerializer(serializer);
+
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string): Result => {
@@ -74,6 +78,15 @@ describe("FractionChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "multiplying by one over something results in a fraction",
+        ]);
+    });
+
+    it("a / b -> a * 1/b", () => {
+        const result = checkStep("a / b", "a * 1/b");
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "fraction is the same as multiplying by one over",
         ]);
     });
 
@@ -284,6 +297,11 @@ describe("FractionChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "distribution",
+            // TODO: fix this
+            "multiplying fractions",
+            "multiplication with identity",
+            "multiplying fractions",
+            "multiplication with identity",
         ]);
     });
 
@@ -294,6 +312,11 @@ describe("FractionChecker", () => {
 
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
+            // TODO: fix this
+            "multiplying fractions",
+            "multiplication with identity",
+            "multiplying fractions",
+            "multiplication with identity",
             "factoring",
         ]);
     });
@@ -303,8 +326,14 @@ describe("FractionChecker", () => {
 
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
+            // TODO: fix this
             "fraction is the same as multiplying by one over",
             "distribution",
+            "multiplying fractions",
+            "multiplication with identity",
+            "multiplying fractions",
+            "multiplication with identity",
+            "fraction is the same as multiplying by one over",
         ]);
     });
 
@@ -321,7 +350,24 @@ describe("FractionChecker", () => {
         const result = checkStep("a/c  + b/c", "(a + b) / c");
 
         expect(result.equivalent).toBe(true);
+        expect(result.reasons[0].nodes[0]).toMatchInlineSnapshot(`
+            (div
+              (add a b)
+              c)
+        `);
+        expect(result.reasons[0].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (add a b)
+              (div 1 c))
+        `);
+
         expect(result.reasons.map(reason => reason.message)).toEqual([
+            // TODO: fix this
+            "multiplying by one over something results in a fraction",
+            "multiplying fractions",
+            "multiplication with identity",
+            "multiplying fractions",
+            "multiplication with identity",
             "factoring",
             "multiplying by one over something results in a fraction",
         ]);

--- a/src/step-checker/__tests__/fraction-checker.test.ts
+++ b/src/step-checker/__tests__/fraction-checker.test.ts
@@ -318,7 +318,6 @@ describe("FractionChecker", () => {
 
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
-            // TODO: fix this
             "fraction is the same as multiplying by one over",
             "commutative property",
             "fraction is the same as multiplying by one over",

--- a/src/step-checker/__tests__/integer-checker.test.ts
+++ b/src/step-checker/__tests__/integer-checker.test.ts
@@ -329,7 +329,6 @@ describe("IntegerChecker", () => {
         ]);
     });
 
-    // TODO: there is a missing substep
     it("-(a + b) -> -1(a + b) -> -1a + -1b -> -a + -b", () => {
         const result = checkStep("-(a + b)", "-a + -b");
 
@@ -359,39 +358,173 @@ describe("IntegerChecker", () => {
         `);
         expect(result.reasons[1].message).toEqual("distribution");
 
-        expect(result.reasons).toHaveLength(2);
+        // TODO: make reasons[2] and reasons[3] be sub-steps for reasons[1]
+        // or better yet, apply [2] and [3] to [1] to the next step at global
+        // level.
+        expect(result.reasons[2].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
+        expect(result.reasons[2].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              a)
+        `);
+        expect(result.reasons[2].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons[3].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
+        expect(result.reasons[3].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              b)
+        `);
+        expect(result.reasons[3].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons).toHaveLength(4);
     });
 
-    // TODO: there is a missing substep
-    it("-a + -b -> -1 * (a + b) -> -(a + b)", () => {
+    it("-a + -b -> -1a + -1b -> -1 * (a + b) -> -(a + b)", () => {
         const result = checkStep("-a + -b", "-(a + b)");
 
         expect(result.equivalent).toBe(true);
 
-        expect(result.reasons[0].nodes[0]).toMatchInlineSnapshot(`
+        expect(result.reasons[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
+        expect(result.reasons[0].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              a)
+        `);
+        expect(result.reasons[0].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
+        expect(result.reasons[1].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              b)
+        `);
+        expect(result.reasons[1].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons[2].nodes[0]).toMatchInlineSnapshot(`
             (add
               (neg a)
               (neg b))
         `);
+        expect(result.reasons[2].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              (add a b))
+        `);
+        expect(result.reasons[2].message).toEqual("factoring");
+
+        expect(result.reasons[3].nodes[0]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              (add a b))
+        `);
+        expect(result.reasons[3].nodes[1]).toMatchInlineSnapshot(
+            `(neg (add a b))`,
+        );
+        expect(result.reasons[3].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons).toHaveLength(4);
+    });
+
+    it("-a + -b -> -1a + -1b", () => {
+        const result = checkStep("-a + -b", "-1a + -1b");
+
+        expect(result.equivalent).toBe(true);
+
+        expect(result.reasons[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
         expect(result.reasons[0].nodes[1]).toMatchInlineSnapshot(`
             (mul.exp
               (neg 1)
-              (add a b))
+              a)
         `);
-        expect(result.reasons[0].message).toEqual("factoring");
+        expect(result.reasons[0].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
 
-        expect(result.reasons[1].nodes[0]).toMatchInlineSnapshot(`
+        expect(result.reasons[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
+        expect(result.reasons[1].nodes[1]).toMatchInlineSnapshot(`
             (mul.exp
               (neg 1)
-              (add a b))
+              b)
         `);
-        expect(result.reasons[1].nodes[1]).toMatchInlineSnapshot(
-            `(neg (add a b))`,
-        );
         expect(result.reasons[1].message).toEqual(
             "negation is the same as multipling by negative one",
         );
 
         expect(result.reasons).toHaveLength(2);
+    });
+
+    it("-1a + -1b -> -1(a + b)", () => {
+        const result = checkStep("-1a + -1b", "-1(a + b)");
+
+        expect(result.equivalent).toBe(true);
+
+        expect(result.reasons[0].nodes[0]).toMatchInlineSnapshot(`
+            (add
+              (mul.imp
+                (neg 1)
+                a)
+              (mul.imp
+                (neg 1)
+                b))
+        `);
+        expect(result.reasons[0].nodes[1]).toMatchInlineSnapshot(`
+            (mul.imp
+              (neg 1)
+              (add a b))
+        `);
+        expect(result.reasons[0].message).toEqual("factoring");
+
+        expect(result.reasons).toHaveLength(1);
+    });
+
+    it("-a + -b -> -1(a + b)", () => {
+        const result = checkStep("-a + -b", "-1(a + b)");
+
+        expect(result.equivalent).toBe(true);
+
+        expect(result.reasons[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
+        expect(result.reasons[0].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              a)
+        `);
+        expect(result.reasons[0].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
+        expect(result.reasons[1].nodes[1]).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg 1)
+              b)
+        `);
+        expect(result.reasons[1].message).toEqual(
+            "negation is the same as multipling by negative one",
+        );
+
+        expect(result.reasons[2].nodes[0]).toMatchInlineSnapshot(`
+            (add
+              (neg a)
+              (neg b))
+        `);
+        expect(result.reasons[2].nodes[1]).toMatchInlineSnapshot(`
+            (mul.imp
+              (neg 1)
+              (add a b))
+        `);
+        expect(result.reasons[2].message).toEqual("factoring");
+
+        expect(result.reasons).toHaveLength(3);
     });
 });

--- a/src/step-checker/__tests__/step-checker.test.ts
+++ b/src/step-checker/__tests__/step-checker.test.ts
@@ -390,9 +390,6 @@ describe("StepChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "distribution",
-            // TODO: fix this
-            "commutative property",
-            "commutative property",
         ]);
     });
 
@@ -434,9 +431,6 @@ describe("StepChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "distribution",
-            // TODO: fix this
-            "commutative property",
-            "commutative property",
         ]);
     });
 

--- a/src/step-checker/__tests__/step-checker.test.ts
+++ b/src/step-checker/__tests__/step-checker.test.ts
@@ -390,6 +390,9 @@ describe("StepChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "distribution",
+            // TODO: fix this
+            "commutative property",
+            "commutative property",
         ]);
     });
 
@@ -431,6 +434,9 @@ describe("StepChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "distribution",
+            // TODO: fix this
+            "commutative property",
+            "commutative property",
         ]);
     });
 

--- a/src/step-checker/fraction-checker.ts
+++ b/src/step-checker/fraction-checker.ts
@@ -413,7 +413,7 @@ class FractionChecker {
                 ? [
                       {
                           message: "multiplying fractions",
-                          nodes: [],
+                          nodes: [prev, newPrev],
                       },
                       ...result.reasons,
                   ]

--- a/src/step-checker/fraction-checker.ts
+++ b/src/step-checker/fraction-checker.ts
@@ -389,6 +389,18 @@ class FractionChecker {
                     reasons: [],
                 };
             }
+            // Handle 1/b * a as well since this can come up during factoring
+            // and distribution of division.
+            if (
+                prev.args[0].type === "div" &&
+                prev.args[1].type !== "div" &&
+                checker.exactMatch(prev.args[0].args[0], Arithmetic.ONE)
+            ) {
+                return {
+                    equivalent: false,
+                    reasons: [],
+                };
+            }
         }
 
         const numFactors: Semantic.Expression[] = [];

--- a/src/step-checker/step-checker.ts
+++ b/src/step-checker/step-checker.ts
@@ -368,10 +368,18 @@ class StepChecker implements IStepChecker {
                     // before next.
                     const subReasons: Reason[] = [];
                     const equivalent = addNode.args.every((arg, index) => {
-                        const term = Arithmetic.mul([x, y.args[index]]);
+                        // Each term is in the correct order based on whether
+                        // we're distributing/factoring from left to right or
+                        // the reverse
+                        const term =
+                            x === left
+                                ? Arithmetic.mul([x, y.args[index]])
+                                : Arithmetic.mul([y.args[index], x]);
+
                         // We reset the "reasons" parameter here because we checking
                         // different nodes so we won't run into a cycle here.
                         const substep = this.checkStep(arg, term, []);
+
                         subReasons.push(...substep.reasons);
                         return substep.equivalent;
                     });
@@ -391,10 +399,8 @@ class StepChecker implements IStepChecker {
                                               nodes,
                                           },
                                           ...subReasons,
-                                          ...reasons,
                                       ]
                                     : [
-                                          ...reasons,
                                           ...subReasons,
                                           {
                                               message: reason,

--- a/src/step-checker/step-checker.ts
+++ b/src/step-checker/step-checker.ts
@@ -323,6 +323,7 @@ class StepChecker implements IStepChecker {
     checkDistribution(
         prev: Semantic.Expression,
         next: Semantic.Expression,
+        reasons: Reason[],
     ): Result {
         if (prev.type !== "mul" || next.type !== "add") {
             return {
@@ -330,12 +331,13 @@ class StepChecker implements IStepChecker {
                 reasons: [],
             };
         }
-        return this.distributionFactoring(next, prev, "distribution");
+        return this.distributionFactoring(next, prev, reasons, "distribution");
     }
 
     checkFactoring(
         prev: Semantic.Expression,
         next: Semantic.Expression,
+        reasons: Reason[],
     ): Result {
         if (prev.type !== "add" || next.type !== "mul") {
             return {
@@ -343,12 +345,13 @@ class StepChecker implements IStepChecker {
                 reasons: [],
             };
         }
-        return this.distributionFactoring(prev, next, "factoring");
+        return this.distributionFactoring(prev, next, reasons, "factoring");
     }
 
     distributionFactoring(
         addNode: Semantic.Add,
         mulNode: Semantic.Mul,
+        reasons: Reason[],
         reason: "distribution" | "factoring",
     ): Result {
         // TODO: handle distribution across n-ary multiplication later
@@ -361,26 +364,43 @@ class StepChecker implements IStepChecker {
                 if (y.type === "add" && y.args.length === addNode.args.length) {
                     // TODO: use exactMatch instead here... or we'll have track all
                     // of the reasons that are generated
+                    // TODO: apply the subReasons to previous node to get the node
+                    // before next.
+                    const subReasons: Reason[] = [];
                     const equivalent = addNode.args.every((arg, index) => {
                         const term = Arithmetic.mul([x, y.args[index]]);
                         // We reset the "reasons" parameter here because we checking
                         // different nodes so we won't run into a cycle here.
-                        return this.checkStep(arg, term, []).equivalent;
+                        const substep = this.checkStep(arg, term, []);
+                        subReasons.push(...substep.reasons);
+                        return substep.equivalent;
                     });
 
                     if (equivalent) {
-                        // TODO: include sub-reasons from checkStep
+                        const nodes =
+                            reason === "distribution"
+                                ? [mulNode, addNode]
+                                : [addNode, mulNode];
                         return {
                             equivalent: true,
-                            reasons: [
-                                {
-                                    message: reason,
-                                    nodes:
-                                        reason === "distribution"
-                                            ? [mulNode, addNode]
-                                            : [addNode, mulNode],
-                                },
-                            ],
+                            reasons:
+                                reason === "distribution"
+                                    ? [
+                                          {
+                                              message: reason,
+                                              nodes,
+                                          },
+                                          ...subReasons,
+                                          ...reasons,
+                                      ]
+                                    : [
+                                          ...reasons,
+                                          ...subReasons,
+                                          {
+                                              message: reason,
+                                              nodes,
+                                          },
+                                      ],
                         };
                     }
                 }
@@ -740,12 +760,12 @@ class StepChecker implements IStepChecker {
             return result;
         }
 
-        result = this.checkDistribution(prev, next);
+        result = this.checkDistribution(prev, next, reasons);
         if (result.equivalent) {
             return result;
         }
 
-        result = this.checkFactoring(prev, next);
+        result = this.checkFactoring(prev, next, reasons);
         if (result.equivalent) {
             return result;
         }


### PR DESCRIPTION
This PR ensures that distribution of negatives and fractions include sub-steps for converting to/from multiplication by one and to/from multiplication by one over something (respectively).