### PR TITLE
[editor]: fix issues when deleting frac, subsup, and roots at the end of an expression

### DIFF
--- a/packages/editor/src/__tests__/editor-reducer.test.ts
+++ b/packages/editor/src/__tests__/editor-reducer.test.ts
@@ -1361,6 +1361,69 @@ describe("reducer", () => {
                     next: 2,
                 });
             });
+
+            test("deleting a sup at the end of an expression", () => {
+                const math = row([glyph("1"), Util.sup("")]);
+                const cursor = {
+                    path: [1, SUP],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("1")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: 0,
+                    next: null,
+                });
+            });
+
+            test("deleting a sub at the end of an expression", () => {
+                const math = row([glyph("1"), Util.sub("")]);
+                const cursor = {
+                    path: [1, SUB],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("1")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: 0,
+                    next: null,
+                });
+            });
+
+            test("deleting a subsp at the end of an expression", () => {
+                const math = row([glyph("1"), Util.subsup("2", "")]);
+                const cursor = {
+                    path: [1, SUP],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(row([glyph("1"), Util.sub("2")])),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: 1,
+                    next: null,
+                });
+            });
         });
 
         describe("frac", () => {
@@ -1436,6 +1499,27 @@ describe("reducer", () => {
                     path: [],
                     prev: 0,
                     next: 1,
+                });
+            });
+
+            test("deleting a frac at the end of an expression", () => {
+                const math = row([glyph("1"), Util.frac("ab", "")]);
+                const cursor = {
+                    path: [1, DENOMINATOR],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("1ab")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: 2,
+                    next: null,
                 });
             });
         });
@@ -1647,6 +1731,27 @@ describe("reducer", () => {
                     path: [],
                     prev: 0,
                     next: 1,
+                });
+            });
+
+            test("deleting a root at the end of an expression", () => {
+                const math = row([glyph("1"), Util.sqrt("")]);
+                const cursor = {
+                    path: [1, RADICAND],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("1")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: 0,
+                    next: null,
                 });
             });
         });

--- a/packages/editor/src/__tests__/editor-reducer.test.ts
+++ b/packages/editor/src/__tests__/editor-reducer.test.ts
@@ -1362,6 +1362,27 @@ describe("reducer", () => {
                 });
             });
 
+            test("deleting a sup at the end of an expression resulting in an empty expression", () => {
+                const math = row([Util.sup("")]);
+                const cursor = {
+                    path: [0, SUP],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: null,
+                    next: null,
+                });
+            });
+
             test("deleting a sup at the end of an expression", () => {
                 const math = row([glyph("1"), Util.sup("")]);
                 const cursor = {
@@ -1519,6 +1540,27 @@ describe("reducer", () => {
                 expect(newState.cursor).toEqual({
                     path: [],
                     prev: 2,
+                    next: null,
+                });
+            });
+
+            test("deleting a frac at the end of an expression resulting in an empty expression", () => {
+                const math = row([Util.frac("", "")]);
+                const cursor = {
+                    path: [0, DENOMINATOR],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: null,
                     next: null,
                 });
             });
@@ -1751,6 +1793,27 @@ describe("reducer", () => {
                 expect(newState.cursor).toEqual({
                     path: [],
                     prev: 0,
+                    next: null,
+                });
+            });
+
+            test("deleting a root at the end of an expression resulting in an empty expression", () => {
+                const math = row([Util.sqrt("")]);
+                const cursor = {
+                    path: [0, RADICAND],
+                    prev: null,
+                    next: null,
+                };
+
+                const state: State = {math, cursor};
+                const newState = reducer(state, action);
+
+                expect(Editor.stripIDs(newState.math)).toEqual(
+                    Editor.stripIDs(Util.row("")),
+                );
+                expect(newState.cursor).toEqual({
+                    path: [],
+                    prev: null,
                     next: null,
                 });
             });

--- a/packages/editor/src/editor-reducer.ts
+++ b/packages/editor/src/editor-reducer.ts
@@ -198,10 +198,15 @@ const moveLeft = (
             }
         } else {
             // move to the left
+            const newPrev = prevIndex(children, prev);
+            const newNext =
+                newPrev == null
+                    ? firstIndex(children)
+                    : nextIndex(children, newPrev);
             return {
                 path: cursor.path,
-                prev: prevIndex(children, prev),
-                next: cursor.prev,
+                prev: newPrev,
+                next: newNext,
             };
         }
     } else if (cursor.path.length >= 1) {
@@ -498,15 +503,18 @@ const backspace = (currentNode: HasChildren, draft: State): void => {
             draft.cursor = moveLeft(currentNode, draft);
             return;
         }
+        const newChildren = removeChildWithIndex(children, removeIndex);
+        const newPrev = prevIndex(newChildren, cursor.prev);
+        const newNext =
+            newPrev == null
+                ? firstIndex(newChildren)
+                : nextIndex(newChildren, newPrev);
         const newCursor = {
             ...cursor,
-            prev: prevIndex(currentNode.children, cursor.prev),
-            next:
-                cursor.next != null
-                    ? prevIndex(currentNode.children, cursor.next)
-                    : null,
+            prev: newPrev,
+            next: newNext,
         };
-        currentNode.children = removeChildWithIndex(children, removeIndex);
+        currentNode.children = newChildren;
         draft.cursor = newCursor;
         return;
     }
@@ -563,10 +571,15 @@ const backspace = (currentNode: HasChildren, draft: State): void => {
             }
 
             // update cursor
+            const newPrev = prevIndex(newChildren, parentIndex);
+            const newNext =
+                newPrev == null
+                    ? firstIndex(newChildren)
+                    : nextIndex(newChildren, newPrev);
             const newCursor = {
                 path: cursor.path.slice(0, -2), // move up two levels
-                prev: prevIndex(newChildren, parentIndex),
-                next: parentIndex,
+                prev: newPrev,
+                next: newNext,
             };
 
             // update children
@@ -597,10 +610,15 @@ const backspace = (currentNode: HasChildren, draft: State): void => {
             }
 
             // update cursor
+            const newPrev = prevIndex(newChildren, parentIndex);
+            const newNext =
+                newPrev == null
+                    ? firstIndex(newChildren)
+                    : nextIndex(newChildren, newPrev);
             const newCursor = {
                 path: cursor.path.slice(0, -2), // move up two levels
-                prev: prevIndex(newChildren, parentIndex),
-                next: parentIndex,
+                prev: newPrev,
+                next: newNext,
             };
 
             // update children
@@ -628,10 +646,15 @@ const backspace = (currentNode: HasChildren, draft: State): void => {
             }
 
             // update cursor
+            const newPrev = prevIndex(newChildren, parentIndex);
+            const newNext =
+                newPrev == null
+                    ? firstIndex(newChildren)
+                    : nextIndex(newChildren, newPrev);
             const newCursor = {
                 path: cursor.path.slice(0, -2), // move up two levels
-                prev: prevIndex(newChildren, parentIndex),
-                next: parentIndex,
+                prev: newPrev,
+                next: newNext,
             };
 
             // update children


### PR DESCRIPTION
This fixes #68.