### PR TITLE
[editor]: improve selection highlight

### DIFF
--- a/packages/demo/src/editor-page.tsx
+++ b/packages/demo/src/editor-page.tsx
@@ -5,7 +5,11 @@ import * as Editor from "@math-blocks/editor";
 
 const EditorPage: React.SFC<{}> = () => (
     <div>
-        <MathEditor readonly={false} value={Editor.Util.row("2x+5=10")} />
+        <MathEditor
+            readonly={false}
+            value={Editor.Util.row("2x+5=10")}
+            focus={true}
+        />
         <div style={{position: "fixed", bottom: 0, left: 0}}>
             <MathKeypad />
         </div>

--- a/packages/editor/src/__tests__/editor-reducer.test.ts
+++ b/packages/editor/src/__tests__/editor-reducer.test.ts
@@ -2851,6 +2851,33 @@ describe("reducer", () => {
             expect(newState.selectionStart).toBe(undefined);
         });
 
+        test("starting in the middle and going left to start, ending right", () => {
+            const state = {
+                math: Util.row("1+2"),
+                cursor: {
+                    path: [],
+                    prev: null,
+                    next: 0,
+                },
+                selectionStart: {
+                    path: [],
+                    prev: 1,
+                    next: 2,
+                },
+            };
+
+            const action = {type: "ArrowRight"};
+
+            const newState = reducer(state, action);
+
+            expect(newState.cursor).toEqual({
+                path: [],
+                prev: 1,
+                next: 2,
+            });
+            expect(newState.selectionStart).toBe(undefined);
+        });
+
         // TODO: write tests for selections starting in fractions
     });
 

--- a/packages/editor/src/editor-reducer.ts
+++ b/packages/editor/src/editor-reducer.ts
@@ -1241,7 +1241,10 @@ const reducer = (state: State = initialState, action: Action): State => {
                         selectionStart.path.length > cursor.path.length
                             ? selectionStart.path[cursor.path.length]
                             : selectionStart.prev;
-                    if (next == null || (cursor.next && next > cursor.next)) {
+                    if (
+                        next == null ||
+                        (cursor.next != null && next > cursor.next)
+                    ) {
                         draft.cursor = {
                             ...draft.cursor,
                             prev,

--- a/packages/react/src/__tests__/util.test.ts
+++ b/packages/react/src/__tests__/util.test.ts
@@ -29,7 +29,7 @@ describe("layoutCursorFromState", () => {
                 parent: state.math.id,
                 prev: math.children[1].id,
                 next: math.children[2].id,
-                selection: true,
+                selection: false,
             });
         });
 


### PR DESCRIPTION
Now `layoutCursorFromState` only sets the `selection` property of the result to true if there's a selection, i.e. the selectionStart and cursor aren't in the same location.