### PR TITLE
[editor]: refactor Editor.Node to be more flexible

### DIFF
--- a/packages/demo/src/step-checker-page.tsx
+++ b/packages/demo/src/step-checker-page.tsx
@@ -10,8 +10,12 @@ import * as Semantic from "@math-blocks/semantic";
 
 const checker = new StepChecker();
 
-const question: Editor.Row<Editor.Glyph> = Editor.Util.row("2x+5=10");
-const step1: Editor.Row<Editor.Glyph> = Editor.Util.row("2x+5=10");
+type ID = {
+    id: number;
+};
+
+const question: Editor.Row<Editor.Glyph, ID> = Editor.Util.row("2x+5=10");
+const step1: Editor.Row<Editor.Glyph, ID> = Editor.Util.row("2x+5=10");
 
 enum StepState {
     Correct,
@@ -22,7 +26,7 @@ enum StepState {
 
 type Step = {
     state: StepState;
-    value: Editor.Row<Editor.Glyph>;
+    value: Editor.Row<Editor.Glyph, ID>;
 };
 
 enum ProblemState {
@@ -50,8 +54,8 @@ export const App: React.SFC<{}> = () => {
     ]);
 
     const handleCheckStep = (
-        prev: Editor.Row<Editor.Glyph>,
-        next: Editor.Row<Editor.Glyph>,
+        prev: Editor.Row<Editor.Glyph, ID>,
+        next: Editor.Row<Editor.Glyph, ID>,
     ): boolean => {
         const prevTokens = Editor.Lexer.lex(prev);
         const nextTokens = Editor.Lexer.lex(next);
@@ -168,7 +172,9 @@ export const App: React.SFC<{}> = () => {
                                         steps[index + 1].value,
                                     );
                                 }}
-                                onChange={(value: Editor.Row<Editor.Glyph>) => {
+                                onChange={(
+                                    value: Editor.Row<Editor.Glyph, ID>,
+                                ) => {
                                     const state = Editor.isEqual(
                                         steps[index].value,
                                         value,

--- a/packages/editor/src/__tests__/editor-parser.test.ts
+++ b/packages/editor/src/__tests__/editor-parser.test.ts
@@ -2,7 +2,11 @@ import parser from "../editor-parser";
 import * as Lexer from "../editor-lexer";
 import * as Editor from "../editor-ast";
 
-import {Token} from "../editor-parser";
+import * as LexUtil from "../lexer-ast";
+
+type Loc = {};
+
+type LexNode = Editor.Node<Lexer.Token, Loc>;
 
 import {serializer} from "@math-blocks/semantic";
 
@@ -131,7 +135,7 @@ describe("NewMathParser", () => {
     });
 
     it("should parse implicit multiplication", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.identifier("a"),
             Lexer.identifier("b"),
             Lexer.identifier("c"),
@@ -143,10 +147,10 @@ describe("NewMathParser", () => {
     });
 
     it("should handle fractions", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.number("1"),
             Lexer.plus(),
-            Editor.frac([Lexer.number("1")], [Lexer.identifier("x")]),
+            LexUtil.frac([Lexer.number("1")], [Lexer.identifier("x")]),
         ];
 
         const parseTree = parser.parse(tokens);
@@ -159,9 +163,9 @@ describe("NewMathParser", () => {
     });
 
     it("should handle exponents", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.identifier("x"),
-            Editor.subsup(undefined, [Lexer.number("2")]),
+            LexUtil.subsup(undefined, [Lexer.number("2")]),
         ];
 
         const parseTree = parser.parse(tokens);
@@ -170,11 +174,11 @@ describe("NewMathParser", () => {
     });
 
     it("should handle nested exponents", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.identifier("x"),
-            Editor.subsup(undefined, [
+            LexUtil.subsup(undefined, [
                 Lexer.identifier("y"),
-                Editor.subsup(undefined, [Lexer.number("2")]),
+                LexUtil.subsup(undefined, [Lexer.number("2")]),
             ]),
         ];
 
@@ -188,9 +192,9 @@ describe("NewMathParser", () => {
     });
 
     it("should handle subscripts on identifiers", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.identifier("a"),
-            Editor.subsup(
+            LexUtil.subsup(
                 [Lexer.identifier("n"), Lexer.plus(), Lexer.number("1")],
                 undefined,
             ),
@@ -202,9 +206,9 @@ describe("NewMathParser", () => {
     });
 
     it("should handle subscripts and superscripts identifiers", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.identifier("a"),
-            Editor.subsup(
+            LexUtil.subsup(
                 [Lexer.identifier("n"), Lexer.plus(), Lexer.number("1")],
                 [Lexer.number("2")],
             ),
@@ -218,9 +222,9 @@ describe("NewMathParser", () => {
     });
 
     it("should throw when a subscript is being used on a number", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.number("2"),
-            Editor.subsup([Lexer.number("0")], undefined),
+            LexUtil.subsup([Lexer.number("0")], undefined),
         ];
 
         expect(() => parser.parse(tokens)).toThrowErrorMatchingInlineSnapshot(
@@ -229,7 +233,7 @@ describe("NewMathParser", () => {
     });
 
     it("should throw when an atom is expected", () => {
-        const tokens: Array<Token> = [Lexer.number("2"), Lexer.minus()];
+        const tokens: Array<LexNode> = [Lexer.number("2"), Lexer.minus()];
 
         expect(() => parser.parse(tokens)).toThrowErrorMatchingInlineSnapshot(
             `"Unexpected 'eol' atom"`,
@@ -237,7 +241,7 @@ describe("NewMathParser", () => {
     });
 
     it("should throw on a trailing '+'", () => {
-        const tokens: Array<Token> = [
+        const tokens: Array<LexNode> = [
             Lexer.number("2"),
             Lexer.plus(),
             Lexer.number("2"),
@@ -375,7 +379,7 @@ describe("NewMathParser", () => {
             Lexer.plus(),
             Lexer.identifier("b"),
             Lexer.rparens(),
-            Editor.frac([Lexer.number("1")], [Lexer.number("2")]),
+            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
         ];
 
         const ast = parser.parse(tokens);
@@ -389,7 +393,7 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication by a frac at the start", () => {
         const tokens = [
-            Editor.frac([Lexer.number("1")], [Lexer.number("2")]),
+            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
             Lexer.identifier("b"),
         ];
 
@@ -404,8 +408,8 @@ describe("NewMathParser", () => {
 
     it("should error on two fractions in a row without an operator", () => {
         const tokens = [
-            Editor.frac([Lexer.number("1")], [Lexer.number("2")]),
-            Editor.frac([Lexer.number("1")], [Lexer.number("2")]),
+            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
+            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
         ];
 
         expect(() => parser.parse(tokens)).toThrowError(
@@ -416,7 +420,7 @@ describe("NewMathParser", () => {
     it("should handle implicit multiplication with roots", () => {
         const tokens = [
             Lexer.identifier("a"),
-            Editor.root([Lexer.identifier("b")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.identifier("b")], [Lexer.number("2")]),
         ];
 
         const ast = parser.parse(tokens);
@@ -431,8 +435,8 @@ describe("NewMathParser", () => {
     it("should handle implicit multiplication with multiple roots", () => {
         const tokens = [
             Lexer.identifier("a"),
-            Editor.root([Lexer.identifier("b")], [Lexer.identifier("2")]),
-            Editor.root([Lexer.identifier("c")], [Lexer.identifier("3")]),
+            LexUtil.root([Lexer.identifier("b")], [Lexer.identifier("2")]),
+            LexUtil.root([Lexer.identifier("c")], [Lexer.identifier("3")]),
         ];
 
         const ast = parser.parse(tokens);
@@ -447,8 +451,8 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication starting with a root", () => {
         const tokens = [
-            Editor.root([Lexer.identifier("b")], [Lexer.identifier("2")]),
-            Editor.root([Lexer.identifier("c")], [Lexer.identifier("3")]),
+            LexUtil.root([Lexer.identifier("b")], [Lexer.identifier("2")]),
+            LexUtil.root([Lexer.identifier("c")], [Lexer.identifier("3")]),
         ];
 
         const ast = parser.parse(tokens);
@@ -462,7 +466,7 @@ describe("NewMathParser", () => {
 
     it("should handle (√2)a", () => {
         const tokens = [
-            Editor.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
             Lexer.identifier("a"),
         ];
 
@@ -478,7 +482,7 @@ describe("NewMathParser", () => {
     it("should handle 5√2", () => {
         const tokens = [
             Lexer.number("5"),
-            Editor.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
         ];
 
         const ast = parser.parse(tokens);
@@ -492,7 +496,7 @@ describe("NewMathParser", () => {
 
     it("should handle √2 5", () => {
         const tokens = [
-            Editor.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
             Lexer.number("5"),
         ];
 
@@ -507,8 +511,8 @@ describe("NewMathParser", () => {
 
     it("should handle √2√3", () => {
         const tokens = [
-            Editor.root([Lexer.number("2")], [Lexer.number("2")]),
-            Editor.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
         ];
 
         const ast = parser.parse(tokens);
@@ -522,7 +526,7 @@ describe("NewMathParser", () => {
 
     it("should handle √2 a", () => {
         const tokens = [
-            Editor.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
             Lexer.identifier("a"),
         ];
 

--- a/packages/editor/src/editor-parser.ts
+++ b/packages/editor/src/editor-parser.ts
@@ -4,7 +4,7 @@ import {Parser} from "@math-blocks/core";
 import * as Lexer from "./editor-lexer";
 import * as Editor from "./editor-ast";
 
-export type Token = Editor.Node<Lexer.Token>;
+type Token = Editor.Node<Lexer.Token>;
 
 // TODO: fill out this list
 type Operator =

--- a/packages/editor/src/editor-printer.ts
+++ b/packages/editor/src/editor-printer.ts
@@ -9,7 +9,11 @@ import * as Editor from "./editor-ast";
 // the original nodes, even if they don't appear in the semantic tree as
 // is the case with most operators
 
-const print = (expr: Semantic.Expression): Editor.Node<Editor.Glyph> => {
+type ID = {
+    id: number;
+};
+
+const print = (expr: Semantic.Expression): Editor.Node<Editor.Glyph, ID> => {
     switch (expr.type) {
         case "identifier": {
             // TODO: handle multi-character identifiers, e.g. sin, cos, etc.
@@ -25,7 +29,7 @@ const print = (expr: Semantic.Expression): Editor.Node<Editor.Glyph> => {
             };
         }
         case "add": {
-            const children: Editor.Node<Editor.Glyph>[] = [];
+            const children: Editor.Node<Editor.Glyph, ID>[] = [];
 
             for (const arg of expr.args) {
                 if (arg.type === "neg" && arg.subtraction) {
@@ -61,7 +65,7 @@ const print = (expr: Semantic.Expression): Editor.Node<Editor.Glyph> => {
             };
         }
         case "mul": {
-            const children: Editor.Node<Editor.Glyph>[] = [];
+            const children: Editor.Node<Editor.Glyph, ID>[] = [];
 
             for (const arg of expr.args) {
                 const node = print(arg);

--- a/packages/editor/src/editor-reducer.ts
+++ b/packages/editor/src/editor-reducer.ts
@@ -3,8 +3,12 @@ import produce from "immer";
 import * as Editor from "./editor-ast";
 import {getId} from "@math-blocks/core";
 
+type ID = {
+    id: number;
+};
+
 export type State = {
-    math: Editor.Row<Editor.Glyph>;
+    math: Editor.Row<Editor.Glyph, ID>;
     cursor: Editor.Cursor;
     selectionStart?: Editor.Cursor;
 };
@@ -35,16 +39,18 @@ const initialState: State = {
 
 type Identifiable = {readonly id: number};
 
-type HasChildren = Editor.Row<Editor.Glyph>;
+type HasChildren = Editor.Row<Editor.Glyph, ID>;
 
-const hasChildren = (node: Editor.Node<Editor.Glyph>): node is HasChildren => {
+const hasChildren = (
+    node: Editor.Node<Editor.Glyph, ID>,
+): node is HasChildren => {
     return node.type === "row";
 };
 
 const isGlyph = (
-    node: Editor.Node<Editor.Glyph>,
+    node: Editor.Node<Editor.Glyph, ID>,
     char: string,
-): node is Editor.Atom<Editor.Glyph> =>
+): node is Editor.Atom<Editor.Glyph, ID> =>
     node.type === "atom" && node.value.char == char;
 
 const getChildWithIndex = <T extends Identifiable>(
@@ -67,14 +73,14 @@ const lastIndex = <T extends Identifiable>(
 };
 
 const nextIndex = (
-    children: Editor.Node<Editor.Glyph>[],
+    children: Editor.Node<Editor.Glyph, ID>[],
     childIndex: number,
 ): number | null => {
     return childIndex < children.length - 1 ? childIndex + 1 : null;
 };
 
 const prevIndex = (
-    children: Editor.Node<Editor.Glyph>[],
+    children: Editor.Node<Editor.Glyph, ID>[],
     childIndex: number,
 ): number | null => {
     return childIndex > 0 ? childIndex - 1 : null;
@@ -132,9 +138,9 @@ const selectionSplit = (
     cursor: Editor.Cursor,
     selectionStart: Editor.Cursor,
 ): {
-    head: Editor.Node<Editor.Glyph>[];
-    body: Editor.Node<Editor.Glyph>[];
-    tail: Editor.Node<Editor.Glyph>[];
+    head: Editor.Node<Editor.Glyph, ID>[];
+    body: Editor.Node<Editor.Glyph, ID>[];
+    tail: Editor.Node<Editor.Glyph, ID>[];
 } => {
     const {prev, next} = getSelectionBounds(cursor, selectionStart);
 
@@ -153,7 +159,7 @@ const selectionSplit = (
 };
 
 const moveLeft = (
-    currentNode: Editor.HasChildren<Editor.Glyph>,
+    currentNode: Editor.HasChildren<Editor.Glyph, ID>,
     draft: State,
     selecting?: boolean,
 ): Editor.Cursor => {
@@ -784,12 +790,12 @@ const caret = (currentNode: HasChildren, draft: State): void => {
         };
         return;
     }
-    const sup: Editor.Row<Editor.Glyph> = {
+    const sup: Editor.Row<Editor.Glyph, ID> = {
         id: getId(),
         type: "row",
         children: [],
     };
-    const newNode: Editor.SubSup<Editor.Glyph> = {
+    const newNode: Editor.SubSup<Editor.Glyph, ID> = {
         id: getId(),
         type: "subsup",
         children: [null, sup],
@@ -855,12 +861,12 @@ const underscore = (currentNode: HasChildren, draft: State): void => {
         };
         return;
     }
-    const sub: Editor.Row<Editor.Glyph> = {
+    const sub: Editor.Row<Editor.Glyph, ID> = {
         id: getId(),
         type: "row",
         children: [],
     };
-    const newNode: Editor.SubSup<Editor.Glyph> = {
+    const newNode: Editor.SubSup<Editor.Glyph, ID> = {
         id: getId(),
         type: "subsup",
         children: [sub, null],
@@ -908,12 +914,12 @@ const root = (currentNode: HasChildren, draft: State): void => {
     const {cursor} = draft;
     const {next} = cursor;
 
-    const radicand: Editor.Row<Editor.Glyph> = {
+    const radicand: Editor.Row<Editor.Glyph, ID> = {
         id: getId(),
         type: "row",
         children: [],
     };
-    const newNode: Editor.Root<Editor.Glyph> = {
+    const newNode: Editor.Root<Editor.Glyph, ID> = {
         id: getId(),
         type: "root",
         children: [radicand, null /* index */],

--- a/packages/editor/src/lexer-ast.ts
+++ b/packages/editor/src/lexer-ast.ts
@@ -1,0 +1,56 @@
+import {Node, SubSup, Frac, Row, Atom, Root} from "./editor-ast";
+import {Token} from "./editor-lexer";
+
+type Location = {
+    path: [];
+    start: number;
+    end: number;
+};
+
+type Loc = {};
+
+export function row(children: Node<Token, Loc>[]): Row<Token, Loc> {
+    return {
+        type: "row",
+        children,
+    };
+}
+
+export function subsup(
+    sub?: Node<Token, Loc>[],
+    sup?: Node<Token, Loc>[],
+): SubSup<Token, Loc> {
+    return {
+        type: "subsup",
+        children: [sub ? row(sub) : null, sup ? row(sup) : null],
+    };
+}
+
+export function frac(
+    numerator: Node<Token, Loc>[],
+    denominator: Node<Token, Loc>[],
+): Frac<Token, Loc> {
+    return {
+        type: "frac",
+        children: [row(numerator), row(denominator)],
+    };
+}
+
+// It would be nice if we could provide defaults to parameterized functions
+// We'd need type-classes for that but thye don't exist in JavaScript.
+export function root(
+    arg: Node<Token, Loc>[],
+    index: Node<Token, Loc>[] | null,
+): Root<Token, Loc> {
+    return {
+        type: "root",
+        children: [row(arg), index ? row(index) : null],
+    };
+}
+
+export function atom(value: Token): Atom<Token, Loc> {
+    return {
+        type: "atom",
+        value,
+    };
+}

--- a/packages/editor/src/util.ts
+++ b/packages/editor/src/util.ts
@@ -60,16 +60,20 @@ export const isEqual = (
     }
 };
 
-export const row = (str: string): Editor.Row<Editor.Glyph> =>
+type ID = {
+    id: number;
+};
+
+export const row = (str: string): Editor.Row<Editor.Glyph, ID> =>
     Editor.row(str.split("").map(glyph => Editor.glyph(glyph)));
 
-export const frac = (num: string, den: string): Editor.Frac<Editor.Glyph> =>
+export const frac = (num: string, den: string): Editor.Frac<Editor.Glyph, ID> =>
     Editor.frac(
         num.split("").map(glyph => Editor.glyph(glyph)),
         den.split("").map(glyph => Editor.glyph(glyph)),
     );
 
-export const sqrt = (radicand: string): Editor.Root<Editor.Glyph> =>
+export const sqrt = (radicand: string): Editor.Root<Editor.Glyph, ID> =>
     Editor.root(
         radicand.split("").map(glyph => Editor.glyph(glyph)),
         null,
@@ -78,25 +82,28 @@ export const sqrt = (radicand: string): Editor.Root<Editor.Glyph> =>
 export const root = (
     radicand: string,
     index: string,
-): Editor.Root<Editor.Glyph> =>
+): Editor.Root<Editor.Glyph, ID> =>
     Editor.root(
         radicand.split("").map(glyph => Editor.glyph(glyph)),
         index.split("").map(glyph => Editor.glyph(glyph)),
     );
 
-export const sup = (sup: string): Editor.SubSup<Editor.Glyph> =>
+export const sup = (sup: string): Editor.SubSup<Editor.Glyph, ID> =>
     Editor.subsup(
         undefined,
         sup.split("").map(glyph => Editor.glyph(glyph)),
     );
 
-export const sub = (sub: string): Editor.SubSup<Editor.Glyph> =>
+export const sub = (sub: string): Editor.SubSup<Editor.Glyph, ID> =>
     Editor.subsup(
         sub.split("").map(glyph => Editor.glyph(glyph)),
         undefined,
     );
 
-export const subsup = (sub: string, sup: string): Editor.SubSup<Editor.Glyph> =>
+export const subsup = (
+    sub: string,
+    sup: string,
+): Editor.SubSup<Editor.Glyph, ID> =>
     Editor.subsup(
         sub.split("").map(glyph => Editor.glyph(glyph)),
         sup.split("").map(glyph => Editor.glyph(glyph)),

--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -12,19 +12,23 @@ import {layoutCursorFromState} from "./util";
 
 const {useEffect, useState, useRef} = React;
 
+type ID = {
+    id: number;
+};
+
 type Props = {
     /**
      * value
      */
-    value: Editor.Row<Editor.Glyph>;
+    value: Editor.Row<Editor.Glyph, ID>;
 
     readonly: boolean;
 
     // TODO: figure out a better way of handling focus
     focus?: boolean;
 
-    onSubmit?: (value: Editor.Row<Editor.Glyph>) => unknown;
-    onChange?: (value: Editor.Row<Editor.Glyph>) => unknown;
+    onSubmit?: (value: Editor.Row<Editor.Glyph, ID>) => unknown;
+    onChange?: (value: Editor.Row<Editor.Glyph, ID>) => unknown;
 
     /**
      * Style

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -3,9 +3,13 @@ import * as Layout from "./layout";
 import {FontMetrics} from "./metrics";
 import {UnreachableCaseError} from "@math-blocks/core";
 
+type ID = {
+    id: number;
+};
+
 const typeset = (fontMetrics: FontMetrics) => (baseFontSize: number) => (
     multiplier = 1,
-) => (node: Editor.Node<Editor.Glyph>): Layout.Node => {
+) => (node: Editor.Node<Editor.Glyph, ID>): Layout.Node => {
     const _typeset = typeset(fontMetrics)(baseFontSize)(multiplier);
     const fontSize = multiplier * baseFontSize;
     const _makeGlyph = Layout.makeGlyph(fontMetrics)(fontSize);
@@ -14,8 +18,8 @@ const typeset = (fontMetrics: FontMetrics) => (baseFontSize: number) => (
 
     // Adds appropriate padding around operators where appropriate
     const typesetChildren = (
-        _typeset: (node: Editor.Node<Editor.Glyph>) => Layout.Node,
-        children: Editor.Node<Editor.Glyph>[],
+        _typeset: (node: Editor.Node<Editor.Glyph, ID>) => Layout.Node,
+        children: Editor.Node<Editor.Glyph, ID>[],
     ): Layout.Node[] =>
         children.map((child, index) => {
             if (child.type === "atom") {

--- a/stories/1-math-editor.stories.tsx
+++ b/stories/1-math-editor.stories.tsx
@@ -11,9 +11,13 @@ export default {
     component: MathEditor,
 };
 
+type ID = {
+    id: number;
+};
+
 export const Editable: React.SFC<{}> = () => {
     // TODO: write a function to convert a Semantic AST into an Editor AST
-    const math: Editor.Row<Editor.Glyph> = row([
+    const math: Editor.Row<Editor.Glyph, ID> = row([
         glyph("2"),
         glyph("x"),
         glyph("+"),
@@ -36,7 +40,7 @@ export const Editable: React.SFC<{}> = () => {
 
 export const Readonly: React.SFC<{}> = () => {
     // TODO: how to convert
-    const math: Editor.Row<Editor.Glyph> = row([
+    const math: Editor.Row<Editor.Glyph, ID> = row([
         glyph("2"),
         glyph("x"),
         glyph("+"),

--- a/stories/2-math-renderer.stories.tsx
+++ b/stories/2-math-renderer.stories.tsx
@@ -13,9 +13,13 @@ export default {
     component: MathRenderer,
 };
 
+type ID = {
+    id: number;
+};
+
 export const Small: React.SFC<{}> = () => {
     // TODO: write a function to convert a Semantic AST into an Editor AST
-    const math: Editor.Row<Editor.Glyph> = row([
+    const math: Editor.Row<Editor.Glyph, ID> = row([
         glyph("2"),
         glyph("x"),
         glyph("+"),
@@ -32,7 +36,7 @@ export const Small: React.SFC<{}> = () => {
 
 export const Large: React.SFC<{}> = () => {
     // TODO: how to convert
-    const math: Editor.Row<Editor.Glyph> = row([
+    const math: Editor.Row<Editor.Glyph, ID> = row([
         glyph("2"),
         glyph("x"),
         glyph("-"),


### PR DESCRIPTION
In particular Editor.Node takes two params: one for the type to store in atoms and the other to control which properties are mixed into each of the node types.  This is more flexible than setting type of the `id` prop and will allow us to have `id`s, `location`s, or in some cases no extra properties.  I'll add location data in a future PR.