### PR TITLE
[editor-parser]: add location data to lexer nodes

### DIFF
--- a/packages/editor-parser/src/__tests__/editor-lexer.test.ts
+++ b/packages/editor-parser/src/__tests__/editor-lexer.test.ts
@@ -11,25 +11,34 @@ describe("Lexer", () => {
     describe("lex", () => {
         it("should coalesce integers", () => {
             const glyphTree = row([glyph("1"), glyph("2"), glyph("3")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(`(row (num 123))`);
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:3 123))
+            `);
         });
 
         it("should coalesce reals", () => {
             const glyphTree = row([glyph("1"), glyph("."), glyph("3")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(`(row (num 1.3))`);
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:3 1.3))
+            `);
         });
 
         it("should parse `1 + a`", () => {
             const glyphTree = row([glyph("1"), glyph("+"), glyph("a")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (num 1) plus (ident a))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:1 1) 
+                  plus@[]:1:2 
+                  (ident@[]:2:3 a))
+            `);
         });
 
         it("should parse `1 + 1/x`", () => {
@@ -38,11 +47,16 @@ describe("Lexer", () => {
                 glyph("+"),
                 frac([glyph("1")], [glyph("x")]),
             ]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (num 1) plus (frac (row (num 1)) (row (ident x))))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:1 1) 
+                  plus@[]:1:2 
+                  (frac@[]:2:3 atom (row 
+                    (num@[2,0]:0:1 1)) (row 
+                    (ident@[2,1]:0:1 x))))
+            `);
         });
 
         it("should parse `e^x`", () => {
@@ -50,11 +64,14 @@ describe("Lexer", () => {
                 glyph("e"),
                 subsup(undefined, [glyph("x")]),
             ]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (ident e) (frac _ (row (ident x))))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (ident@[]:0:1 e) 
+                  (subsup@[]:1:2 atom _ (row 
+                    (ident@[1,1]:0:1 x))))
+            `);
         });
 
         it("should parse `a_n`", () => {
@@ -62,79 +79,112 @@ describe("Lexer", () => {
                 glyph("a"),
                 subsup([glyph("n")], undefined),
             ]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (ident a) (frac (row (ident n)) _))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (ident@[]:0:1 a) 
+                  (subsup@[]:1:2 atom (row 
+                    (ident@[1,0]:0:1 n)) _))
+            `);
         });
 
         it("should parse `a_n^2`", () => {
             const glyphTree = row([glyph("a"), Editor.Util.subsup("n", "2")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (ident a) (frac (row (ident n)) (row (num 2))))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (ident@[]:0:1 a) 
+                  (subsup@[]:1:2 atom (row 
+                    (ident@[1,0]:0:1 n)) (row 
+                    (num@[1,1]:0:1 2))))
+            `);
         });
 
         it("should parse parens", () => {
             const glyphTree = Editor.Util.row("(1 + 2)");
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row lparens (num 1) plus (num 2) rparens)`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  lparens@[]:0:1 
+                  (num@[]:1:2 1) 
+                  plus@[]:3:4 
+                  (num@[]:5:6 2) 
+                  rparens@[]:6:7)
+            `);
         });
 
         it("should parse a square root", () => {
             const glyphTree = row([Editor.Util.sqrt("123")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (frac (row (num 123)) _))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (root@[]:0:1 atom (row 
+                    (num@[0,0]:0:3 123)) _))
+            `);
         });
 
         it("should parse a nth root", () => {
             const glyphTree = row([Editor.Util.root("123", "n")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (frac (row (num 123)) (row (ident n))))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (root@[]:0:1 atom (row 
+                    (num@[0,0]:0:3 123)) (row 
+                    (ident@[0,1]:0:1 n))))
+            `);
         });
 
         it("should parse multi character identifiers", () => {
             const glyphTree = row([glyph("s"), glyph("i"), glyph("n")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(`(row (ident sin))`);
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (ident@[]:0:3 sin))
+            `);
         });
 
         it("should parse a minus sign", () => {
             const glyphTree = row([glyph("1"), glyph("\u2212"), glyph("2")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (num 1) minus (num 2))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:1 1) 
+                  minus@[]:1:2 
+                  (num@[]:2:3 2))
+            `);
         });
 
         it("should parse an equal sign", () => {
             const glyphTree = row([glyph("1"), glyph("="), glyph("2")]);
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(`(row (num 1) eq (num 2))`);
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:1 1) 
+                  eq@[]:1:2 
+                  (num@[]:2:3 2))
+            `);
         });
 
         it("should parse an ellipsis", () => {
             const glyphTree = Editor.Util.row("1+...+n");
-            const tokenTree = Lexer.lex(glyphTree);
+            const tokenTree = Lexer.lexRow(glyphTree);
 
-            expect(tokenTree).toMatchInlineSnapshot(
-                `(row (num 1) plus ellipsis plus (ident n))`,
-            );
+            expect(tokenTree).toMatchInlineSnapshot(`
+                (row 
+                  (num@[]:0:1 1) 
+                  plus@[]:1:2 
+                  ellipsis@[]:2:5 
+                  plus@[]:5:6 
+                  (ident@[]:6:7 n))
+            `);
         });
     });
 });

--- a/packages/editor-parser/src/__tests__/editor-parser.test.ts
+++ b/packages/editor-parser/src/__tests__/editor-parser.test.ts
@@ -4,9 +4,9 @@ import parser from "../editor-parser";
 import * as Lexer from "../editor-lexer";
 import * as LexUtil from "../test-util";
 
-type Loc = {};
+type LexNode = Editor.Node<Lexer.Token, {loc: Lexer.Location}>;
 
-type LexNode = Editor.Node<Lexer.Token, Loc>;
+const {location} = Lexer;
 
 import {serializer} from "@math-blocks/semantic";
 
@@ -15,10 +15,10 @@ expect.addSnapshotSerializer(serializer);
 describe("NewMathParser", () => {
     it("should handle equations", () => {
         const tokens = [
-            Lexer.number("2"),
-            Lexer.identifier("x"),
-            Lexer.eq(),
-            Lexer.number("10"),
+            Lexer.number("2", location([], 0, 1)),
+            Lexer.identifier("x", location([], 1, 2)),
+            Lexer.eq(location([], 2, 3)),
+            Lexer.number("10", location([], 3, 5)),
         ];
 
         const ast = parser.parse(tokens);
@@ -32,11 +32,11 @@ describe("NewMathParser", () => {
 
     it("should handle n-ary equality", () => {
         const tokens = [
-            Lexer.identifier("x"),
-            Lexer.eq(),
-            Lexer.identifier("y"),
-            Lexer.eq(),
-            Lexer.identifier("z"),
+            Lexer.identifier("x", location([], 0, 1)),
+            Lexer.eq(location([], 1, 2)),
+            Lexer.identifier("y", location([], 2, 3)),
+            Lexer.eq(location([], 3, 4)),
+            Lexer.identifier("z", location([], 4, 5)),
         ];
 
         const ast = parser.parse(tokens);
@@ -45,7 +45,11 @@ describe("NewMathParser", () => {
     });
 
     it("should parse binary expressions containing subtraction", () => {
-        const tokens = [Lexer.number("1"), Lexer.minus(), Lexer.number("2")];
+        const tokens = [
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.minus(location([], 1, 2)),
+            Lexer.number("2", location([], 2, 3)),
+        ];
 
         const ast = parser.parse(tokens);
 
@@ -58,11 +62,11 @@ describe("NewMathParser", () => {
 
     it("should parse n-ary expressions containing subtraction", () => {
         const tokens = [
-            Lexer.number("1"),
-            Lexer.minus(),
-            Lexer.number("2"),
-            Lexer.minus(),
-            Lexer.number("3"),
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.minus(location([], 1, 2)),
+            Lexer.number("2", location([], 2, 3)),
+            Lexer.minus(location([], 3, 4)),
+            Lexer.number("3", location([], 4, 5)),
         ];
 
         const ast = parser.parse(tokens);
@@ -77,10 +81,10 @@ describe("NewMathParser", () => {
 
     it("should handle subtracting negative numbers", () => {
         const tokens = [
-            Lexer.number("1"),
-            Lexer.minus(),
-            Lexer.minus(),
-            Lexer.number("2"),
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.minus(location([], 1, 2)),
+            Lexer.minus(location([], 2, 3)),
+            Lexer.number("2", location([], 3, 4)),
         ];
 
         const ast = parser.parse(tokens);
@@ -94,12 +98,12 @@ describe("NewMathParser", () => {
 
     it("should parse expressions containing unary minus", () => {
         const tokens = [
-            Lexer.number("1"),
-            Lexer.plus(),
-            Lexer.minus(),
-            Lexer.number("2"),
-            Lexer.plus(),
-            Lexer.number("3"),
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.plus(location([], 1, 2)),
+            Lexer.minus(location([], 2, 3)),
+            Lexer.number("2", location([], 3, 4)),
+            Lexer.plus(location([], 4, 5)),
+            Lexer.number("3", location([], 5, 6)),
         ];
 
         const ast = parser.parse(tokens);
@@ -113,7 +117,11 @@ describe("NewMathParser", () => {
     });
 
     it("should parse nexplicit multiplication", () => {
-        const tokens = [Lexer.number("1"), Lexer.times(), Lexer.number("2")];
+        const tokens = [
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.times(location([], 1, 2)),
+            Lexer.number("2", location([], 2, 3)),
+        ];
 
         const ast = parser.parse(tokens);
 
@@ -122,11 +130,11 @@ describe("NewMathParser", () => {
 
     it("should parse n-ary explicit multiplication", () => {
         const tokens = [
-            Lexer.number("1"),
-            Lexer.times(),
-            Lexer.number("2"),
-            Lexer.times(),
-            Lexer.number("3"),
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.times(location([], 1, 2)),
+            Lexer.number("2", location([], 2, 3)),
+            Lexer.times(location([], 3, 4)),
+            Lexer.number("3", location([], 4, 5)),
         ];
 
         const ast = parser.parse(tokens);
@@ -136,9 +144,9 @@ describe("NewMathParser", () => {
 
     it("should parse implicit multiplication", () => {
         const tokens: Array<LexNode> = [
-            Lexer.identifier("a"),
-            Lexer.identifier("b"),
-            Lexer.identifier("c"),
+            Lexer.identifier("a", location([], 0, 1)),
+            Lexer.identifier("b", location([], 1, 2)),
+            Lexer.identifier("c", location([], 2, 3)),
         ];
 
         const ast = parser.parse(tokens);
@@ -148,9 +156,13 @@ describe("NewMathParser", () => {
 
     it("should handle fractions", () => {
         const tokens: Array<LexNode> = [
-            Lexer.number("1"),
-            Lexer.plus(),
-            LexUtil.frac([Lexer.number("1")], [Lexer.identifier("x")]),
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.plus(location([], 1, 2)),
+            LexUtil.frac(
+                [Lexer.number("1", location([2, 0], 0, 1))],
+                [Lexer.identifier("x", location([2, 1], 0, 1))],
+                location([], 2, 3),
+            ),
         ];
 
         const parseTree = parser.parse(tokens);
@@ -164,8 +176,12 @@ describe("NewMathParser", () => {
 
     it("should handle exponents", () => {
         const tokens: Array<LexNode> = [
-            Lexer.identifier("x"),
-            LexUtil.subsup(undefined, [Lexer.number("2")]),
+            Lexer.identifier("x", location([], 0, 1)),
+            LexUtil.subsup(
+                undefined,
+                [Lexer.number("2", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
         ];
 
         const parseTree = parser.parse(tokens);
@@ -175,11 +191,19 @@ describe("NewMathParser", () => {
 
     it("should handle nested exponents", () => {
         const tokens: Array<LexNode> = [
-            Lexer.identifier("x"),
-            LexUtil.subsup(undefined, [
-                Lexer.identifier("y"),
-                LexUtil.subsup(undefined, [Lexer.number("2")]),
-            ]),
+            Lexer.identifier("x", location([], 0, 1)),
+            LexUtil.subsup(
+                undefined,
+                [
+                    Lexer.identifier("y", location([1, 1], 0, 1)),
+                    LexUtil.subsup(
+                        undefined,
+                        [Lexer.number("2", location([1, 1, 1, 1], 0, 1))],
+                        location([1, 1], 1, 2),
+                    ),
+                ],
+                location([], 1, 2),
+            ),
         ];
 
         const parseTree = parser.parse(tokens);
@@ -193,10 +217,15 @@ describe("NewMathParser", () => {
 
     it("should handle subscripts on identifiers", () => {
         const tokens: Array<LexNode> = [
-            Lexer.identifier("a"),
+            Lexer.identifier("a", location([], 0, 1)),
             LexUtil.subsup(
-                [Lexer.identifier("n"), Lexer.plus(), Lexer.number("1")],
+                [
+                    Lexer.identifier("n", location([1, 0], 0, 1)),
+                    Lexer.plus(location([1, 0], 1, 2)),
+                    Lexer.number("1", location([1, 0], 2, 3)),
+                ],
                 undefined,
+                location([], 1, 2),
             ),
         ];
 
@@ -207,10 +236,15 @@ describe("NewMathParser", () => {
 
     it("should handle subscripts and superscripts identifiers", () => {
         const tokens: Array<LexNode> = [
-            Lexer.identifier("a"),
+            Lexer.identifier("a", location([], 0, 1)),
             LexUtil.subsup(
-                [Lexer.identifier("n"), Lexer.plus(), Lexer.number("1")],
-                [Lexer.number("2")],
+                [
+                    Lexer.identifier("n", location([1, 0], 0, 1)),
+                    Lexer.plus(location([1, 0], 1, 2)),
+                    Lexer.number("1", location([1, 0], 2, 3)),
+                ],
+                [Lexer.number("2", location([1, 1], 1, 2))],
+                location([], 1, 2),
             ),
         ];
 
@@ -223,8 +257,12 @@ describe("NewMathParser", () => {
 
     it("should throw when a subscript is being used on a number", () => {
         const tokens: Array<LexNode> = [
-            Lexer.number("2"),
-            LexUtil.subsup([Lexer.number("0")], undefined),
+            Lexer.number("2", location([], 0, 1)),
+            LexUtil.subsup(
+                [Lexer.number("0", location([1, 0], 0, 1))],
+                undefined,
+                location([], 1, 2),
+            ),
         ];
 
         expect(() => parser.parse(tokens)).toThrowErrorMatchingInlineSnapshot(
@@ -233,7 +271,10 @@ describe("NewMathParser", () => {
     });
 
     it("should throw when an atom is expected", () => {
-        const tokens: Array<LexNode> = [Lexer.number("2"), Lexer.minus()];
+        const tokens: Array<LexNode> = [
+            Lexer.number("2", location([], 0, 1)),
+            Lexer.minus(location([], 1, 2)),
+        ];
 
         expect(() => parser.parse(tokens)).toThrowErrorMatchingInlineSnapshot(
             `"Unexpected 'eol' atom"`,
@@ -242,10 +283,10 @@ describe("NewMathParser", () => {
 
     it("should throw on a trailing '+'", () => {
         const tokens: Array<LexNode> = [
-            Lexer.number("2"),
-            Lexer.plus(),
-            Lexer.number("2"),
-            Lexer.plus(),
+            Lexer.number("2", location([], 0, 1)),
+            Lexer.plus(location([], 1, 2)),
+            Lexer.number("2", location([], 2, 3)),
+            Lexer.plus(location([], 3, 4)),
         ];
 
         expect(() => parser.parse(tokens)).toThrowErrorMatchingInlineSnapshot(
@@ -255,11 +296,11 @@ describe("NewMathParser", () => {
 
     it("should handle an ellispis", () => {
         const tokens = [
-            Lexer.number("1"),
-            Lexer.plus(),
-            Lexer.ellipsis(),
-            Lexer.plus(),
-            Lexer.identifier("n"),
+            Lexer.number("1", location([], 0, 1)),
+            Lexer.plus(location([], 1, 2)),
+            Lexer.ellipsis(location([], 2, 5)),
+            Lexer.plus(location([], 5, 6)),
+            Lexer.identifier("n", location([], 6, 7)),
         ];
 
         const ast = parser.parse(tokens);
@@ -274,13 +315,13 @@ describe("NewMathParser", () => {
 
     it("should handle adding with parens", () => {
         const tokens = [
-            Lexer.identifier("a"),
-            Lexer.plus(),
-            Lexer.lparens(),
-            Lexer.identifier("b"),
-            Lexer.plus(),
-            Lexer.identifier("c"),
-            Lexer.rparens(),
+            Lexer.identifier("a", location([], 0, 1)),
+            Lexer.plus(location([], 1, 2)),
+            Lexer.lparens(location([], 2, 3)),
+            Lexer.identifier("b", location([], 3, 4)),
+            Lexer.plus(location([], 4, 5)),
+            Lexer.identifier("c", location([], 5, 6)),
+            Lexer.rparens(location([], 6, 7)),
         ];
 
         const ast = parser.parse(tokens);
@@ -294,12 +335,12 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication with parens", () => {
         const tokens = [
-            Lexer.identifier("a"),
-            Lexer.lparens(),
-            Lexer.identifier("b"),
-            Lexer.plus(),
-            Lexer.identifier("c"),
-            Lexer.rparens(),
+            Lexer.identifier("a", location([], 0, 1)),
+            Lexer.lparens(location([], 1, 2)),
+            Lexer.identifier("b", location([], 2, 3)),
+            Lexer.plus(location([], 3, 4)),
+            Lexer.identifier("c", location([], 4, 5)),
+            Lexer.rparens(location([], 5, 6)),
         ];
 
         const ast = parser.parse(tokens);
@@ -313,17 +354,17 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication with multiple parens", () => {
         const tokens = [
-            Lexer.identifier("a"),
-            Lexer.lparens(),
-            Lexer.identifier("b"),
-            Lexer.plus(),
-            Lexer.identifier("c"),
-            Lexer.rparens(),
-            Lexer.lparens(),
-            Lexer.identifier("d"),
-            Lexer.plus(),
-            Lexer.identifier("e"),
-            Lexer.rparens(),
+            Lexer.identifier("a", location([], 0, 1)),
+            Lexer.lparens(location([], 1, 2)),
+            Lexer.identifier("b", location([], 2, 3)),
+            Lexer.plus(location([], 3, 4)),
+            Lexer.identifier("c", location([], 4, 5)),
+            Lexer.rparens(location([], 5, 6)),
+            Lexer.lparens(location([], 6, 7)),
+            Lexer.identifier("d", location([], 7, 8)),
+            Lexer.plus(location([], 8, 9)),
+            Lexer.identifier("e", location([], 9, 10)),
+            Lexer.rparens(location([], 10, 11)),
         ];
 
         const ast = parser.parse(tokens);
@@ -338,16 +379,16 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication with parens at the start", () => {
         const tokens = [
-            Lexer.lparens(),
-            Lexer.identifier("b"),
-            Lexer.plus(),
-            Lexer.identifier("c"),
-            Lexer.rparens(),
-            Lexer.lparens(),
-            Lexer.identifier("d"),
-            Lexer.plus(),
-            Lexer.identifier("e"),
-            Lexer.rparens(),
+            Lexer.lparens(location([], 0, 1)),
+            Lexer.identifier("b", location([], 1, 2)),
+            Lexer.plus(location([], 2, 3)),
+            Lexer.identifier("c", location([], 3, 4)),
+            Lexer.rparens(location([], 4, 5)),
+            Lexer.lparens(location([], 5, 6)),
+            Lexer.identifier("d", location([], 6, 7)),
+            Lexer.plus(location([], 7, 8)),
+            Lexer.identifier("e", location([], 8, 9)),
+            Lexer.rparens(location([], 9, 10)),
         ];
 
         const ast = parser.parse(tokens);
@@ -361,10 +402,10 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication by a number at the end", () => {
         const tokens = [
-            Lexer.lparens(),
-            Lexer.identifier("b"),
-            Lexer.rparens(),
-            Lexer.number("2"),
+            Lexer.lparens(location([], 0, 1)),
+            Lexer.identifier("b", location([], 1, 2)),
+            Lexer.rparens(location([], 2, 3)),
+            Lexer.number("2", location([], 3, 4)),
         ];
 
         const ast = parser.parse(tokens);
@@ -374,12 +415,16 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication by a frac at the end", () => {
         const tokens = [
-            Lexer.lparens(),
-            Lexer.identifier("a"),
-            Lexer.plus(),
-            Lexer.identifier("b"),
-            Lexer.rparens(),
-            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
+            Lexer.lparens(location([], 0, 1)),
+            Lexer.identifier("a", location([], 1, 2)),
+            Lexer.plus(location([], 2, 3)),
+            Lexer.identifier("b", location([], 3, 4)),
+            Lexer.rparens(location([], 4, 5)),
+            LexUtil.frac(
+                [Lexer.number("1", location([5, 0], 0, 1))],
+                [Lexer.number("2", location([5, 1], 0, 1))],
+                location([], 5, 6),
+            ),
         ];
 
         const ast = parser.parse(tokens);
@@ -393,8 +438,12 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication by a frac at the start", () => {
         const tokens = [
-            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
-            Lexer.identifier("b"),
+            LexUtil.frac(
+                [Lexer.number("1", location([0, 0], 0, 1))],
+                [Lexer.number("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            Lexer.identifier("b", location([], 1, 2)),
         ];
 
         const ast = parser.parse(tokens);
@@ -408,8 +457,16 @@ describe("NewMathParser", () => {
 
     it("should error on two fractions in a row without an operator", () => {
         const tokens = [
-            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
-            LexUtil.frac([Lexer.number("1")], [Lexer.number("2")]),
+            LexUtil.frac(
+                [Lexer.number("1", location([0, 0], 0, 1))],
+                [Lexer.number("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            LexUtil.frac(
+                [Lexer.number("1", location([1, 0], 0, 1))],
+                [Lexer.number("2", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
         ];
 
         expect(() => parser.parse(tokens)).toThrowError(
@@ -419,8 +476,12 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication with roots", () => {
         const tokens = [
-            Lexer.identifier("a"),
-            LexUtil.root([Lexer.identifier("b")], [Lexer.number("2")]),
+            Lexer.identifier("a", location([], 0, 1)),
+            LexUtil.root(
+                [Lexer.identifier("b", location([1, 0], 0, 1))],
+                [Lexer.number("2", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
         ];
 
         const ast = parser.parse(tokens);
@@ -434,9 +495,17 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication with multiple roots", () => {
         const tokens = [
-            Lexer.identifier("a"),
-            LexUtil.root([Lexer.identifier("b")], [Lexer.identifier("2")]),
-            LexUtil.root([Lexer.identifier("c")], [Lexer.identifier("3")]),
+            Lexer.identifier("a", location([], 0, 1)),
+            LexUtil.root(
+                [Lexer.identifier("b", location([1, 0], 0, 1))],
+                [Lexer.identifier("2", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
+            LexUtil.root(
+                [Lexer.identifier("c", location([2, 0], 0, 1))],
+                [Lexer.identifier("3", location([2, 1], 0, 1))],
+                location([], 2, 3),
+            ),
         ];
 
         const ast = parser.parse(tokens);
@@ -451,8 +520,16 @@ describe("NewMathParser", () => {
 
     it("should handle implicit multiplication starting with a root", () => {
         const tokens = [
-            LexUtil.root([Lexer.identifier("b")], [Lexer.identifier("2")]),
-            LexUtil.root([Lexer.identifier("c")], [Lexer.identifier("3")]),
+            LexUtil.root(
+                [Lexer.identifier("b", location([0, 0], 0, 1))],
+                [Lexer.identifier("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            LexUtil.root(
+                [Lexer.identifier("c", location([1, 0], 0, 1))],
+                [Lexer.identifier("3", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
         ];
 
         const ast = parser.parse(tokens);
@@ -466,8 +543,12 @@ describe("NewMathParser", () => {
 
     it("should handle (√2)a", () => {
         const tokens = [
-            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
-            Lexer.identifier("a"),
+            LexUtil.root(
+                [Lexer.number("2", location([0, 0], 0, 1))],
+                [Lexer.number("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            Lexer.identifier("a", location([], 1, 2)),
         ];
 
         const ast = parser.parse(tokens);
@@ -481,8 +562,12 @@ describe("NewMathParser", () => {
 
     it("should handle 5√2", () => {
         const tokens = [
-            Lexer.number("5"),
-            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
+            Lexer.number("5", location([], 0, 1)),
+            LexUtil.root(
+                [Lexer.number("2", location([1, 0], 0, 1))],
+                [Lexer.number("2", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
         ];
 
         const ast = parser.parse(tokens);
@@ -496,8 +581,12 @@ describe("NewMathParser", () => {
 
     it("should handle √2 5", () => {
         const tokens = [
-            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
-            Lexer.number("5"),
+            LexUtil.root(
+                [Lexer.number("2", location([0, 0], 0, 1))],
+                [Lexer.number("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            Lexer.number("5", location([], 1, 2)),
         ];
 
         const ast = parser.parse(tokens);
@@ -511,8 +600,16 @@ describe("NewMathParser", () => {
 
     it("should handle √2√3", () => {
         const tokens = [
-            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
-            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
+            LexUtil.root(
+                [Lexer.number("2", location([0, 0], 0, 1))],
+                [Lexer.number("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            LexUtil.root(
+                [Lexer.number("3", location([1, 0], 0, 1))],
+                [Lexer.number("2", location([1, 1], 0, 1))],
+                location([], 1, 2),
+            ),
         ];
 
         const ast = parser.parse(tokens);
@@ -520,14 +617,18 @@ describe("NewMathParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               (root :radicand 2 :index 2)
-              (root :radicand 2 :index 2))
+              (root :radicand 3 :index 2))
         `);
     });
 
     it("should handle √2 a", () => {
         const tokens = [
-            LexUtil.root([Lexer.number("2")], [Lexer.number("2")]),
-            Lexer.identifier("a"),
+            LexUtil.root(
+                [Lexer.number("2", location([0, 0], 0, 1))],
+                [Lexer.number("2", location([0, 1], 0, 1))],
+                location([], 0, 1),
+            ),
+            Lexer.identifier("a", location([], 1, 2)),
         ];
 
         const ast = parser.parse(tokens);

--- a/packages/editor-parser/src/editor-lexer.ts
+++ b/packages/editor-parser/src/editor-lexer.ts
@@ -7,14 +7,23 @@
  * - symbols
  */
 import * as Editor from "@math-blocks/editor";
-import {Atom} from "@math-blocks/editor";
 import {UnreachableCaseError} from "@math-blocks/core";
 
-type Location = {
+export type Location = {
     path: number[];
     start: number;
     end: number;
 };
+
+export const location = (
+    path: number[],
+    start: number,
+    end: number,
+): Location => ({
+    path,
+    start,
+    end,
+});
 
 // operations / relations: + - = < <= > >= != sqrt
 // symbols: a - z, pi, theta, etc.
@@ -33,28 +42,50 @@ type RParens = {kind: "rparens"};
 type Ellipsis = {kind: "ellipsis"};
 type EOL = {kind: "eol"};
 
-const atom = (token: Token): Atom<Token, {}> => ({
+export const atom = (
+    token: Token,
+    loc: Location,
+): Editor.Atom<Token, {loc: Location}> => ({
     type: "atom",
     value: token,
+    loc,
 });
 
-export const identifier = (name: string): Atom<Token, {}> =>
-    atom({kind: "identifier", name});
+export const identifier = (
+    name: string,
+    loc: Location,
+): Editor.Atom<Token, {loc: Location}> => atom({kind: "identifier", name}, loc);
 
-export const number = (value: string): Atom<Token, {}> => {
+export const number = (
+    value: string,
+    loc: Location,
+): Editor.Atom<Token, {loc: Location}> => {
     if (isNaN(parseFloat(value))) {
         throw new Error(`${value} is not a number`);
     }
-    return atom({kind: "number", value});
+    return atom({kind: "number", value}, loc);
 };
 
-export const plus = (): Atom<Token, {}> => atom({kind: "plus"});
-export const minus = (): Atom<Token, {}> => atom({kind: "minus"});
-export const times = (): Atom<Token, {}> => atom({kind: "times"});
-export const lparens = (): Atom<Token, {}> => atom({kind: "lparens"});
-export const rparens = (): Atom<Token, {}> => atom({kind: "rparens"});
-export const ellipsis = (): Atom<Token, {}> => atom({kind: "ellipsis"});
-export const eq = (): Atom<Token, {}> => atom({kind: "eq"});
+export const plus = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "plus"}, loc);
+
+export const minus = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "minus"}, loc);
+
+export const times = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "times"}, loc);
+
+export const lparens = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "lparens"}, loc);
+
+export const rparens = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "rparens"}, loc);
+
+export const ellipsis = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "ellipsis"}, loc);
+
+export const eq = (loc: Location): Editor.Atom<Token, {loc: Location}> =>
+    atom({kind: "eq"}, loc);
 
 export type Token =
     | Ident
@@ -72,109 +103,160 @@ const TOKEN_REGEX = /([1-9]*[0-9]\.?[0-9]*|\.[0-9]+)|(\+|\u2212|=|\(|\)|\.\.\.)|
 
 // TODO: include ids of source glyphs in parsed tokens
 
-const processGlyphs = (glyphs: Editor.Glyph[]): Atom<Token, {}>[] => {
-    const tokens: Atom<Token, {}>[] = [];
+const processGlyphs = (
+    glyphs: Editor.Glyph[],
+    path: number[],
+    offset: number,
+): Editor.Atom<Token, {loc: Location}>[] => {
+    const tokens: Editor.Atom<Token, {loc: Location}>[] = [];
     if (glyphs.length > 0) {
         const str = glyphs.map(glyph => glyph.char).join("");
         const matches = str.matchAll(TOKEN_REGEX);
 
         for (const match of matches) {
             const [, value, sym, name] = match;
+            const {index} = match;
+            if (typeof index !== "number") {
+                // Should we throw if there's match?
+                continue;
+            }
             if (value) {
-                tokens.push(number(value));
+                const loc = location(
+                    path,
+                    offset + index,
+                    offset + index + value.length,
+                );
+                tokens.push(number(value, loc));
             } else if (sym) {
+                const loc = location(
+                    path,
+                    offset + index,
+                    offset + index + sym.length,
+                );
                 switch (sym) {
                     case "=":
-                        tokens.push(eq());
+                        tokens.push(eq(loc));
                         break;
                     case "+":
-                        tokens.push(plus());
+                        tokens.push(plus(loc));
                         break;
                     case "\u2212":
-                        tokens.push(minus());
+                        tokens.push(minus(loc));
                         break;
                     case "...":
-                        tokens.push(ellipsis());
+                        tokens.push(ellipsis(loc));
                         break;
                     case "(":
-                        tokens.push(lparens());
+                        tokens.push(lparens(loc));
                         break;
                     case ")":
-                        tokens.push(rparens());
+                        tokens.push(rparens(loc));
                         break;
                     default:
                         throw new Error(`Unexpected symbol token: ${sym}`);
                 }
             } else if (name) {
-                tokens.push(identifier(name));
+                const loc = location(
+                    path,
+                    offset + index,
+                    offset + index + name.length,
+                );
+                tokens.push(identifier(name, loc));
             }
             // TODO: check if there are leftover characters between token matches
         }
         // TODO: check if there are leftover characters after the last token match
         glyphs = [];
     }
+
     return tokens;
 };
 
 const lexChildren = (
     nodes: Editor.Node<Editor.Glyph, {id: number}>[],
-): Editor.Node<Token, {}>[] => {
-    const tokens: Editor.Node<Token, {}>[] = [];
+    path: number[],
+): Editor.Node<Token, {loc: Location}>[] => {
+    const tokens: Editor.Node<Token, {loc: Location}>[] = [];
 
     let glyphs: Editor.Glyph[] = [];
 
-    for (const node of nodes) {
+    nodes.forEach((node, index) => {
         if (node.type === "atom") {
             const {value} = node;
             glyphs.push(value);
         } else {
-            tokens.push(...processGlyphs(glyphs));
-            tokens.push(lex(node));
+            const offset = index - glyphs.length;
+            tokens.push(...processGlyphs(glyphs, path, offset));
+            tokens.push(lex(node, path, index));
             glyphs = [];
         }
-    }
+    });
 
-    tokens.push(...processGlyphs(glyphs));
+    const offset = nodes.length - glyphs.length;
+    tokens.push(...processGlyphs(glyphs, path, offset));
 
     return tokens;
 };
 
-const lexRow = (
+export const lexRow = (
     row: Editor.Row<Editor.Glyph, {id: number}>,
-): Editor.Row<Token, {}> => {
+    path: number[] = [],
+): Editor.Row<Token, {loc: Location}> => {
     return {
         type: "row",
-        children: lexChildren(row.children),
+        children: lexChildren(row.children, path),
+        loc: location(path, -1, -1),
     };
 };
 
+// TODO: the entry point should be lexRow since the root node of the
+// editor is a row.
 export const lex = (
     node: Editor.Node<Editor.Glyph, {id: number}>,
-): Editor.Node<Token, {}> => {
+    path: number[],
+    offset: number,
+): Editor.Node<Token, {loc: Location}> => {
     switch (node.type) {
         case "row":
+            // This never gets called because rows must be children of
+            // either: subsup, frac, or root.
             return {
                 type: "row",
-                children: lexChildren(node.children),
+                children: lexChildren(node.children, path),
+                loc: location(path, offset, offset + 1),
             };
         case "subsup": {
             const [sub, sup] = node.children;
             return {
                 type: "subsup",
                 // TODO: use null-coalescing
-                children: [sub ? lexRow(sub) : null, sup ? lexRow(sup) : null],
+                children: [
+                    sub ? lexRow(sub, [...path, offset, 0]) : null,
+                    sup ? lexRow(sup, [...path, offset, 1]) : null,
+                ],
+                loc: location(path, offset, offset + 1),
             };
         }
-        case "frac":
+        case "frac": {
+            const [numerator, denominator] = node.children;
             return {
                 type: "frac",
-                children: [lexRow(node.children[0]), lexRow(node.children[1])],
+                children: [
+                    lexRow(numerator, [...path, offset, 0]),
+                    lexRow(denominator, [...path, offset, 1]),
+                ],
+                loc: location(path, offset, offset + 1),
             };
+        }
         case "root": {
             const [radicand, index] = node.children;
             return {
                 type: "root",
-                children: [lexRow(radicand), index ? lexRow(index) : null],
+                children: [
+                    lexRow(radicand, [...path, offset, 0]),
+                    index ? lexRow(index, [...path, offset, 1]) : null,
+                ],
+                loc: location(path, offset, offset + 1),
             };
         }
         case "atom":

--- a/packages/editor-parser/src/editor-parser.ts
+++ b/packages/editor-parser/src/editor-parser.ts
@@ -3,8 +3,9 @@ import * as Editor from "@math-blocks/editor";
 import * as Parser from "@math-blocks/parser";
 
 import * as Lexer from "./editor-lexer";
+import {Location} from "./editor-lexer";
 
-type Token = Editor.Node<Lexer.Token>;
+type Token = Editor.Node<Lexer.Token, {loc: Location}>;
 
 // TODO: fill out this list
 type Operator =
@@ -329,7 +330,7 @@ const getOpPrecedence = (op: Operator): number => {
     }
 };
 
-const EOL: Token = Editor.atom({kind: "eol"});
+const EOL: Token = Lexer.atom({kind: "eol"}, Lexer.location([], -1, -1));
 
 const editorParser = Parser.parserFactory<Token, Semantic.Expression, Operator>(
     getPrefixParselet,
@@ -338,14 +339,11 @@ const editorParser = Parser.parserFactory<Token, Semantic.Expression, Operator>(
     EOL,
 );
 
-type EditorNode = Editor.Node<Editor.Glyph, {id: number}>;
-
-export const parse = (input: EditorNode): Semantic.Expression => {
-    const token = Lexer.lex(input);
-    if (token.type !== "row") {
-        throw new Error("Expected lex to return a row.");
-    }
-    return editorParser.parse(token.children);
+export const parse = (
+    input: Editor.Row<Editor.Glyph, {id: number}>,
+): Semantic.Expression => {
+    const tokenRow = Lexer.lexRow(input);
+    return editorParser.parse(tokenRow.children);
 };
 
 export default editorParser;

--- a/packages/editor-parser/src/test-util.ts
+++ b/packages/editor-parser/src/test-util.ts
@@ -2,81 +2,96 @@ import * as Editor from "@math-blocks/editor";
 import {Node, SubSup, Frac, Row, Atom, Root} from "@math-blocks/editor";
 
 import {Token} from "./editor-lexer";
+import {Location} from "./editor-lexer";
 
-type Location = {
-    path: [];
-    start: number;
-    end: number;
-};
-
-type Loc = {};
-
-export function row(children: Node<Token, Loc>[]): Row<Token, Loc> {
+export function row(
+    children: Node<Token, {loc: Location}>[],
+): Row<Token, {loc: Location}> {
     return {
         type: "row",
         children,
+        loc: {path: [], start: -1, end: -1},
     };
 }
 
 export function subsup(
-    sub?: Node<Token, Loc>[],
-    sup?: Node<Token, Loc>[],
-): SubSup<Token, Loc> {
+    sub: Node<Token, {loc: Location}>[] | void,
+    sup: Node<Token, {loc: Location}>[] | void,
+    loc: Location,
+): SubSup<Token, {loc: Location}> {
     return {
         type: "subsup",
         children: [sub ? row(sub) : null, sup ? row(sup) : null],
+        loc,
     };
 }
 
 export function frac(
-    numerator: Node<Token, Loc>[],
-    denominator: Node<Token, Loc>[],
-): Frac<Token, Loc> {
+    numerator: Node<Token, {loc: Location}>[],
+    denominator: Node<Token, {loc: Location}>[],
+    loc: Location,
+): Frac<Token, {loc: Location}> {
     return {
         type: "frac",
         children: [row(numerator), row(denominator)],
+        loc,
     };
 }
 
 // It would be nice if we could provide defaults to parameterized functions
 // We'd need type-classes for that but thye don't exist in JavaScript.
 export function root(
-    arg: Node<Token, Loc>[],
-    index: Node<Token, Loc>[] | null,
-): Root<Token, Loc> {
+    arg: Node<Token, {loc: Location}>[],
+    index: Node<Token, {loc: Location}>[] | null,
+    loc: Location,
+): Root<Token, {loc: Location}> {
     return {
         type: "root",
         children: [row(arg), index ? row(index) : null],
+        loc,
     };
 }
 
-export function atom(value: Token): Atom<Token, Loc> {
+export function atom(
+    value: Token,
+    loc: Location,
+): Atom<Token, {loc: Location}> {
     return {
         type: "atom",
         value,
+        loc,
     };
 }
 
 const print = (
-    ast: Editor.Node<Token>,
+    ast: Editor.Node<Token, {loc: Location}>,
     serialize: (ast: Editor.Node<Token>) => string,
     indent: (str: string) => string,
 ): string => {
+    const {loc} = ast;
     switch (ast.type) {
         case "atom": {
             const atom = ast.value;
             switch (atom.kind) {
                 case "number":
-                    return `(num ${atom.value})`;
+                    return `(num@[${loc.path.map(String).join(",")}]:${
+                        loc.start
+                    }:${loc.end} ${atom.value})`;
                 case "identifier":
-                    return `(ident ${atom.name})`;
+                    return `(ident@[${loc.path.map(String).join(",")}]:${
+                        loc.start
+                    }:${loc.end} ${atom.name})`;
                 default:
-                    return atom.kind;
+                    return `${atom.kind}@[${loc.path.map(String).join(",")}]:${
+                        loc.start
+                    }:${loc.end}`;
             }
         }
         case "frac": {
             const [numerator, denominator] = ast.children;
-            return `(frac ${print(numerator, serialize, indent)} ${print(
+            return `(frac@[${loc.path.map(String).join(",")}]:${loc.start}:${
+                loc.end
+            } ${atom.name} ${print(numerator, serialize, indent)} ${print(
                 denominator,
                 serialize,
                 indent,
@@ -84,18 +99,22 @@ const print = (
         }
         case "row": {
             return `(row ${ast.children
-                .map(child => print(child, serialize, indent))
+                .map(child => "\n" + indent(print(child, serialize, indent)))
                 .join(" ")})`;
         }
         case "subsup": {
             const [sub, sup] = ast.children;
-            return `(frac ${sub ? print(sub, serialize, indent) : "_"} ${
+            return `(subsup@[${loc.path.map(String).join(",")}]:${loc.start}:${
+                loc.end
+            } ${atom.name} ${sub ? print(sub, serialize, indent) : "_"} ${
                 sup ? print(sup, serialize, indent) : "_"
             })`;
         }
         case "root": {
             const [radicand, index] = ast.children;
-            return `(frac ${print(radicand, serialize, indent)} ${
+            return `(root@[${loc.path.map(String).join(",")}]:${loc.start}:${
+                loc.end
+            } ${atom.name} ${print(radicand, serialize, indent)} ${
                 index ? print(index, serialize, indent) : "_"
             })`;
         }


### PR DESCRIPTION
This PR adds a `loc` property to all so-called lexer nodes (nodes in the tree produced by the lexer).  In the next PR the parser will use the `loc` property to add location information to each node in the semantic tree it produces.