### PR TITLE
Simplify result type

### DIFF
--- a/packages/demo/src/step-checker-page.tsx
+++ b/packages/demo/src/step-checker-page.tsx
@@ -64,7 +64,7 @@ export const App: React.SFC<{}> = () => {
             steps: [],
         });
 
-        if (result.equivalent) {
+        if (result) {
             const semanticNext = parse(next);
             if (
                 semanticNext.type === "eq" &&

--- a/packages/step-checker/src/__tests__/axiom-checker.test.ts
+++ b/packages/step-checker/src/__tests__/axiom-checker.test.ts
@@ -7,10 +7,17 @@ import {Result} from "../types";
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string): Result => {
-    return checker.checkStep(parse(prev), parse(next), {
+    const result = checker.checkStep(parse(prev), parse(next), {
         checker,
         steps: [],
     });
+    if (!result) {
+        return {
+            equivalent: false,
+            steps: [],
+        };
+    }
+    return result;
 };
 
 expect.addSnapshotSerializer(serializer);

--- a/packages/step-checker/src/__tests__/axiom-checker.test.ts
+++ b/packages/step-checker/src/__tests__/axiom-checker.test.ts
@@ -12,10 +12,7 @@ const checkStep = (prev: string, next: string): Result => {
         steps: [],
     });
     if (!result) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        throw new Error("no path found");
     }
     return result;
 };
@@ -27,7 +24,7 @@ describe("AxiomChecker", () => {
         it("a = 3 -> 3 = a", () => {
             const result = checkStep("a = 3", "3 = a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "symmetric property",
             ]);
@@ -36,7 +33,7 @@ describe("AxiomChecker", () => {
         it("a = b = c -> b = c = a", () => {
             const result = checkStep("a = b = c", "b = c = a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "symmetric property",
             ]);
@@ -45,7 +42,7 @@ describe("AxiomChecker", () => {
         it("a = 1 + 2 -> 3 = a", () => {
             const result = checkStep("a = 1 + 2", "3 = a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "symmetric property",
                 "evaluation of addition",
@@ -57,7 +54,7 @@ describe("AxiomChecker", () => {
         it("1 + 2 -> 2 + 1", () => {
             const result = checkStep("1 + 2", "2 + 1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
@@ -66,7 +63,7 @@ describe("AxiomChecker", () => {
         it("(2 - 1) + (1 + 1) -> 2 + 1", () => {
             const result = checkStep("(2 - 1) + (1 + 1)", "2 + 1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
                 "evaluation of addition",
@@ -78,7 +75,7 @@ describe("AxiomChecker", () => {
         it("(1 + 2) + (a + b) -> (2 + 1) + (b + a)", () => {
             const result = checkStep("(1 + 2) + (a + b)", "(b + a) + (2 + 1)");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
                 "commutative property",
@@ -87,16 +84,14 @@ describe("AxiomChecker", () => {
         });
 
         it("1 + 2 + 3 + 4 -> 6 [incorrect]", () => {
-            const result = checkStep("1 + 2 + 3 + 4", "6");
-
-            expect(result.equivalent).toBe(false);
+            expect(() => checkStep("1 + 2 + 3 + 4", "6")).toThrow();
         });
 
         // commutative property with additive identity
         it("2 + 0 -> 0 + 2", () => {
             const result = checkStep("2 + 0", "0 + 2");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
@@ -108,7 +103,7 @@ describe("AxiomChecker", () => {
 
             const result = checkStep(before, after);
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
@@ -117,7 +112,7 @@ describe("AxiomChecker", () => {
         it("x + a + 2 -> x + 2 + a", () => {
             const result = checkStep("x + a + 2", "x + 2 + a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
@@ -126,16 +121,14 @@ describe("AxiomChecker", () => {
         it("x + a + 2 -> a + x + 2", () => {
             const result = checkStep("x + a + 2", "a + x + 2");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
         });
 
         it("x + a + 2 -> x + 2 + b [incorrect step]", () => {
-            const result = checkStep("x + a + 2", "x + 2 + b");
-
-            expect(result.equivalent).toBe(false);
+            expect(() => checkStep("x + a + 2", "x + 2 + b")).toThrow();
         });
     });
 
@@ -144,7 +137,7 @@ describe("AxiomChecker", () => {
         it("1 * 2 -> 2 * 1", () => {
             const result = checkStep("1 * 2", "2 * 1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
@@ -153,7 +146,7 @@ describe("AxiomChecker", () => {
         it("2 * 3 -> 3 * 2", () => {
             const result = checkStep("2 * 3", "3 * 2");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "commutative property",
             ]);
@@ -162,7 +155,7 @@ describe("AxiomChecker", () => {
         it("(1 + 1) * (1 + 2) -> 3 * 2", () => {
             const result = checkStep("(1 + 1) * (1 + 2)", "3 * 2");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
                 "evaluation of addition",
@@ -173,7 +166,7 @@ describe("AxiomChecker", () => {
         it("3 * 2 -> (1 + 1) * (1 + 2)", () => {
             const result = checkStep("3 * 2", "(1 + 1) * (1 + 2)");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose sum",
                 "decompose sum",
@@ -186,7 +179,7 @@ describe("AxiomChecker", () => {
         it("a + 0 -> a", () => {
             const result = checkStep("a + 0", "a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
             ]);
@@ -195,7 +188,7 @@ describe("AxiomChecker", () => {
         it("a -> a + 0", () => {
             const result = checkStep("a", "a + 0");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
             ]);
@@ -204,7 +197,7 @@ describe("AxiomChecker", () => {
         it("a + b -> a + b + 0", () => {
             const result = checkStep("a + b", "a + b + 0");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
             ]);
@@ -213,7 +206,7 @@ describe("AxiomChecker", () => {
         it("a + b -> a + 0 + b", () => {
             const result = checkStep("a + b", "a + 0 + b");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
             ]);
@@ -222,7 +215,7 @@ describe("AxiomChecker", () => {
         it("a + b -> b + a + 0 -> b + 0 + a", () => {
             const result = checkStep("a + b", "b + 0 + a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
                 "commutative property",
@@ -232,7 +225,7 @@ describe("AxiomChecker", () => {
         it("a + b -> a + 0 + b + 0", () => {
             const result = checkStep("a + b", "a + 0 + b + 0");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
             ]);
@@ -241,7 +234,7 @@ describe("AxiomChecker", () => {
         it("0 + (a + b) -> a + b", () => {
             const result = checkStep("0 + (a + b)", "a + b");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "addition with identity",
             ]);
@@ -252,7 +245,7 @@ describe("AxiomChecker", () => {
         it("1 * a -> a", () => {
             const result = checkStep("1 * a", "a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication with identity",
             ]);
@@ -261,7 +254,7 @@ describe("AxiomChecker", () => {
         it("a -> a * 1", () => {
             const result = checkStep("a", "a * 1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication with identity",
             ]);
@@ -270,7 +263,7 @@ describe("AxiomChecker", () => {
         it("1 * (a * b) -> a * b", () => {
             const result = checkStep("1 * (a * b)", "a * b");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication with identity",
             ]);
@@ -279,7 +272,7 @@ describe("AxiomChecker", () => {
         it("a * b -> b * a * 1 -> b * 1 * a", () => {
             const result = checkStep("a * b", "b * 1 * a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication with identity",
                 "commutative property",
@@ -289,7 +282,7 @@ describe("AxiomChecker", () => {
         it("a * b -> a * 1 * b * 1", () => {
             const result = checkStep("a * b", "a * 1 * b * 1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication with identity",
             ]);
@@ -300,7 +293,7 @@ describe("AxiomChecker", () => {
         it("a * (b + c) -> a * b + a * c", () => {
             const result = checkStep("a * (b + c)", "a * b + a * c");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -309,23 +302,20 @@ describe("AxiomChecker", () => {
         it("(b + c) * a -> b * a + c * a", () => {
             const result = checkStep("(b + c) * a", "b * a + c * a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
         });
 
         it("a * (b + c) -> a * b + c [incorrect]", () => {
-            const result = checkStep("a * (b + c)", "a * b + c");
-
-            expect(result.equivalent).toBe(false);
-            expect(result.steps).toEqual([]);
+            expect(() => checkStep("a * (b + c)", "a * b + c")).toThrow();
         });
 
         it("2(x + y) -> 2x + 2y", () => {
             const result = checkStep("2(x + y)", "2x + 2y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -334,7 +324,7 @@ describe("AxiomChecker", () => {
         it("-2(x + y) -> -2x - 2y", () => {
             const result = checkStep("-2(x + y)", "-2x - 2y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
                 "subtracting is the same as adding the inverse",
@@ -344,7 +334,7 @@ describe("AxiomChecker", () => {
         it("1 + 2(x + y) -> 1 + 2x + 2y", () => {
             const result = checkStep("1 + 2(x + y)", "1 + 2x + 2y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -353,7 +343,7 @@ describe("AxiomChecker", () => {
         it("1 + -2(x + y) -> 1 - 2x - 2y", () => {
             const result = checkStep("1 + -2(x + y)", "1 - 2x - 2y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
                 "subtracting is the same as adding the inverse",
@@ -364,7 +354,7 @@ describe("AxiomChecker", () => {
         it("1 - 2(x + y) -> 1 - 2x - 2y", () => {
             const result = checkStep("1 - 2(x + y)", "1 - 2x - 2y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
                 "distribution",
@@ -376,7 +366,7 @@ describe("AxiomChecker", () => {
         it("1 - 2(x + y) -> 1 + -2(x + y)", () => {
             const result = checkStep("1 - 2(x + y)", "1 + -2(x + y)");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
             ]);
@@ -389,7 +379,7 @@ describe("AxiomChecker", () => {
                 "2 * a * b + 2 * a * c",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -401,7 +391,7 @@ describe("AxiomChecker", () => {
                 "(a + b) * x + (a + b) * y",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -413,7 +403,7 @@ describe("AxiomChecker", () => {
                 "a * (x + y) + b * (x + y)",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -425,7 +415,7 @@ describe("AxiomChecker", () => {
                 "ax + ay + b * (x + y)",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
             ]);
@@ -486,7 +476,7 @@ describe("AxiomChecker", () => {
                   (mul.exp b y))
             `);
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
                 "distribution",
@@ -499,7 +489,7 @@ describe("AxiomChecker", () => {
         it("a * b + a * c -> a * (b + c)", () => {
             const result = checkStep("a * b + a * c", "a * (b + c)");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "factoring",
             ]);
@@ -510,7 +500,7 @@ describe("AxiomChecker", () => {
         it("0 -> 0 * a", () => {
             const result = checkStep("0", "0 * a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication by zero",
             ]);
@@ -519,7 +509,7 @@ describe("AxiomChecker", () => {
         it("a * 0 * b -> 0", () => {
             const result = checkStep("a * 0 * b", "0");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication by zero",
             ]);

--- a/packages/step-checker/src/__tests__/equation-checker.test.ts
+++ b/packages/step-checker/src/__tests__/equation-checker.test.ts
@@ -15,10 +15,7 @@ const checkStep = (prev: string, next: string): Result => {
         steps: [],
     });
     if (!result) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        throw new Error("no path found");
     }
     return result;
 };
@@ -43,7 +40,7 @@ describe("EquationChecker", () => {
         it("x = y -> x + 5 = y + 5", () => {
             const result = checkStep("x = y", "x + 5 = y + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "adding the same value to both sides",
             ]);
@@ -52,7 +49,7 @@ describe("EquationChecker", () => {
         it("x + 5 = y + 5 -> x = y", () => {
             const result = checkStep("x + 5 = y + 5", "x = y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toHaveLength(3);
 
             expect(result.steps[0].message).toEqual(
@@ -75,7 +72,7 @@ describe("EquationChecker", () => {
         it("x + 5 = y + 5 + 5 -> x = y + 5", () => {
             const result = checkStep("x + 5 = y + 5 + 5", "x = y + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toHaveLength(3);
 
             expect(result.steps[0].message).toEqual(
@@ -98,7 +95,7 @@ describe("EquationChecker", () => {
         it("x + 5 - 5 = y + 5 + 5 - 5 -> x = y + 5", () => {
             const result = checkStep("x + 5 - 5 = y + 5 + 5 - 5", "x = y + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
                 (add
                   x
@@ -124,7 +121,7 @@ describe("EquationChecker", () => {
         it("x = y -> 5 + x = y + 5", () => {
             const result = checkStep("x = y", "5 + x = y + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "adding the same value to both sides",
             ]);
@@ -136,17 +133,14 @@ describe("EquationChecker", () => {
                 "x + 10 + 5 = y + 15 + 5",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "adding the same value to both sides",
             ]);
         });
 
         it("2x + 5 = 10 -> 2x + 5 - 5 = 10 [incorrect]", () => {
-            const result = checkStep("2x + 5 = 10", "2x + 5 - 5 = 10");
-
-            expect(result.equivalent).toBe(false);
-            expect(result.steps).toEqual([]);
+            expect(() => checkStep("2x + 5 = 10", "2x + 5 - 5 = 10")).toThrow();
         });
     });
 
@@ -154,7 +148,7 @@ describe("EquationChecker", () => {
         it("x = y -> x - 5 = y - 5", () => {
             const result = checkStep("x = y", "x - 5 = y - 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting the same value from both sides",
             ]);
@@ -163,7 +157,7 @@ describe("EquationChecker", () => {
         it("x - 5 = y - 5 -> x = y", () => {
             const result = checkStep("x - 5 = y - 5", "x = y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toHaveLength(3);
 
             expect(result.steps[0].message).toEqual(
@@ -189,17 +183,16 @@ describe("EquationChecker", () => {
                 "x + 10 - 5 = y + 15 - 5",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting the same value from both sides",
             ]);
         });
 
         it("2x + 5 = 10 -> 2x + 5 - 5 = 10 - 10 [incorrect step]", () => {
-            const result = checkStep("2x + 5 = 10", "2x + 5 - 5 = 10 - 10");
-
-            expect(result.equivalent).toBe(false);
-            expect(result.steps).toEqual([]);
+            expect(() =>
+                checkStep("2x + 5 = 10", "2x + 5 - 5 = 10 - 10"),
+            ).toThrow();
         });
     });
 
@@ -207,7 +200,7 @@ describe("EquationChecker", () => {
         it("x = y -> x * 5 = y * 5", () => {
             const result = checkStep("x = y", "x * 5 = y * 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiply both sides by the same value",
             ]);
@@ -219,7 +212,7 @@ describe("EquationChecker", () => {
                 "x * 10 * 5 = y * 15 * 5",
             );
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiply both sides by the same value",
             ]);
@@ -228,7 +221,7 @@ describe("EquationChecker", () => {
         test("2(x + 2.5) = (5)2 -> x + 2.5 = 5", () => {
             const result = checkStep("2(x + 2.5) = (5)2", "x + 2.5 = 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
 
             // The reason why there are so many substeps, is that cancelling
             // values in the numerator and denominator result it lots of sub steps.
@@ -248,7 +241,7 @@ describe("EquationChecker", () => {
         it("x = y -> x / 5 = y / 5", () => {
             const result = checkStep("x = y", "x / 5 = y / 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "divide both sides by the same value",
             ]);
@@ -257,7 +250,7 @@ describe("EquationChecker", () => {
         it("x / 5 = y / 5 -> x = y", () => {
             const result = checkStep("x / 5 = y / 5", "x = y");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toHaveLength(11);
 
             expect(result.steps[0].message).toEqual(
@@ -271,10 +264,7 @@ describe("EquationChecker", () => {
         });
 
         it("x = y -> x / 5 = y / 10 [incorrect step]", () => {
-            const result = checkStep("x = y", "x / 5 = y / 10");
-
-            expect(result.equivalent).toBe(false);
-            expect(result.steps).toEqual([]);
+            expect(() => checkStep("x = y", "x / 5 = y / 10")).toThrow();
         });
     });
 });

--- a/packages/step-checker/src/__tests__/equation-checker.test.ts
+++ b/packages/step-checker/src/__tests__/equation-checker.test.ts
@@ -10,10 +10,17 @@ expect.addSnapshotSerializer(serializer);
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string): Result => {
-    return checker.checkStep(parse(prev), parse(next), {
+    const result = checker.checkStep(parse(prev), parse(next), {
         checker,
         steps: [],
     });
+    if (!result) {
+        return {
+            equivalent: false,
+            steps: [],
+        };
+    }
+    return result;
 };
 
 expect.extend({

--- a/packages/step-checker/src/__tests__/eval-decomp-checker.test.ts
+++ b/packages/step-checker/src/__tests__/eval-decomp-checker.test.ts
@@ -11,10 +11,7 @@ const checkStep = (prev: string, next: string): Result => {
         steps: [],
     });
     if (!result) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        throw new Error("no path found");
     }
     return result;
 };
@@ -24,7 +21,7 @@ describe("EvalChecker", () => {
         it("2 + 3 -> 5", () => {
             const result = checkStep("2 + 3", "5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -33,7 +30,7 @@ describe("EvalChecker", () => {
         it("a + 2 + 3 -> a + 5", () => {
             const result = checkStep("a + 2 + 3", "a + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -42,7 +39,7 @@ describe("EvalChecker", () => {
         it("1 + 2 + 3 -> 1 + 5", () => {
             const result = checkStep("1 + 2 + 3", "1 + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -55,7 +52,7 @@ describe("EvalChecker", () => {
         it("1 + 2 + 3 + 4 -> 3 + 7", () => {
             const result = checkStep("1 + 2 + 3 + 4", "3 + 7");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
                 "evaluation of addition",
@@ -69,7 +66,7 @@ describe("EvalChecker", () => {
 
             const result = checkStep(before, after);
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -82,7 +79,7 @@ describe("EvalChecker", () => {
 
             const result = checkStep(before, after);
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -94,7 +91,7 @@ describe("EvalChecker", () => {
 
             const result = checkStep(before, after);
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -103,7 +100,7 @@ describe("EvalChecker", () => {
         it("10 - 5 + 2 -> 7", () => {
             const result = checkStep("10 - 5 + 2", "7");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -112,7 +109,7 @@ describe("EvalChecker", () => {
         it("10 - 5 + 2 -> 5 + 2", () => {
             const result = checkStep("10 - 5 + 2", "5 + 2");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of addition",
             ]);
@@ -123,7 +120,7 @@ describe("EvalChecker", () => {
         it("2 * 3 -> 6", () => {
             const result = checkStep("2 * 3", "6");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -132,7 +129,7 @@ describe("EvalChecker", () => {
         it("a * 2 * 3 -> a * 6", () => {
             const result = checkStep("a * 2 * 3", "a * 6");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -141,7 +138,7 @@ describe("EvalChecker", () => {
         it("2 * 3 * 4 -> 6 * 4", () => {
             const result = checkStep("2 * 3 * 4", "6 * 4");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -150,7 +147,7 @@ describe("EvalChecker", () => {
         it("1/2 * 1/3 -> 1/6", () => {
             const result = checkStep("1/2 * 1/3", "1/6");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -159,7 +156,7 @@ describe("EvalChecker", () => {
         it("2 * 1/3 -> 2/3", () => {
             const result = checkStep("2 * 1/3", "2/3");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -168,7 +165,7 @@ describe("EvalChecker", () => {
         it("2/3 * 3/4 -> 6/12", () => {
             const result = checkStep("2/3 * 3/4", "6/12");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -178,7 +175,7 @@ describe("EvalChecker", () => {
         it("2/3 * 3/4 -> 1/2", () => {
             const result = checkStep("2/3 * 3/4", "1/2");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "evaluation of multiplication",
             ]);
@@ -189,7 +186,7 @@ describe("EvalChecker", () => {
         it("6 -> 2 * 3", () => {
             const result = checkStep("6", "2 * 3");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose product",
             ]);
@@ -198,7 +195,7 @@ describe("EvalChecker", () => {
         it("6a -> 2 * 3 * a", () => {
             const result = checkStep("6a", "2 * 3 * a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose product",
             ]);
@@ -207,7 +204,7 @@ describe("EvalChecker", () => {
         it("4 * 6 -> 2 * 2 * 2 * 3", () => {
             const result = checkStep("4 * 6", "2 * 2 * 2 * 3");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose product",
                 "decompose product",
@@ -219,7 +216,7 @@ describe("EvalChecker", () => {
         it("5 -> 2 + 3", () => {
             const result = checkStep("5", "2 + 3");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose sum",
             ]);
@@ -228,7 +225,7 @@ describe("EvalChecker", () => {
         it("5 + a -> 2 + 3 + a", () => {
             const result = checkStep("5 + a", "2 + 3 + a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose sum",
             ]);
@@ -237,7 +234,7 @@ describe("EvalChecker", () => {
         it("5 + 10 -> 2 + 3 + 4 + 6", () => {
             const result = checkStep("5 + 10", "2 + 3 + 4 + 5");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "decompose sum",
             ]);
@@ -247,9 +244,7 @@ describe("EvalChecker", () => {
         // In practice this shouldn't come up very often so let's defer doing anything
         // about it.
         it("10 + 5 -> 2 + 3 + 4 + 6 [incorrect]", () => {
-            const result = checkStep("10 + 5", "2 + 3 + 4 + 5");
-
-            expect(result.equivalent).toBe(false);
+            expect(() => checkStep("10 + 5", "2 + 3 + 4 + 5")).toThrow();
         });
     });
 });

--- a/packages/step-checker/src/__tests__/eval-decomp-checker.test.ts
+++ b/packages/step-checker/src/__tests__/eval-decomp-checker.test.ts
@@ -6,10 +6,17 @@ import {Result} from "../types";
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string): Result => {
-    return checker.checkStep(parse(prev), parse(next), {
+    const result = checker.checkStep(parse(prev), parse(next), {
         checker,
         steps: [],
     });
+    if (!result) {
+        return {
+            equivalent: false,
+            steps: [],
+        };
+    }
+    return result;
 };
 
 describe("EvalChecker", () => {

--- a/packages/step-checker/src/__tests__/fraction-checker.test.ts
+++ b/packages/step-checker/src/__tests__/fraction-checker.test.ts
@@ -10,10 +10,17 @@ expect.addSnapshotSerializer(serializer);
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string): Result => {
-    return checker.checkStep(parse(prev), parse(next), {
+    const result = checker.checkStep(parse(prev), parse(next), {
         checker,
         steps: [],
     });
+    if (!result) {
+        return {
+            equivalent: false,
+            steps: [],
+        };
+    }
+    return result;
 };
 
 expect.extend({
@@ -147,6 +154,10 @@ describe("FractionChecker", () => {
             steps: [],
         });
 
+        if (!result) {
+            throw new Error("failure");
+        }
+
         expect(result.equivalent).toBe(true);
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "prime factorization",
@@ -163,6 +174,10 @@ describe("FractionChecker", () => {
             checker,
             steps: [],
         });
+
+        if (!result) {
+            throw new Error("failure");
+        }
 
         expect(result.equivalent).toBe(true);
         expect(result.steps).toHaveLength(6);
@@ -218,6 +233,10 @@ describe("FractionChecker", () => {
                 steps: [],
             },
         );
+
+        if (!result) {
+            throw new Error("failure");
+        }
 
         expect(result.equivalent).toBe(true);
         expect(result.steps.map((reason) => reason.message)).toEqual([
@@ -360,8 +379,7 @@ describe("FractionChecker", () => {
     it("2a/a -> 2b [incorrect]", () => {
         const result = checkStep("2a/a", "2b");
 
-        expect(result.equivalent).toBe(false);
-        expect(result.steps).toEqual([]);
+        expect(result.equivalent).toEqual(false);
     });
 
     it("2abc/ab -> ab/ab * 2c/1 -> 1 * 2c/1 -> 2c", () => {

--- a/packages/step-checker/src/__tests__/fraction-checker.test.ts
+++ b/packages/step-checker/src/__tests__/fraction-checker.test.ts
@@ -15,10 +15,7 @@ const checkStep = (prev: string, next: string): Result => {
         steps: [],
     });
     if (!result) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        throw new Error("no path found");
     }
     return result;
 };
@@ -42,7 +39,7 @@ describe("FractionChecker", () => {
     it("a * 1/b -> a / b", () => {
         const result = checkStep("a * 1/b", "a / b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying by one over something results in a fraction",
         ]);
@@ -51,7 +48,7 @@ describe("FractionChecker", () => {
     it("1/b * a -> a / b", () => {
         const result = checkStep("1/b * a", "a / b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps).toHaveLength(2);
 
         expect(result.steps[0].message).toEqual("commutative property");
@@ -68,7 +65,7 @@ describe("FractionChecker", () => {
     it("a / b -> a * 1/b", () => {
         const result = checkStep("a / b", "a * 1/b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "fraction is the same as multiplying by one over",
         ]);
@@ -78,7 +75,7 @@ describe("FractionChecker", () => {
     it("1/a * 1/b -> (1)(1) / ab -> 1 / ab", () => {
         const result = checkStep("1/a * 1/b", "1 / ab");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying fractions",
             "multiplication with identity",
@@ -88,7 +85,7 @@ describe("FractionChecker", () => {
     it("1 -> a/a", () => {
         const result = checkStep("1", "a/a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "division by the same value",
         ]);
@@ -97,13 +94,13 @@ describe("FractionChecker", () => {
     it("b(a/b) -> a", () => {
         const result = checkStep("b(a/b)", "a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
     });
 
     it("a/b * c/d -> ac / bd", () => {
         const result = checkStep("a/b * c/d", "ac / bd");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying fractions",
         ]);
@@ -112,7 +109,7 @@ describe("FractionChecker", () => {
     it("ac / bd -> a/b * c/d", () => {
         const result = checkStep("ac / bd", "a/b * c/d");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying fractions",
         ]);
@@ -121,7 +118,7 @@ describe("FractionChecker", () => {
     it("ab/cd * e/f -> abe / cdf", () => {
         const result = checkStep("ab/cd * e/f", "abe / cdf");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying fractions",
         ]);
@@ -130,7 +127,7 @@ describe("FractionChecker", () => {
     it("a/b * 1/d -> a*1 / bd -> a / bd", () => {
         const result = checkStep("a/b * 1/d", "a / bd");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         // expect(result.steps).toHaveLength(2);
 
         expect(result.steps[0].message).toEqual("multiplying fractions");
@@ -158,7 +155,7 @@ describe("FractionChecker", () => {
             throw new Error("failure");
         }
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "prime factorization",
             "extract common factors from numerator and denominator",
@@ -179,7 +176,7 @@ describe("FractionChecker", () => {
             throw new Error("failure");
         }
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps).toHaveLength(6);
 
         expect(result.steps[0].message).toEqual("prime factorization");
@@ -238,7 +235,7 @@ describe("FractionChecker", () => {
             throw new Error("failure");
         }
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -250,7 +247,7 @@ describe("FractionChecker", () => {
         it("a / (b/c) -> a * c/b", () => {
             const result = checkStep("a / (b/c)", "a * c/b");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "dividing by a fraction is the same as multiplying by the reciprocal",
             ]);
@@ -259,7 +256,7 @@ describe("FractionChecker", () => {
         it("1 / (a/b) -> b / a", () => {
             const result = checkStep("1 / (a/b)", "b / a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toHaveLength(2);
 
             expect(result.steps[0].message).toEqual(
@@ -278,7 +275,7 @@ describe("FractionChecker", () => {
         it("1 / (1/a) -> a", () => {
             const result = checkStep("1 / (1/a)", "a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toHaveLength(3);
 
             expect(result.steps[0].message).toEqual(
@@ -313,7 +310,7 @@ describe("FractionChecker", () => {
         it("a / (1/b) -> a * b/1 -> ab", () => {
             const result = checkStep("a / (1/b)", "ab");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
 
             expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
                 (div
@@ -340,7 +337,7 @@ describe("FractionChecker", () => {
         it("a/b * b/a -> ab/ba -> ab/ab -> 1", () => {
             const result = checkStep("a/b * b/a", "1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplying fractions",
                 "commutative property",
@@ -352,7 +349,7 @@ describe("FractionChecker", () => {
     it("24ab / 6a -> 2*2*2*3*a*b / 2*3*a -> 2*3*a/2*3*a * 2*2/1 -> 1 * 2*2/1 -> 2*2/1 -> 4/1 -> 4b", () => {
         const result = checkStep("24ab / 6a", "4b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "prime factorization",
             "extract common factors from numerator and denominator",
@@ -367,7 +364,7 @@ describe("FractionChecker", () => {
     it("2a/a -> a/a * 2/1 -> 1 * 2/1 -> 2/1 -> 2", () => {
         const result = checkStep("2a/a", "2");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -377,15 +374,13 @@ describe("FractionChecker", () => {
     });
 
     it("2a/a -> 2b [incorrect]", () => {
-        const result = checkStep("2a/a", "2b");
-
-        expect(result.equivalent).toEqual(false);
+        expect(() => checkStep("2a/a", "2b")).toThrow();
     });
 
     it("2abc/ab -> ab/ab * 2c/1 -> 1 * 2c/1 -> 2c", () => {
         const result = checkStep("2abc/ab", "2c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -398,7 +393,7 @@ describe("FractionChecker", () => {
     it("2abc/ab -> a/a * 2bc/b -> 1 * 2bc/b -> 2bc/b", () => {
         const result = checkStep("2abc/ab", "2bc/b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -409,7 +404,7 @@ describe("FractionChecker", () => {
     it("2abc/abd -> 2c/d", () => {
         const result = checkStep("2abc/abd", "2c/d");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -420,7 +415,7 @@ describe("FractionChecker", () => {
     it("ab/abde -> ab/ab * 1/de -> 1 * 1/de -> 1/de", () => {
         const result = checkStep("ab/abde", "1/de");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -431,7 +426,7 @@ describe("FractionChecker", () => {
     it("a * b/b -> a * 1 -> a", () => {
         const result = checkStep("a * b/b", "a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "division by the same value",
             "multiplication with identity",
@@ -441,7 +436,7 @@ describe("FractionChecker", () => {
     it("a -> a * 1 -> a * b/b", () => {
         const result = checkStep("a", "a * b/b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         // TODO: order the substeps based on the order of the steps
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "division by the same value",
@@ -452,7 +447,7 @@ describe("FractionChecker", () => {
     it("a -> a / 1", () => {
         const result = checkStep("a", "a / 1");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "division by one",
         ]);
@@ -461,7 +456,7 @@ describe("FractionChecker", () => {
     it("ab -> ab / 1", () => {
         const result = checkStep("ab", "ab / 1");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "division by one",
         ]);
@@ -472,7 +467,7 @@ describe("FractionChecker", () => {
     it("(a + b) * 1/c -> a/c + b/c", () => {
         const result = checkStep("(a + b) * 1/c", "a/c  + b/c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "distribution",
             "multiplying by one over something results in a fraction",
@@ -484,7 +479,7 @@ describe("FractionChecker", () => {
     it("a/c + b/c -> 1/c * (a + b)", () => {
         const result = checkStep("a/c + b/c", "1/c * (a + b)");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "fraction is the same as multiplying by one over",
             "commutative property",
@@ -497,7 +492,7 @@ describe("FractionChecker", () => {
     it("(a + b) / c -> (a + b) * 1/c -> a * 1/c + b * 1/c -> a/c + b/c", () => {
         const result = checkStep("(a + b) / c", "a/c + b/c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "fraction is the same as multiplying by one over",
             "distribution",
@@ -509,7 +504,7 @@ describe("FractionChecker", () => {
     it("(a + b) / c -> (a + b) * 1/c", () => {
         const result = checkStep("(a + b) / c", "(a + b) * 1/c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "fraction is the same as multiplying by one over",
         ]);
@@ -518,7 +513,7 @@ describe("FractionChecker", () => {
     it("a/c + b/c -> (a + b) / c", () => {
         const result = checkStep("a/c  + b/c", "(a + b) / c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps).toHaveLength(4);
 
         expect(result.steps[0].message).toEqual(

--- a/packages/step-checker/src/__tests__/integer-checker.test.ts
+++ b/packages/step-checker/src/__tests__/integer-checker.test.ts
@@ -14,10 +14,7 @@ const checkStep = (prev: string, next: string): Result => {
         steps: [],
     });
     if (!result) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        throw new Error("no path found");
     }
     return result;
 };
@@ -26,7 +23,7 @@ describe("IntegerChecker", () => {
     it("a + -a -> 0", () => {
         const result = checkStep("a + -a", "0");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
             (add
               a
@@ -39,7 +36,7 @@ describe("IntegerChecker", () => {
     it("0 -> a + -a", () => {
         const result = checkStep("0", "a + -a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`0`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
@@ -53,7 +50,7 @@ describe("IntegerChecker", () => {
     it("a + b + -a + c -> b + c", () => {
         const result = checkStep("a + b + -a + c", "b + c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "adding inverse",
         ]);
@@ -62,7 +59,7 @@ describe("IntegerChecker", () => {
     it("a - b -> a + -b", () => {
         const result = checkStep("a - b", "a + -b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "subtracting is the same as adding the inverse",
         ]);
@@ -71,7 +68,7 @@ describe("IntegerChecker", () => {
     it("a + -b -> a - b", () => {
         const result = checkStep("a + -b", "a - b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "subtracting is the same as adding the inverse",
         ]);
@@ -80,7 +77,7 @@ describe("IntegerChecker", () => {
     it("a + b - c -> a + b + -c", () => {
         const result = checkStep("a + b - c", "a + b + -c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "subtracting is the same as adding the inverse",
         ]);
@@ -89,7 +86,7 @@ describe("IntegerChecker", () => {
     it("a - b - c -> a + -b + -c", () => {
         const result = checkStep("a - b - c", "a + -b + -c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
             (add
               a
@@ -126,7 +123,7 @@ describe("IntegerChecker", () => {
     it("a - b - c -> a - b + -c", () => {
         const result = checkStep("a - b - c", "a - b + -c");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
             (add
@@ -150,7 +147,7 @@ describe("IntegerChecker", () => {
     it("a - -b -> a + --b -> a + b", () => {
         const result = checkStep("a - -b", "a + b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
             (add
@@ -184,7 +181,7 @@ describe("IntegerChecker", () => {
     it("a + b -> a + --b -> a - -b", () => {
         const result = checkStep("a + b", "a - -b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "negative of a negative is positive",
             "subtracting is the same as adding the inverse",
@@ -207,7 +204,7 @@ describe("IntegerChecker", () => {
     it("a - a -> 0", () => {
         const result = checkStep("a - a", "0");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "adding inverse",
         ]);
@@ -216,7 +213,7 @@ describe("IntegerChecker", () => {
     it("--a -> a", () => {
         const result = checkStep("--a", "a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps[0].message).toEqual(
             "negative of a negative is positive",
         );
@@ -225,7 +222,7 @@ describe("IntegerChecker", () => {
     it("a -> --a", () => {
         const result = checkStep("a", "--a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`a`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`(neg (neg a))`);
         expect(result.steps[0].message).toEqual(
@@ -238,7 +235,7 @@ describe("IntegerChecker", () => {
     it("----a -> --a", () => {
         const result = checkStep("----a", "--a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "negative of a negative is positive",
         ]);
@@ -247,7 +244,7 @@ describe("IntegerChecker", () => {
     it("--a -> ----a", () => {
         const result = checkStep("--a", "----a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "negative of a negative is positive",
         ]);
@@ -262,7 +259,7 @@ describe("IntegerChecker", () => {
     it("----a -> a", () => {
         const result = checkStep("----a", "a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(
             `(neg (neg (neg (neg a))))`,
         );
@@ -283,7 +280,7 @@ describe("IntegerChecker", () => {
     it("a -> ----a", () => {
         const result = checkStep("a", "----a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`a`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`(neg (neg a))`);
@@ -305,7 +302,7 @@ describe("IntegerChecker", () => {
     it("-a -> -1 * a", () => {
         const result = checkStep("-a", "-1 * a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "negation is the same as multipling by negative one",
         ]);
@@ -314,7 +311,7 @@ describe("IntegerChecker", () => {
     it("-1*a -> -a", () => {
         const result = checkStep("-1 * a", "-a");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "negation is the same as multipling by negative one",
         ]);
@@ -323,7 +320,7 @@ describe("IntegerChecker", () => {
     it("(-a)(-b) -> ab", () => {
         const result = checkStep("(-a)(-b)", "ab");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying two negatives is a positive",
         ]);
@@ -332,7 +329,7 @@ describe("IntegerChecker", () => {
     it("ab -> (-a)(-b)", () => {
         const result = checkStep("ab", "(-a)(-b)");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
         expect(result.steps.map((reason) => reason.message)).toEqual([
             "multiplying two negatives is a positive",
         ]);
@@ -341,7 +338,7 @@ describe("IntegerChecker", () => {
     it("-(a + b) -> -1(a + b) -> -1a + -1b -> -a + -b", () => {
         const result = checkStep("-(a + b)", "-a + -b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(
             `(neg (add a b))`,
@@ -400,7 +397,7 @@ describe("IntegerChecker", () => {
     it("-a + -b -> -1a + -1b -> -1 * (a + b) -> -(a + b)", () => {
         const result = checkStep("-a + -b", "-(a + b)");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
@@ -456,7 +453,7 @@ describe("IntegerChecker", () => {
     it("-a + -b -> -1a + -1b", () => {
         const result = checkStep("-a + -b", "-1a + -1b");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
@@ -484,7 +481,7 @@ describe("IntegerChecker", () => {
     it("-1a + -1b -> -1(a + b)", () => {
         const result = checkStep("-1a + -1b", "-1(a + b)");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
             (add
@@ -508,7 +505,7 @@ describe("IntegerChecker", () => {
     it("-a + -b -> -1a + -1b -> -1(a + b)", () => {
         const result = checkStep("-a + -b", "-1(a + b)");
 
-        expect(result.equivalent).toBe(true);
+        expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`

--- a/packages/step-checker/src/__tests__/integer-checker.test.ts
+++ b/packages/step-checker/src/__tests__/integer-checker.test.ts
@@ -13,6 +13,12 @@ const checkStep = (prev: string, next: string): Result => {
         checker,
         steps: [],
     });
+    if (!result) {
+        return {
+            equivalent: false,
+            steps: [],
+        };
+    }
     return result;
 };
 
@@ -80,7 +86,7 @@ describe("IntegerChecker", () => {
         ]);
     });
 
-    it.skip("a - b - c -> a + -b + -c", () => {
+    it("a - b - c -> a + -b + -c", () => {
         const result = checkStep("a - b - c", "a + -b + -c");
 
         expect(result.equivalent).toBe(true);

--- a/packages/step-checker/src/__tests__/step-checker.test.ts
+++ b/packages/step-checker/src/__tests__/step-checker.test.ts
@@ -7,10 +7,17 @@ import {Result} from "../types";
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string): Result => {
-    return checker.checkStep(parse(prev), parse(next), {
+    const result = checker.checkStep(parse(prev), parse(next), {
         checker,
         steps: [],
     });
+    if (!result) {
+        return {
+            equivalent: false,
+            steps: [],
+        };
+    }
+    return result;
 };
 
 // TODO: create a test helper
@@ -52,7 +59,7 @@ describe("StepChecker", () => {
                     steps: [],
                 });
 
-                expect(result.equivalent).toBe(false);
+                expect(result).toBeUndefined();
                 expect(checker.checkStep).not.toHaveBeenCalled();
             }
         });

--- a/packages/step-checker/src/__tests__/step-checker.test.ts
+++ b/packages/step-checker/src/__tests__/step-checker.test.ts
@@ -13,7 +13,6 @@ const checkStep = (prev: string, next: string): Result => {
     });
     if (!result) {
         return {
-            equivalent: false,
             steps: [],
         };
     }
@@ -27,21 +26,21 @@ describe("StepChecker", () => {
         test("1 -> 1", () => {
             const result = checkStep("1", "1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toEqual([]);
         });
 
         test("a -> a", () => {
             const result = checkStep("a", "a");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toEqual([]);
         });
 
         test("-1 -> -1", () => {
             const result = checkStep("-1", "-1");
 
-            expect(result.equivalent).toBe(true);
+            expect(result).toBeTruthy();
             expect(result.steps).toEqual([]);
         });
     });

--- a/packages/step-checker/src/axiom-checker.ts
+++ b/packages/step-checker/src/axiom-checker.ts
@@ -28,7 +28,7 @@ const checkIdentity: Check<Semantic.Add | Semantic.Mul> = (
     const nonIdentityArgs: Semantic.Expression[] = [];
     for (const arg of prev.args) {
         const result = context.checker.checkStep(arg, identity, context);
-        if (result.equivalent) {
+        if (result) {
             identitySteps.push(...result.steps);
         } else {
             nonIdentityArgs.push(arg);
@@ -59,7 +59,7 @@ const checkIdentity: Check<Semantic.Add | Semantic.Mul> = (
             : "multiplication with identity";
 
     const result = context.checker.checkStep(newNext, next, context);
-    if (result.equivalent) {
+    if (result) {
         return {
             equivalent: true,
             steps: [
@@ -103,7 +103,7 @@ const checkDistribution: Check = (prev, next, context) => {
                     next,
                     context,
                 );
-                if (result.equivalent) {
+                if (result) {
                     results.push({
                         equivalent: true,
                         steps: [
@@ -131,10 +131,7 @@ const checkDistribution: Check = (prev, next, context) => {
         }
     }
     if (prev.type !== "mul" || next.type !== "add") {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        return FAILED_CHECK;
     }
     if (prev.args[1].type === "add") {
         const newPrev = Semantic.add(
@@ -144,7 +141,7 @@ const checkDistribution: Check = (prev, next, context) => {
         );
 
         const result = context.checker.checkStep(newPrev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return {
                 equivalent: true,
                 steps: [
@@ -165,7 +162,7 @@ const checkDistribution: Check = (prev, next, context) => {
         );
 
         const result = context.checker.checkStep(newPrev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return {
                 equivalent: true,
                 steps: [
@@ -213,8 +210,10 @@ const checkFactoring: Check = (prev, next, context) => {
                         steps: [],
                     });
 
-                    subReasons.push(...substep.steps);
-                    return substep.equivalent;
+                    if (substep) {
+                        subReasons.push(...substep.steps);
+                    }
+                    return substep;
                 });
 
                 if (equivalent) {
@@ -250,17 +249,15 @@ const mulByZero: Check = (prev, next, context) => {
 
     // TODO: ensure that steps from these calls to checkStep
     // are captured.
-    const hasZero = prev.args.some(
-        (arg) =>
-            context.checker.checkStep(arg, Semantic.number("0"), context)
-                .equivalent,
+    const hasZero = prev.args.some((arg) =>
+        context.checker.checkStep(arg, Semantic.number("0"), context),
     );
     const result = context.checker.checkStep(
         next,
         Semantic.number("0"),
         context,
     );
-    if (hasZero && result.equivalent) {
+    if (hasZero && result) {
         return {
             equivalent: true,
             steps: [
@@ -287,11 +284,8 @@ const commuteAddition: Check = (prev, next, context) => {
         const result = context.checker.checkArgs(prev, next, context);
 
         // If they aren't we can stop this check right here.
-        if (!result.equivalent) {
-            return {
-                equivalent: false,
-                steps: [],
-            };
+        if (!result) {
+            return FAILED_CHECK;
         }
 
         // If at least some of the pairs don't line up then it's safe to
@@ -301,7 +295,7 @@ const commuteAddition: Check = (prev, next, context) => {
             // since we're already getting the reasons why the nodes are equivalent
             // from the call to checkArgs
             const result = context.checker.checkStep(first, second, context);
-            return !result.equivalent;
+            return !result;
         });
 
         if (reordered) {
@@ -343,7 +337,7 @@ const commuteMultiplication: Check = (prev, next, context) => {
         const result = context.checker.checkArgs(prev, next, context);
 
         // If the args are the same then we can stop here.
-        if (!result.equivalent) {
+        if (!result) {
             return FAILED_CHECK;
         }
 
@@ -352,12 +346,12 @@ const commuteMultiplication: Check = (prev, next, context) => {
                 // It's safe to ignore the steps from these checks
                 // since we already have the steps from the checkArgs
                 // call.
-                !context.checker.checkStep(first, second, context).equivalent,
+                !context.checker.checkStep(first, second, context),
         );
 
         const newPrev = applySteps(prev, result.steps);
 
-        if (reordered && result.equivalent) {
+        if (reordered && result) {
             return {
                 equivalent: true,
                 steps: [
@@ -383,13 +377,13 @@ const symmetricProperty: Check = (prev, next, context) => {
         const pairs = zip(prev.args, next.args);
 
         const result = context.checker.checkArgs(prev, next, context);
-        if (!result.equivalent) {
+        if (!result) {
             return result;
         }
 
         const commutative = pairs.some(
             ([first, second]) =>
-                !context.checker.checkStep(first, second, context).equivalent,
+                !context.checker.checkStep(first, second, context),
         );
 
         if (commutative) {
@@ -410,62 +404,62 @@ const symmetricProperty: Check = (prev, next, context) => {
 };
 
 export const runChecks: Check = (prev, next, context) => {
-    let result: Result;
+    let result: Result | void;
 
     result = symmetricProperty(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = commuteAddition(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = commuteMultiplication(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = addZero(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = addZero(next, prev, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = mulOne(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = mulOne(next, prev, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkDistribution(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkFactoring(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     // a * 0 -> 0
     result = mulByZero(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     // 0 -> a * 0
     result = mulByZero(next, prev, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 

--- a/packages/step-checker/src/axiom-checker.ts
+++ b/packages/step-checker/src/axiom-checker.ts
@@ -105,7 +105,6 @@ const checkDistribution: Check = (prev, next, context) => {
                 );
                 if (result) {
                     results.push({
-                        equivalent: true,
                         steps: [
                             {
                                 message: "distribution",

--- a/packages/step-checker/src/constants.ts
+++ b/packages/step-checker/src/constants.ts
@@ -1,4 +1,1 @@
-export const FAILED_CHECK = {
-    equivalent: false,
-    steps: [],
-};
+export const FAILED_CHECK = undefined;

--- a/packages/step-checker/src/equation-checker.ts
+++ b/packages/step-checker/src/equation-checker.ts
@@ -62,10 +62,7 @@ const checkAddSub: Check<Semantic.Eq, Semantic.Eq> = (
                         "removing the same term from both sides",
                 )
             ) {
-                return {
-                    equivalent: false,
-                    steps: [],
-                };
+                return FAILED_CHECK;
             }
 
             const newPrev = Semantic.eq([
@@ -99,7 +96,7 @@ const checkAddSub: Check<Semantic.Eq, Semantic.Eq> = (
                 ...context,
                 steps: newSteps,
             });
-            if (result.equivalent) {
+            if (result) {
                 return {
                     equivalent: true,
                     steps: [
@@ -119,7 +116,7 @@ const checkAddSub: Check<Semantic.Eq, Semantic.Eq> = (
         // TODO: handle adding multiple things to lhs and rhs as the same time
         // TODO: do we want to enforce that the thing being added is exactly
         // the same or do we want to allow equivalent expressions?
-        if (result.equivalent && result.steps.length === 0) {
+        if (result && result.steps.length === 0) {
             if (
                 Semantic.isSubtraction(lhsNewTerms[0]) &&
                 Semantic.isSubtraction(rhsNewTerms[0])
@@ -212,7 +209,7 @@ const checkMul: Check<Semantic.Eq, Semantic.Eq> = (
                 ...context,
                 steps: newSteps,
             });
-            if (result.equivalent) {
+            if (result) {
                 return {
                     equivalent: true,
                     steps: [
@@ -231,7 +228,7 @@ const checkMul: Check<Semantic.Eq, Semantic.Eq> = (
 
         // TODO: do we want to enforce that the thing being added is exactly
         // the same or do we want to allow equivalent expressions?
-        if (result.equivalent && result.steps.length === 0) {
+        if (result && result.steps.length === 0) {
             return {
                 equivalent: true,
                 steps: [
@@ -263,8 +260,8 @@ const checkDiv: Check<Semantic.Eq, Semantic.Eq> = (
 
     if (lhsB.type === "div" && rhsB.type === "div") {
         if (
-            checker.checkStep(lhsA, lhsB.args[NUMERATOR], context).equivalent &&
-            checker.checkStep(rhsA, rhsB.args[NUMERATOR], context).equivalent
+            checker.checkStep(lhsA, lhsB.args[NUMERATOR], context) &&
+            checker.checkStep(rhsA, rhsB.args[NUMERATOR], context)
         ) {
             const result = checker.checkStep(
                 lhsB.args[DENOMINATOR],
@@ -302,7 +299,7 @@ const checkDiv: Check<Semantic.Eq, Semantic.Eq> = (
                     ...context,
                     steps: newSteps,
                 });
-                if (result.equivalent) {
+                if (result) {
                     return {
                         equivalent: true,
                         steps: [
@@ -320,7 +317,7 @@ const checkDiv: Check<Semantic.Eq, Semantic.Eq> = (
                 }
             }
 
-            if (result.equivalent) {
+            if (result) {
                 return {
                     equivalent: true,
                     steps: [
@@ -341,41 +338,38 @@ const checkDiv: Check<Semantic.Eq, Semantic.Eq> = (
 
 export const runChecks: Check = (prev, next, context) => {
     if (prev.type !== "eq" || next.type !== "eq") {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        return FAILED_CHECK;
     }
 
-    let result: Result;
+    let result: Result | void;
 
     result = checkAddSub(prev, next, context, false);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkAddSub(prev, next, context, true);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkMul(prev, next, context, false);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkMul(prev, next, context, true);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkDiv(prev, next, context, false);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = checkDiv(prev, next, context, true);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 

--- a/packages/step-checker/src/eval-decomp-checker.ts
+++ b/packages/step-checker/src/eval-decomp-checker.ts
@@ -32,15 +32,12 @@ function evalDecompNaryOp(
     op: "add" | "mul",
     direction: Direction,
     context: Context,
-): Result {
+): Result | void {
     const aTerms = op === "add" ? Semantic.getTerms(a) : Semantic.getFactors(a);
     const bTerms = op === "add" ? Semantic.getTerms(b) : Semantic.getFactors(b);
 
     if (a.type !== op && b.type !== op) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        return FAILED_CHECK;
     }
 
     const steps: Step[] = [];
@@ -50,7 +47,7 @@ function evalDecompNaryOp(
         const aTerm = aTerms[i];
         const bTerm = bTerms[j];
 
-        if (context.checker.exactMatch(aTerm, bTerm).equivalent) {
+        if (context.checker.exactMatch(aTerm, bTerm)) {
             i++;
             continue;
         }
@@ -101,18 +98,12 @@ function evalDecompNaryOp(
                 }
             }
         } catch (e) {
-            return {
-                equivalent: false,
-                steps: [],
-            };
+            return FAILED_CHECK;
         }
     }
 
     if (i < aTerms.length) {
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        return FAILED_CHECK;
     }
 
     if (steps.length > 0) {
@@ -122,10 +113,7 @@ function evalDecompNaryOp(
         };
     }
 
-    return {
-        equivalent: false,
-        steps: [],
-    };
+    return FAILED_CHECK;
 }
 
 const evalMul: Check = (prev, next, context) => {
@@ -147,25 +135,25 @@ const decompProduct: Check = (prev, next, context) => {
 };
 
 export const runChecks: Check = (prev, next, context) => {
-    let result: Result;
+    let result: Result | void;
 
     result = evalMul(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = evalAdd(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = decompProduct(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = decompSum(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 

--- a/packages/step-checker/src/eval-decomp-checker.ts
+++ b/packages/step-checker/src/eval-decomp-checker.ts
@@ -108,7 +108,6 @@ function evalDecompNaryOp(
 
     if (steps.length > 0) {
         return {
-            equivalent: true,
             steps,
         };
     }

--- a/packages/step-checker/src/integer-checker.ts
+++ b/packages/step-checker/src/integer-checker.ts
@@ -27,7 +27,7 @@ const addInverse: Check = (prev, next, context, reverse) => {
             if (Semantic.isNegative(b) || Semantic.isSubtraction(b)) {
                 const result = checker.checkStep(a, b.arg, context);
                 if (
-                    result.equivalent &&
+                    result &&
                     // Avoid removing a term that matches a term that's
                     // already been removed.
                     (!indicesToRemove.has(j) || !indicesToRemove.has(j))
@@ -50,7 +50,7 @@ const addInverse: Check = (prev, next, context, reverse) => {
             ? checker.checkStep(next, newPrev, context)
             : checker.checkStep(newPrev, next, context);
 
-        if (result.equivalent) {
+        if (result) {
             return {
                 equivalent: true,
                 steps: reverse
@@ -85,7 +85,7 @@ const doubleNegative: Check = (prev, next, context, reverse) => {
         const result = reverse
             ? checker.checkStep(next, newPrev, context)
             : checker.checkStep(newPrev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return {
                 equivalent: true,
                 steps: reverse
@@ -117,6 +117,7 @@ const subIsNeg: Check = (prev, next, context, reverse) => {
     if (reverse) {
         [prev, next] = [next, prev];
     }
+
     if (prev.type === "add" && next.type === "add") {
         const subs: Semantic.Neg[] = prev.args.filter(Semantic.isSubtraction);
 
@@ -141,7 +142,7 @@ const subIsNeg: Check = (prev, next, context, reverse) => {
             const result = reverse
                 ? checker.checkStep(next, newPrev, context)
                 : checker.checkStep(newPrev, next, context);
-            if (result.equivalent) {
+            if (result) {
                 results.push({
                     equivalent: true,
                     steps: reverse
@@ -199,7 +200,7 @@ const negIsMulNegOne: Check = (prev, next, context, reverse) => {
         const result = reverse
             ? checker.checkStep(next, newPrev, context)
             : checker.checkStep(newPrev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return {
                 equivalent: true,
                 steps: reverse
@@ -243,7 +244,7 @@ const mulTwoNegsIsPos: Check = (prev, next, context, reverse) => {
                 const result = reverse
                     ? checker.checkStep(next, newPrev, context)
                     : checker.checkStep(newPrev, next, context);
-                if (result.equivalent) {
+                if (result) {
                     return {
                         equivalent: true,
                         steps: reverse
@@ -273,56 +274,56 @@ const mulTwoNegsIsPos: Check = (prev, next, context, reverse) => {
 };
 
 export const runChecks: Check = (prev, next, context) => {
-    let result: Result;
-    let result1: Result;
-    let result2: Result;
+    let result: Result | void;
+    let result1: Result | void;
+    let result2: Result | void;
 
     result = addInverse(prev, next, context, false);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = addInverse(prev, next, context, true);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result1 = subIsNeg(prev, next, context, false);
     result2 = subIsNeg(prev, next, context, true);
-    if (result1.equivalent && result2.equivalent) {
+    if (result1 && result2) {
         if (result1.steps.length < result2.steps.length) {
             return result1;
         } else {
             return result2;
         }
-    } else if (result1.equivalent) {
+    } else if (result1) {
         return result1;
-    } else if (result2.equivalent) {
+    } else if (result2) {
         return result2;
     }
 
     result = mulTwoNegsIsPos(prev, next, context, false);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = mulTwoNegsIsPos(prev, next, context, true);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     // Choose the fastest route when multiple paths exist.
     result1 = doubleNegative(prev, next, context, false);
     result2 = doubleNegative(prev, next, context, true);
-    if (result1.equivalent && result2.equivalent) {
+    if (result1 && result2) {
         if (result1.steps.length < result2.steps.length) {
             return result1;
         } else {
             return result2;
         }
-    } else if (result1.equivalent) {
+    } else if (result1) {
         return result1;
-    } else if (result2.equivalent) {
+    } else if (result2) {
         return result2;
     }
 
@@ -332,12 +333,12 @@ export const runChecks: Check = (prev, next, context) => {
     // TODO: provide a way to show this more detailed version of --a -> a so that
     // students know why --a -> a is true.
     result = negIsMulNegOne(prev, next, context, false);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 
     result = negIsMulNegOne(prev, next, context, true);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 

--- a/packages/step-checker/src/integer-checker.ts
+++ b/packages/step-checker/src/integer-checker.ts
@@ -144,7 +144,6 @@ const subIsNeg: Check = (prev, next, context, reverse) => {
                 : checker.checkStep(newPrev, next, context);
             if (result) {
                 results.push({
-                    equivalent: true,
                     steps: reverse
                         ? [
                               ...result.steps,

--- a/packages/step-checker/src/polynomial-checker.ts
+++ b/packages/step-checker/src/polynomial-checker.ts
@@ -9,7 +9,7 @@ const collectLikeTerms: Check = (prev, next, context) => {
 
 export const runChecks: Check = (prev, next, context) => {
     const result = collectLikeTerms(prev, next, context);
-    if (result.equivalent) {
+    if (result) {
         return result;
     }
 

--- a/packages/step-checker/src/step-checker.ts
+++ b/packages/step-checker/src/step-checker.ts
@@ -69,7 +69,6 @@ class StepChecker implements IStepChecker {
         );
         return equivalent
             ? {
-                  equivalent: true,
                   steps: _reasons,
               }
             : FAILED_CHECK;
@@ -132,7 +131,6 @@ class StepChecker implements IStepChecker {
     ): Result | void {
         return deepEquals(prev, next)
             ? {
-                  equivalent: true,
                   steps: [],
               }
             : FAILED_CHECK;
@@ -175,7 +173,6 @@ class StepChecker implements IStepChecker {
             const result = this.checkStep(prev.arg, next.arg, context);
             if (result && prev.subtraction === next.subtraction) {
                 return {
-                    equivalent: true,
                     steps: result.steps,
                 };
             } else {
@@ -211,14 +208,12 @@ class StepChecker implements IStepChecker {
         if (prev.type === "number" && next.type === "number") {
             return prev.value === next.value
                 ? {
-                      equivalent: true,
                       steps: [],
                   }
                 : FAILED_CHECK;
         } else if (prev.type === "identifier" && next.type === "identifier") {
             return prev.name === next.name
                 ? {
-                      equivalent: true,
                       steps: [],
                   }
                 : FAILED_CHECK;

--- a/packages/step-checker/src/step-checker.ts
+++ b/packages/step-checker/src/step-checker.ts
@@ -9,6 +9,7 @@ import * as integerChecker from "./integer-checker";
 import * as evalChecker from "./eval-decomp-checker";
 // import * as polynomialChecker from "./polynomial-checker";
 import * as axiomChecker from "./axiom-checker";
+import {FAILED_CHECK} from "./constants";
 
 export const hasArgs = (a: Semantic.Expression): a is HasArgs =>
     a.type === "add" ||
@@ -48,27 +49,30 @@ class StepChecker implements IStepChecker {
      * checkArgs will return true if each node has the same args even if the
      * order doesn't match.
      */
-    checkArgs<T extends HasArgs>(prev: T, next: T, context: Context): Result {
+    checkArgs<T extends HasArgs>(
+        prev: T,
+        next: T,
+        context: Context,
+    ): Result | void {
         const _reasons: Step[] = [];
         if (prev.args.length !== next.args.length) {
-            return {
-                equivalent: false,
-                steps: [],
-            };
+            return FAILED_CHECK;
         }
         const equivalent = prev.args.every((prevArg) =>
             next.args.some((nextArg) => {
                 const result = this.checkStep(prevArg, nextArg, context);
-                if (result.equivalent) {
+                if (result) {
                     _reasons.push(...result.steps);
                 }
-                return result.equivalent;
+                return result;
             }),
         );
-        return {
-            equivalent,
-            steps: _reasons,
-        };
+        return equivalent
+            ? {
+                  equivalent: true,
+                  steps: _reasons,
+              }
+            : FAILED_CHECK;
     }
 
     /**
@@ -81,9 +85,7 @@ class StepChecker implements IStepChecker {
     ): Semantic.Expression[] {
         const result: Semantic.Expression[] = [];
         for (const a of as) {
-            const index = bs.findIndex(
-                (b) => this.checkStep(a, b, context).equivalent,
-            );
+            const index = bs.findIndex((b) => this.checkStep(a, b, context));
             if (index !== -1) {
                 result.push(a);
                 bs = [...bs.slice(0, index), ...bs.slice(index + 1)];
@@ -102,9 +104,7 @@ class StepChecker implements IStepChecker {
     ): Semantic.Expression[] {
         const result: Semantic.Expression[] = [];
         for (const a of as) {
-            const index = bs.findIndex(
-                (b) => this.checkStep(a, b, context).equivalent,
-            );
+            const index = bs.findIndex((b) => this.checkStep(a, b, context));
             if (index !== -1) {
                 bs = [...bs.slice(0, index), ...bs.slice(index + 1)];
             } else {
@@ -123,16 +123,19 @@ class StepChecker implements IStepChecker {
         bs: Semantic.Expression[],
         context: Context,
     ): boolean {
-        return as.every((a) =>
-            bs.some((b) => this.checkStep(a, b, context).equivalent),
-        );
+        return as.every((a) => bs.some((b) => this.checkStep(a, b, context)));
     }
 
-    exactMatch(prev: Semantic.Expression, next: Semantic.Expression): Result {
-        return {
-            equivalent: deepEquals(prev, next),
-            steps: [],
-        };
+    exactMatch(
+        prev: Semantic.Expression,
+        next: Semantic.Expression,
+    ): Result | void {
+        return deepEquals(prev, next)
+            ? {
+                  equivalent: true,
+                  steps: [],
+              }
+            : FAILED_CHECK;
     }
 
     // TODO: check adding by inverse
@@ -143,16 +146,16 @@ class StepChecker implements IStepChecker {
         prev: Semantic.Expression,
         next: Semantic.Expression,
         context: Context,
-    ): Result {
-        let result: Result;
+    ): Result | void {
+        let result: Result | void;
 
         result = this.exactMatch(prev, next);
-        if (result.equivalent) {
+        if (result) {
             return result;
         }
 
         result = axiomChecker.runChecks(prev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return result;
         }
 
@@ -165,65 +168,63 @@ class StepChecker implements IStepChecker {
         // steps in the output.
         if (prev.type === next.type && hasArgs(prev) && hasArgs(next)) {
             result = this.checkArgs(prev, next, context);
-            if (result.equivalent) {
+            if (result) {
                 return result;
             }
         } else if (prev.type === "neg" && next.type === "neg") {
-            let result = this.checkStep(prev.arg, next.arg, context);
-            result = {
-                equivalent:
-                    prev.subtraction === next.subtraction && result.equivalent,
-                steps:
-                    prev.subtraction === next.subtraction && result.equivalent
-                        ? result.steps
-                        : [],
-            };
-            if (result.equivalent) {
-                return result;
+            const result = this.checkStep(prev.arg, next.arg, context);
+            if (result && prev.subtraction === next.subtraction) {
+                return {
+                    equivalent: true,
+                    steps: result.steps,
+                };
+            } else {
+                return FAILED_CHECK;
             }
         }
         // TODO: handle roots and other things that don't pass the hasArgs test
 
         result = equationChecker.runChecks(prev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return result;
         }
 
         if (!this.options.skipEvalChecker) {
             result = evalChecker.runChecks(prev, next, context);
-            if (result.equivalent) {
+            if (result) {
                 return result;
             }
         }
 
         result = integerChecker.runChecks(prev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return result;
         }
 
         // FractionChecker must appear after EvalChecker
         // TODO: add checks to avoid infinite loops so that we don't have to worry about ordering
         result = fractionChecker.runChecks(prev, next, context);
-        if (result.equivalent) {
+        if (result) {
             return result;
         }
 
         if (prev.type === "number" && next.type === "number") {
-            return {
-                equivalent: prev.value === next.value,
-                steps: [],
-            };
+            return prev.value === next.value
+                ? {
+                      equivalent: true,
+                      steps: [],
+                  }
+                : FAILED_CHECK;
         } else if (prev.type === "identifier" && next.type === "identifier") {
-            return {
-                equivalent: prev.name === next.name,
-                steps: [],
-            };
+            return prev.name === next.name
+                ? {
+                      equivalent: true,
+                      steps: [],
+                  }
+                : FAILED_CHECK;
         }
 
-        return {
-            equivalent: false,
-            steps: [],
-        };
+        return FAILED_CHECK;
     }
 }
 

--- a/packages/step-checker/src/types.ts
+++ b/packages/step-checker/src/types.ts
@@ -6,7 +6,6 @@ export type Step = {
 };
 
 export type Result = {
-    equivalent: boolean;
     steps: Step[];
 };
 

--- a/packages/step-checker/src/types.ts
+++ b/packages/step-checker/src/types.ts
@@ -16,14 +16,16 @@ export type Context = {
 };
 
 export interface IStepChecker {
-    checkStep(
+    checkStep: Check;
+    exactMatch(
         prev: Semantic.Expression,
         next: Semantic.Expression,
-        // We pass an array of reasons since cycles may include multiple steps
+    ): Result | void;
+    checkArgs<T extends HasArgs>(
+        prev: T,
+        next: T,
         context: Context,
-    ): Result;
-    exactMatch(prev: Semantic.Expression, next: Semantic.Expression): Result;
-    checkArgs<T extends HasArgs>(prev: T, next: T, context: Context): Result;
+    ): Result | void;
     intersection(
         as: Semantic.Expression[],
         bs: Semantic.Expression[],
@@ -51,7 +53,12 @@ export type Options = {
 export type Check<
     Prev extends Semantic.Expression = Semantic.Expression,
     Next extends Semantic.Expression = Semantic.Expression
-> = (prev: Prev, next: Next, context: Context, reverse?: boolean) => Result;
+> = (
+    prev: Prev,
+    next: Next,
+    context: Context,
+    reverse?: boolean,
+) => Result | void;
 
 export type HasArgs =
     | Semantic.Add


### PR DESCRIPTION
Having to check `result.equivalent` each time instead of just checking `result` was a pain.  This PR updates all checks to return `undefined` if the check fails which simplifies almost everything except for the tests.  The tests now throw if a check fails.  Thankfully there weren't too many tests that were affected by this.