### PR TITLE
Add rule to move negation inside a mul node

### DIFF
--- a/packages/step-checker/src/all-checks.ts
+++ b/packages/step-checker/src/all-checks.ts
@@ -24,6 +24,7 @@ import {
     doubleNegative,
     negIsMulNegOne,
     moveNegToFirstFactor,
+    moveNegInsideMul,
 } from "./checks/integer-checks";
 import {
     divByFrac,
@@ -59,8 +60,6 @@ export const ALL_CHECKS = [
     commuteMultiplication, // should appear before mulOne
     addZero,
     mulOne,
-    checkDistribution,
-    // checkFactoring,
     mulByZero,
 
     // We do this after axiom checks so that we can include commute steps
@@ -79,10 +78,17 @@ export const ALL_CHECKS = [
     // integer checks
     addInverse,
     subIsNeg,
+
+    moveNegInsideMul, // this needs to come after subIsNeg
+
     mulTwoNegsIsPos,
     doubleNegative,
     negIsMulNegOne,
     moveNegToFirstFactor,
+
+    checkDistribution, // we put this to ensure simpler checks run first
+    // we could avoid having to order thing carefully bu running everything
+    // in parallel and picking the shortest path, but this would be very expensive
 
     // fraction checks
     // NOTE: these must appear after eval checks

--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -913,13 +913,24 @@ describe("Axiom checks", () => {
             const result = checkStep("-a(1 + b)", "-a - ab");
 
             expect(result).toBeTruthy();
-            // TODO: get rid of unnecessary steps
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
                 "multiplication with identity",
                 "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
+
+            expect(result.steps[0].nodes[0]).toParseLike("-a(1 + b)");
+            expect(result.steps[0].nodes[1]).toParseLike("(-a)(1) + (-a)(b)");
+
+            expect(result.steps[1].nodes[0]).toParseLike("(-a)(1)");
+            expect(result.steps[1].nodes[1]).toParseLike("-a");
+
+            expect(result.steps[2].nodes[0]).toParseLike("(-a)(b)");
+            expect(result.steps[2].nodes[1]).toParseLike("-(ab)");
+
+            expect(result.steps[3].nodes[0]).toParseLike("-a + -(ab)");
+            expect(result.steps[3].nodes[1]).toParseLike("-a - ab");
         });
 
         it("2x + 3x -> (2 + 3)x", () => {
@@ -957,6 +968,27 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "multiplication by zero",
+            ]);
+        });
+
+        it("1 + 0a + 0b -> 1", () => {
+            const result = checkStep("1 + 0a + 0b", "1");
+
+            expect(result).toBeTruthy();
+            expect(result.steps.map((reason) => reason.message)).toEqual([
+                "multiplication by zero",
+                "multiplication by zero",
+                "addition with identity",
+            ]);
+        });
+
+        it("1 + (a - a)b -> 1", () => {
+            const result = checkStep("1 + (a - a)b", "1");
+
+            expect(result).toBeTruthy();
+            expect(result.steps.map((reason) => reason.message)).toEqual([
+                "multiplication by zero",
+                "addition with identity",
             ]);
         });
     });

--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -508,8 +508,18 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
+                "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
+
+            expect(result.steps[0].nodes[0]).toParseLike("-2(x + y)");
+            expect(result.steps[0].nodes[1]).toParseLike("-2x + -2y");
+
+            expect(result.steps[1].nodes[0]).toParseLike("-2y");
+            expect(result.steps[1].nodes[1]).toParseLike("-(2y)");
+
+            expect(result.steps[2].nodes[0]).toParseLike("-2x + -(2y)");
+            expect(result.steps[2].nodes[1]).toParseLike("-2x - 2y");
         });
 
         it("1 + 2(x + y) -> 1 + 2x + 2y", () => {
@@ -527,7 +537,9 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
+                "move negation inside multiplication",
                 "distribution",
+                "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
                 "subtracting is the same as adding the inverse",
             ]);
@@ -537,15 +549,38 @@ describe("Axiom checks", () => {
             const result = checkStep("1 - 2(x + y)", "1 + -2(x + y)");
 
             expect(result).toBeTruthy();
-            // TODO: figure out why we don't stop after the first step
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
-                "distribution",
-                "factoring",
+                "move negation inside multiplication",
             ]);
 
             expect(result.steps[0].nodes[0]).toParseLike("1 - 2(x + y)");
-            expect(result.steps[0].nodes[1]).toParseLike("1 + -2(x + y)");
+            expect(result.steps[0].nodes[1]).toParseLike("1 + -(2(x + y))");
+
+            expect(result.steps[1].nodes[0]).toParseLike("-(2(x + y))");
+            expect(result.steps[1].nodes[1]).toParseLike("-2(x + y)");
+        });
+
+        it("1 + (-2)(x + y) -> 1 + -2x + -2y", () => {
+            const result = checkStep("1 + -2(x + y)", "1 + -2x + -2y");
+
+            expect(result).toBeTruthy();
+            expect(result.steps.map((reason) => reason.message)).toEqual([
+                "distribution",
+            ]);
+
+            expect(result.steps[0].nodes[0]).toParseLike("1 + -2(x + y)");
+            expect(result.steps[0].nodes[1]).toParseLike("1 + -2x + -2y");
+        });
+
+        it("1 + -2(x + y) -> 1 + -2x + -2y", () => {
+            const result = checkStep("1 + -2(x + y)", "1 + -2x + -2y");
+
+            expect(result).toBeTruthy();
+
+            expect(result.steps.map((reason) => reason.message)).toEqual([
+                "distribution",
+            ]);
         });
 
         it("1 - (x + y) -> 1 - x - y", () => {
@@ -553,6 +588,7 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
+                "subtracting is the same as adding the inverse",
                 "subtraction is the same as multiplying by negative one",
                 "distribution",
                 "negation is the same as multipling by negative one",
@@ -578,6 +614,7 @@ describe("Axiom checks", () => {
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
                 "move negative to first factor",
+                "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
         });
@@ -588,6 +625,7 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "move negative to first factor",
+                "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
         });
@@ -608,8 +646,10 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
+                "move negation inside multiplication",
                 "distribution",
                 "multiplying two negatives is a positive",
+                "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
         });
@@ -620,8 +660,10 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
+                "move negation inside multiplication",
                 "distribution",
                 "multiplying two negatives is a positive",
+                "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
         });
@@ -635,6 +677,8 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
+                "subtracting is the same as adding the inverse",
+                "subtracting is the same as adding the inverse",
                 "subtraction is the same as multiplying by negative one",
                 "subtraction is the same as multiplying by negative one",
                 "distribution",
@@ -654,29 +698,38 @@ describe("Axiom checks", () => {
                 "1 - (x + y) - (a + b)",
             );
             expect(result.steps[0].nodes[1]).toParseLike(
-                "1 + -1*(x + y) - (a + b)",
+                "1 + -(x + y) - (a + b)",
             );
 
             expect(result.steps[1].nodes[0]).toParseLike(
-                "1 + -1*(x + y) - (a + b)",
+                "1 + -(x + y) - (a + b)",
             );
             expect(result.steps[1].nodes[1]).toParseLike(
-                "1 + -1*(x + y) + -1*(a + b)",
+                "1 + -(x + y) + -(a + b)",
             );
 
             expect(result.steps[2].nodes[0]).toParseLike(
-                "1 + -1*(x + y) + -1*(a + b)",
+                "1 + -(x + y) + -(a + b)",
             );
             expect(result.steps[2].nodes[1]).toParseLike(
-                "1 + -1*x + -1*y + -1*(a + b)",
+                "1 + -1*(x + y) + -(a + b)",
             );
 
             expect(result.steps[3].nodes[0]).toParseLike(
-                "1 + -1*x + -1*y + -1*(a + b)",
+                "1 + -1*(x + y) + -(a + b)",
             );
             expect(result.steps[3].nodes[1]).toParseLike(
-                "1 + -1*x + -1*y + -1*a + -1*b",
+                "1 + -1*(x + y) + -1*(a + b)",
             );
+
+            expect(result.steps[4].nodes[0]).toParseLike(
+                "1 + -1*(x + y) + -1*(a + b)",
+            );
+            expect(result.steps[4].nodes[1]).toParseLike(
+                "1 + -1*x + -1*y + -1*(a + b)",
+            );
+
+            // TODO: switch to implicit mul when going from -(x + y) -> (-1)(x + y)
         });
 
         // TODO: make this test pass
@@ -726,8 +779,6 @@ describe("Axiom checks", () => {
             // TODO: make distribution parallel and pick the shortest path
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "distribution",
-                "distribution",
-                "factoring",
             ]);
         });
 
@@ -822,6 +873,7 @@ describe("Axiom checks", () => {
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
                 "multiplication with identity",
+                "move negation inside multiplication",
             ]);
         });
 
@@ -832,6 +884,7 @@ describe("Axiom checks", () => {
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
                 "multiplication with identity",
+                "move negation inside multiplication",
                 "move negative to first factor",
                 "factoring",
             ]);
@@ -844,6 +897,7 @@ describe("Axiom checks", () => {
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
                 "multiplication with identity", // -a -> (-a)(1)
+                "move negation inside multiplication",
                 "factoring",
             ]);
         });

--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -589,9 +589,8 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
-                "subtraction is the same as multiplying by negative one",
-                "distribution",
                 "negation is the same as multipling by negative one",
+                "distribution",
                 "negation is the same as multipling by negative one",
                 "subtracting is the same as adding the inverse",
                 "subtracting is the same as adding the inverse",
@@ -679,13 +678,9 @@ describe("Axiom checks", () => {
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
                 "subtracting is the same as adding the inverse",
-                "subtraction is the same as multiplying by negative one",
-                "subtraction is the same as multiplying by negative one",
+                "negation is the same as multipling by negative one",
                 "distribution",
                 "distribution",
-                "negation is the same as multipling by negative one",
-                "negation is the same as multipling by negative one",
-                "negation is the same as multipling by negative one",
                 "negation is the same as multipling by negative one",
                 "subtracting is the same as adding the inverse",
                 "subtracting is the same as adding the inverse",
@@ -712,24 +707,24 @@ describe("Axiom checks", () => {
                 "1 + -(x + y) + -(a + b)",
             );
             expect(result.steps[2].nodes[1]).toParseLike(
-                "1 + -1*(x + y) + -(a + b)",
+                "1 + -1(x + y) + -1(a + b)",
             );
 
             expect(result.steps[3].nodes[0]).toParseLike(
-                "1 + -1*(x + y) + -(a + b)",
+                "1 + -1(x + y) + -1(a + b)",
             );
             expect(result.steps[3].nodes[1]).toParseLike(
-                "1 + -1*(x + y) + -1*(a + b)",
+                "1 + -1x + -1y + -1(a + b)",
             );
 
             expect(result.steps[4].nodes[0]).toParseLike(
-                "1 + -1*(x + y) + -1*(a + b)",
+                "1 + -1x + -1y + -1(a + b)",
             );
             expect(result.steps[4].nodes[1]).toParseLike(
-                "1 + -1*x + -1*y + -1*(a + b)",
+                "1 + -1x + -1y + -1a + -1b",
             );
 
-            // TODO: switch to implicit mul when going from -(x + y) -> (-1)(x + y)
+            // TODO: finish writing this test
         });
 
         // TODO: make this test pass
@@ -896,9 +891,34 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result.steps.map((reason) => reason.message)).toEqual([
                 "subtracting is the same as adding the inverse",
-                "multiplication with identity", // -a -> (-a)(1)
+                "multiplication with identity",
                 "move negation inside multiplication",
                 "factoring",
+            ]);
+
+            expect(result.steps[0].nodes[0]).toParseLike("-a - ab");
+            expect(result.steps[0].nodes[1]).toParseLike("-a + -(ab)");
+
+            expect(result.steps[1].nodes[0]).toParseLike("-a");
+            expect(result.steps[1].nodes[1]).toParseLike("(-a)(1)");
+
+            expect(result.steps[2].nodes[0]).toParseLike("-(ab)");
+            expect(result.steps[2].nodes[1]).toParseLike("(-a)(b)");
+
+            expect(result.steps[3].nodes[0]).toParseLike("(-a)(1) + (-a)(b)");
+            expect(result.steps[3].nodes[1]).toParseLike("-a(1 + b)");
+        });
+
+        it("-a(1 + b) -> -a - ab", () => {
+            const result = checkStep("-a(1 + b)", "-a - ab");
+
+            expect(result).toBeTruthy();
+            // TODO: get rid of unnecessary steps
+            expect(result.steps.map((reason) => reason.message)).toEqual([
+                "distribution",
+                "multiplication with identity",
+                "move negation out of multiplication",
+                "subtracting is the same as adding the inverse",
             ]);
         });
 

--- a/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
@@ -411,59 +411,24 @@ describe("Integer checks", () => {
         const result = checkStep("-(a + b)", "-a + -b");
 
         expect(result).toBeTruthy();
-
-        expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(
-            `(neg (add a b))`,
-        );
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              (add a b))
-        `);
-        expect(result.steps[0].message).toEqual(
+        expect(result.steps.map((step) => step.message)).toEqual([
             "negation is the same as multipling by negative one",
-        );
-
-        expect(result.steps[1].nodes[0]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              (add a b))
-        `);
-        expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
-            (add
-              (mul.imp
-                (neg 1)
-                a)
-              (mul.imp
-                (neg 1)
-                b))
-        `);
-        expect(result.steps[1].message).toEqual("distribution");
-
-        // TODO: make reasons[2] and reasons[3] be sub-steps for reasons[1]
-        // or better yet, apply [2] and [3] to [1] to the next step at global
-        // level.
-        expect(result.steps[2].nodes[0]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              a)
-        `);
-        expect(result.steps[2].nodes[1]).toMatchInlineSnapshot(`(neg a)`);
-        expect(result.steps[2].message).toEqual(
+            "distribution",
             "negation is the same as multipling by negative one",
-        );
-
-        expect(result.steps[3].nodes[0]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              b)
-        `);
-        expect(result.steps[3].nodes[1]).toMatchInlineSnapshot(`(neg b)`);
-        expect(result.steps[3].message).toEqual(
             "negation is the same as multipling by negative one",
-        );
+        ]);
 
-        expect(result.steps).toHaveLength(4);
+        expect(result.steps[0].nodes[0]).toParseLike("-(a + b)");
+        expect(result.steps[0].nodes[1]).toParseLike("-1(a + b)");
+
+        expect(result.steps[1].nodes[0]).toParseLike("-1(a + b)");
+        expect(result.steps[1].nodes[1]).toParseLike("-1a + -1b");
+
+        expect(result.steps[2].nodes[0]).toParseLike("-1a");
+        expect(result.steps[2].nodes[1]).toParseLike("-a");
+
+        expect(result.steps[3].nodes[0]).toParseLike("-1b");
+        expect(result.steps[3].nodes[1]).toParseLike("-b");
     });
 
     it("-a + -b -> -(a + b)", () => {
@@ -473,118 +438,17 @@ describe("Integer checks", () => {
 
         expect(result.steps.map((step) => step.message)).toEqual([
             "negation is the same as multipling by negative one",
-            "negation is the same as multipling by negative one",
             "factoring",
             "negation is the same as multipling by negative one",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("-a");
-        expect(result.steps[0].nodes[1]).toParseLike("-1a");
+        expect(result.steps[0].nodes[0]).toParseLike("-a + -b");
+        expect(result.steps[0].nodes[1]).toParseLike("-1a + -1b");
 
-        expect(result.steps[1].nodes[0]).toParseLike("-b");
-        expect(result.steps[1].nodes[1]).toParseLike("-1b");
+        expect(result.steps[1].nodes[0]).toParseLike("-1a + -1b");
+        expect(result.steps[1].nodes[1]).toParseLike("-1(a + b)");
 
-        expect(result.steps[2].nodes[0]).toParseLike("-1a + -1b");
-        expect(result.steps[2].nodes[1]).toParseLike("-1(a + b)");
-
-        expect(result.steps[3].nodes[0]).toParseLike("-1(a + b)");
-        expect(result.steps[3].nodes[1]).toParseLike("-(a + b)");
-    });
-
-    it("-a + -b -> -1a + -1b", () => {
-        const result = checkStep("-a + -b", "-1a + -1b");
-
-        expect(result).toBeTruthy();
-
-        expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              a)
-        `);
-        expect(result.steps[0].message).toEqual(
-            "negation is the same as multipling by negative one",
-        );
-
-        expect(result.steps[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
-        expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              b)
-        `);
-        expect(result.steps[1].message).toEqual(
-            "negation is the same as multipling by negative one",
-        );
-
-        expect(result.steps).toHaveLength(2);
-    });
-
-    it("-1a + -1b -> -1(a + b)", () => {
-        // 1 - 5x -> 1 + -(5x) -> 1 + -5x
-        const result = checkStep("(-1)(a) + (-1)(b)", "(-1)(a + b)");
-
-        expect(result).toBeTruthy();
-
-        expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
-            (add
-              (mul.imp
-                (neg 1)
-                a)
-              (mul.imp
-                (neg 1)
-                b))
-        `);
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              (add a b))
-        `);
-        expect(result.steps[0].message).toEqual("factoring");
-
-        expect(result.steps).toHaveLength(1);
-    });
-
-    it("-a + -b -> -1a + -1b -> -1(a + b)", () => {
-        const result = checkStep("-a + -b", "-1(a + b)");
-
-        expect(result).toBeTruthy();
-
-        expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              a)
-        `);
-        expect(result.steps[0].message).toEqual(
-            "negation is the same as multipling by negative one",
-        );
-
-        expect(result.steps[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
-        expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              b)
-        `);
-        expect(result.steps[1].message).toEqual(
-            "negation is the same as multipling by negative one",
-        );
-
-        expect(result.steps[2].nodes[0]).toMatchInlineSnapshot(`
-            (add
-              (mul.imp
-                (neg 1)
-                a)
-              (mul.imp
-                (neg 1)
-                b))
-        `);
-        expect(result.steps[2].nodes[1]).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg 1)
-              (add a b))
-        `);
-        expect(result.steps[2].message).toEqual("factoring");
-
-        expect(result.steps).toHaveLength(3);
+        expect(result.steps[2].nodes[0]).toParseLike("-1(a + b)");
+        expect(result.steps[2].nodes[1]).toParseLike("-(a + b)");
     });
 });

--- a/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
@@ -415,7 +415,7 @@ describe("Integer checks", () => {
             "negation is the same as multipling by negative one",
             "distribution",
             "negation is the same as multipling by negative one",
-            "negation is the same as multipling by negative one",
+            // "negation is the same as multipling by negative one",
         ]);
 
         expect(result.steps[0].nodes[0]).toParseLike("-(a + b)");
@@ -424,11 +424,23 @@ describe("Integer checks", () => {
         expect(result.steps[1].nodes[0]).toParseLike("-1(a + b)");
         expect(result.steps[1].nodes[1]).toParseLike("-1a + -1b");
 
-        expect(result.steps[2].nodes[0]).toParseLike("-1a");
-        expect(result.steps[2].nodes[1]).toParseLike("-a");
+        expect(result.steps[2].nodes[0]).toMatchInlineSnapshot(`
+            (add
+              (mul.imp
+                (neg 1)
+                a)
+              (mul.imp
+                (neg 1)
+                b))
+        `);
+        expect(result.steps[2].nodes[1]).toMatchInlineSnapshot(`
+            (add
+              (neg a)
+              (neg b))
+        `);
 
-        expect(result.steps[3].nodes[0]).toParseLike("-1b");
-        expect(result.steps[3].nodes[1]).toParseLike("-b");
+        // expect(result.steps[3].nodes[0]).toParseLike("-1b");
+        // expect(result.steps[3].nodes[1]).toParseLike("-b");
     });
 
     it("-a + -b -> -(a + b)", () => {

--- a/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
@@ -416,7 +416,7 @@ describe("Integer checks", () => {
             `(neg (add a b))`,
         );
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               (add a b))
         `);
@@ -425,16 +425,16 @@ describe("Integer checks", () => {
         );
 
         expect(result.steps[1].nodes[0]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               (add a b))
         `);
         expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
             (add
-              (mul.exp
+              (mul.imp
                 (neg 1)
                 a)
-              (mul.exp
+              (mul.imp
                 (neg 1)
                 b))
         `);
@@ -444,7 +444,7 @@ describe("Integer checks", () => {
         // or better yet, apply [2] and [3] to [1] to the next step at global
         // level.
         expect(result.steps[2].nodes[0]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               a)
         `);
@@ -454,7 +454,7 @@ describe("Integer checks", () => {
         );
 
         expect(result.steps[3].nodes[0]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               b)
         `);
@@ -479,26 +479,26 @@ describe("Integer checks", () => {
         ]);
 
         expect(result.steps[0].nodes[0]).toParseLike("-a");
-        expect(result.steps[0].nodes[1]).toParseLike("-1 * a");
+        expect(result.steps[0].nodes[1]).toParseLike("-1a");
 
         expect(result.steps[1].nodes[0]).toParseLike("-b");
-        expect(result.steps[1].nodes[1]).toParseLike("-1 * b");
+        expect(result.steps[1].nodes[1]).toParseLike("-1b");
 
-        expect(result.steps[2].nodes[0]).toParseLike("-1*a + -1*b");
-        expect(result.steps[2].nodes[1]).toParseLike("-1*(a + b)");
+        expect(result.steps[2].nodes[0]).toParseLike("-1a + -1b");
+        expect(result.steps[2].nodes[1]).toParseLike("-1(a + b)");
 
-        expect(result.steps[3].nodes[0]).toParseLike("-1*(a + b)");
+        expect(result.steps[3].nodes[0]).toParseLike("-1(a + b)");
         expect(result.steps[3].nodes[1]).toParseLike("-(a + b)");
     });
 
-    it("-a + -b -> (-1)(a) + (-1)(b)", () => {
-        const result = checkStep("-a + -b", "(-1)(a) + (-1)(b)");
+    it("-a + -b -> -1a + -1b", () => {
+        const result = checkStep("-a + -b", "-1a + -1b");
 
         expect(result).toBeTruthy();
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               a)
         `);
@@ -508,7 +508,7 @@ describe("Integer checks", () => {
 
         expect(result.steps[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
         expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               b)
         `);
@@ -551,7 +551,7 @@ describe("Integer checks", () => {
 
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(neg a)`);
         expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               a)
         `);
@@ -561,7 +561,7 @@ describe("Integer checks", () => {
 
         expect(result.steps[1].nodes[0]).toMatchInlineSnapshot(`(neg b)`);
         expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
+            (mul.imp
               (neg 1)
               b)
         `);

--- a/packages/step-checker/src/checks/axiom-checks.ts
+++ b/packages/step-checker/src/checks/axiom-checks.ts
@@ -102,6 +102,10 @@ export const addZero: Check = (prev, next, context) => {
 addZero.symmetric = true;
 
 export const mulOne: Check = (prev, next, context) => {
+    // This check prunes a lot of paths... we could try multiplying by "1" as
+    // long as prev.
+    // This is going in the direction of (a)(1) -> a
+    // so if we have -a we can go from (-a)(1) -> a
     if (next.type !== "mul") {
         return;
     }
@@ -257,30 +261,6 @@ export const checkDistribution: Check = (prev, next, context) => {
                             "distribution",
                             "factoring",
                         ),
-                    );
-                }
-            } else if (
-                mul.type === "neg" &&
-                !mul.subtraction &&
-                mul.arg.type === "add"
-            ) {
-                const newPrev = Semantic.addTerms([
-                    ...prev.args.slice(0, i),
-                    Semantic.mul([Semantic.neg(Semantic.number("1")), mul.arg]),
-                    ...prev.args.slice(i + 1),
-                ]);
-                const result = context.checker.checkStep(newPrev, next, {
-                    ...context,
-                    filters,
-                });
-                if (result) {
-                    return correctResult(
-                        prev,
-                        newPrev,
-                        context.reversed,
-                        [],
-                        result.steps,
-                        "subtraction is the same as multiplying by negative one",
                     );
                 }
             }

--- a/packages/step-checker/src/checks/axiom-checks.ts
+++ b/packages/step-checker/src/checks/axiom-checks.ts
@@ -335,7 +335,10 @@ export const checkDistribution: Check = (prev, next, context) => {
 
 checkDistribution.symmetric = true;
 
+// TODO: copy what addZero does
 export const mulByZero: Check = (prev, next, context) => {
+    const {checker} = context;
+
     if (prev.type !== "mul") {
         return;
     }
@@ -343,10 +346,10 @@ export const mulByZero: Check = (prev, next, context) => {
     // TODO: ensure that steps from these calls to checkStep
     // are captured.
     const hasZero = prev.args.some((arg) =>
-        context.checker.checkStep(arg, Semantic.number("0"), context),
+        checker.checkStep(arg, Semantic.number("0"), context),
     );
     const newPrev = Semantic.number("0");
-    const result = context.checker.checkStep(newPrev, next, context);
+    const result = checker.checkStep(newPrev, next, context);
 
     if (hasZero && result) {
         return correctResult(

--- a/packages/step-checker/src/checks/axiom-checks.ts
+++ b/packages/step-checker/src/checks/axiom-checks.ts
@@ -218,6 +218,7 @@ export const checkDistribution: Check = (prev, next, context) => {
                 "negIsMulNegOne",
                 "subIsNeg",
                 "mulTwoNegsIsPos",
+                "moveNegInsideMul",
                 "moveNegToFirstFactor",
             ]),
             disallowedChecks: context.filters?.disallowedChecks,
@@ -227,6 +228,7 @@ export const checkDistribution: Check = (prev, next, context) => {
         // each of them.
         for (let i = 0; i < prev.args.length; i++) {
             const mul = prev.args[i];
+
             if (
                 mul.type === "mul" &&
                 mul.args.length === 2 &&
@@ -235,7 +237,7 @@ export const checkDistribution: Check = (prev, next, context) => {
                 const newPrev = Semantic.addTerms([
                     ...prev.args.slice(0, i),
                     ...(mul.args[1].args.map((arg) =>
-                        Semantic.mul([mul.args[0], arg]),
+                        Semantic.mul([mul.args[0], arg], mul.implicit),
                     ) as TwoOrMore<Semantic.Expression>),
                     ...prev.args.slice(i + 1),
                 ]);
@@ -259,7 +261,7 @@ export const checkDistribution: Check = (prev, next, context) => {
                 }
             } else if (
                 mul.type === "neg" &&
-                mul.subtraction &&
+                !mul.subtraction &&
                 mul.arg.type === "add"
             ) {
                 const newPrev = Semantic.addTerms([
@@ -309,7 +311,7 @@ export const checkDistribution: Check = (prev, next, context) => {
                     // Set 'subtraction' prop to false
                     return Semantic.mul([prev.args[0], Semantic.neg(arg.arg)]);
                 } else {
-                    return Semantic.mul([prev.args[0], arg]);
+                    return Semantic.mul([prev.args[0], arg], prev.implicit);
                 }
             }) as TwoOrMore<Semantic.Expression>,
         );

--- a/packages/step-checker/src/checks/integer-checks.ts
+++ b/packages/step-checker/src/checks/integer-checks.ts
@@ -98,16 +98,6 @@ export const subIsNeg: Check = (prev, next, context) => {
         for (const sub of subs) {
             const index = prev.args.indexOf(sub);
             const neg = Semantic.neg(sub.arg);
-            // sub.arg.type === "mul"
-            //     ? Semantic.mul(
-            //           [
-            //               Semantic.neg(sub.arg.args[0]),
-            //               ...sub.arg.args.slice(1),
-            //           ] as TwoOrMore<Semantic.Expression>,
-            //           sub.arg.implicit,
-            //       )
-            //     : Semantic.neg(sub.arg);
-
             const newPrev = Semantic.addTerms([
                 ...prev.args.slice(0, index),
                 neg,
@@ -156,10 +146,13 @@ export const negIsMulNegOne: Check = (prev, next, context) => {
         // exclude -1 to avoid an infinite expansion
         !(prev.arg.type == "number" && prev.arg.value == "1")
     ) {
-        const newPrev = Semantic.mulFactors([
-            Semantic.neg(Semantic.number("1")),
-            ...Semantic.getFactors(prev.arg),
-        ]);
+        const newPrev = Semantic.mulFactors(
+            [
+                Semantic.neg(Semantic.number("1")),
+                ...Semantic.getFactors(prev.arg),
+            ],
+            true,
+        );
 
         const result = checker.checkStep(newPrev, next, context);
         if (result) {

--- a/packages/text-parser/src/__tests__/text-parser.test.ts
+++ b/packages/text-parser/src/__tests__/text-parser.test.ts
@@ -97,6 +97,16 @@ describe("TextParser", () => {
         `);
     });
 
+    it("negation is higher precedence than explicit multplication", () => {
+        const ast = parse("-a * b");
+
+        expect(ast).toMatchInlineSnapshot(`
+            (mul.exp
+              (neg a)
+              b)
+        `);
+    });
+
     it("negation can be on individual factors when wrapped in parens", () => {
         const ast = parse("(-a)(b)");
 


### PR DESCRIPTION
This simplifies `checkDistribution` when negatives are involved.