### PR TITLE
update tests to convert text to an EditorNode before parsing, update print to handle more cases

### DIFF
--- a/packages/editor-parser/src/editor-parser.ts
+++ b/packages/editor-parser/src/editor-parser.ts
@@ -33,6 +33,7 @@ const isIdentifier = (node: Token): boolean =>
 const getPrefixParselet = (
     token: Token,
 ): Parser.PrefixParselet<Token, Semantic.Expression, Operator> => {
+    token.type; // ?
     switch (token.type) {
         case "atom": {
             const atom = token.value;

--- a/packages/editor/src/__tests__/editor-printer.test.ts
+++ b/packages/editor/src/__tests__/editor-printer.test.ts
@@ -199,7 +199,7 @@ describe("print", () => {
 
         const node = print(ast);
 
-        expect(node).toEqualMath(Util.frac("a", "b"));
+        expect(node).toEqualMath(Editor.row([Util.frac("a", "b")]));
     });
 
     test("(a+b)/(x+y)", () => {
@@ -210,7 +210,7 @@ describe("print", () => {
 
         const node = print(ast);
 
-        expect(node).toEqualMath(Util.frac("a+b", "x+y"));
+        expect(node).toEqualMath(Editor.row([Util.frac("a+b", "x+y")]));
     });
 
     test("a + -a", () => {
@@ -269,5 +269,16 @@ describe("print", () => {
         const node = print(ast);
 
         expect(node).toEqualMath(Util.row("a*b*1"));
+    });
+
+    test("y = x + 1", () => {
+        const ast = Semantic.eq([
+            Semantic.identifier("y"),
+            Semantic.add([Semantic.identifier("x"), Semantic.number("1")]),
+        ]);
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("y=x+1"));
     });
 });

--- a/packages/editor/src/__tests__/editor-printer.test.ts
+++ b/packages/editor/src/__tests__/editor-printer.test.ts
@@ -54,6 +54,17 @@ describe("print", () => {
         expect(node).toEqualMath(Util.row("1+2+3"));
     });
 
+    test("12+34", () => {
+        const ast = Semantic.add([
+            Semantic.number("12"),
+            Semantic.number("34"),
+        ]);
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("12+34"));
+    });
+
     test("a*b*c", () => {
         const ast = Semantic.mul(
             [
@@ -200,5 +211,63 @@ describe("print", () => {
         const node = print(ast);
 
         expect(node).toEqualMath(Util.frac("a+b", "x+y"));
+    });
+
+    test("a + -a", () => {
+        const ast = Semantic.add([
+            Semantic.identifier("a"),
+            Semantic.neg(Semantic.identifier("a"), false),
+        ]);
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("a+-a"));
+    });
+
+    test("-1(a + b)", () => {
+        const ast = Semantic.mul(
+            [
+                Semantic.neg(Semantic.number("1")),
+                Semantic.add([
+                    Semantic.identifier("a"),
+                    Semantic.identifier("b"),
+                ]),
+            ],
+            true,
+        );
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("-1(a+b)"));
+    });
+
+    test("(a)(b)(1)", () => {
+        const ast = Semantic.mul(
+            [
+                Semantic.identifier("a"),
+                Semantic.identifier("b"),
+                Semantic.number("1"),
+            ],
+            true,
+        );
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("(a)(b)(1)"));
+    });
+
+    test("a*b*1", () => {
+        const ast = Semantic.mul(
+            [
+                Semantic.identifier("a"),
+                Semantic.identifier("b"),
+                Semantic.number("1"),
+            ],
+            false,
+        );
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("a*b*1"));
     });
 });

--- a/packages/editor/src/editor-printer.ts
+++ b/packages/editor/src/editor-printer.ts
@@ -14,7 +14,6 @@ type ID = {
 };
 
 // TODO: write more tests for this
-// TODO: have a top-evel function that returns an Editor.Row
 const print = (expr: Semantic.Expression): Editor.Node<Editor.Glyph, ID> => {
     switch (expr.type) {
         case "identifier": {
@@ -163,10 +162,37 @@ const print = (expr: Semantic.Expression): Editor.Node<Editor.Glyph, ID> => {
                 ],
             };
         }
+        case "eq": {
+            const children: Editor.Node<Editor.Glyph, ID>[] = [];
+
+            for (const arg of expr.args) {
+                const node = print(arg);
+                if (node.type === "row") {
+                    children.push(...node.children);
+                } else {
+                    children.push(node);
+                }
+                children.push(Editor.glyph("="));
+            }
+
+            children.pop(); // remove extra "="
+
+            return {
+                id: expr.id, // TODO: generate a new id
+                type: "row",
+                children: children,
+            };
+        }
         default: {
-            throw new Error("print doesn't handle this case yet");
+            throw new Error(`print doesn't handle ${expr.type} nodes yet`);
         }
     }
 };
 
-export default print;
+export default (expr: Semantic.Expression): Editor.Row<Editor.Glyph, ID> => {
+    const node = print(expr);
+    if (node.type === "row") {
+        return node;
+    }
+    return Editor.row([node]);
+};

--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -1,27 +1,12 @@
 import {serializer} from "@math-blocks/semantic";
-import {parse} from "@math-blocks/text-parser";
 
 import {MistakeId} from "../../enums";
 
-import {checkStep, checkMistake} from "../test-util";
-import {deepEquals} from "../util";
+import {checkStep, checkMistake, toParseLike} from "../test-util";
 
 expect.addSnapshotSerializer(serializer);
 
-expect.extend({
-    toParseLike(received, expected) {
-        if (deepEquals(received, parse(expected))) {
-            return {
-                message: () => `expected steps not to match`,
-                pass: true,
-            };
-        }
-        return {
-            message: () => `expected steps not to match`,
-            pass: false,
-        };
-    },
-});
+expect.extend({toParseLike});
 
 describe("Axiom checks", () => {
     describe("symmetricProperty", () => {

--- a/packages/step-checker/src/checks/__tests__/basic-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/basic-checks.test.ts
@@ -1,9 +1,21 @@
 import {parse} from "@math-blocks/text-parser";
+import * as Editor from "@math-blocks/editor";
+import {parse as _parse} from "@math-blocks/editor-parser";
+import * as Semantic from "@math-blocks/semantic";
 
 import StepChecker from "../../step-checker";
 import {hasArgs} from "../util";
 
 import {checkArgs} from "../basic-checks";
+
+type ID = {
+    id: number;
+};
+
+const myParse = (text: string): Semantic.Expression => {
+    const node = Editor.print(parse(text)) as Editor.Row<Editor.Glyph, ID>;
+    return _parse(node);
+};
 
 describe("checkArgs", () => {
     const checker = new StepChecker();
@@ -13,8 +25,8 @@ describe("checkArgs", () => {
         jest.spyOn(checker, "checkStep");
         expect.assertions(2);
 
-        const sum1 = parse("1 + 2 + 3");
-        const sum2 = parse("1 + 2 + 3 + 4");
+        const sum1 = myParse("1 + 2 + 3");
+        const sum2 = myParse("1 + 2 + 3 + 4");
         if (hasArgs(sum1) && hasArgs(sum2)) {
             const result = checkArgs(sum1, sum2, {
                 checker,

--- a/packages/step-checker/src/checks/__tests__/equation-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/equation-checks.test.ts
@@ -1,27 +1,11 @@
-import {parse} from "@math-blocks/text-parser";
 import {serializer} from "@math-blocks/semantic";
 
 import {Status, MistakeId} from "../../enums";
 
-import {deepEquals} from "../util";
-import {checkStep, checkMistake} from "../test-util";
+import {checkStep, checkMistake, toParseLike} from "../test-util";
 
 expect.addSnapshotSerializer(serializer);
-
-expect.extend({
-    toParseLike(received, expected) {
-        if (deepEquals(received, parse(expected))) {
-            return {
-                message: () => `expected steps not to match`,
-                pass: true,
-            };
-        }
-        return {
-            message: () => `expected steps not to match`,
-            pass: false,
-        };
-    },
-});
+expect.extend({toParseLike});
 
 describe("Equation checks", () => {
     describe("adding the same value to both sides", () => {

--- a/packages/step-checker/src/checks/__tests__/fraction-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/fraction-checks.test.ts
@@ -1,14 +1,10 @@
 import {serializer} from "@math-blocks/semantic";
 import {parse} from "@math-blocks/text-parser";
-import {parse as _parse} from "@math-blocks/editor-parser";
-import * as Editor from "@math-blocks/editor";
-import * as Semantic from "@math-blocks/semantic";
 
 import StepChecker from "../../step-checker";
 import {Context} from "../../types";
 
-import {deepEquals} from "../util";
-import {checkStep} from "../test-util";
+import {checkStep, toParseLike} from "../test-util";
 import {mulOne} from "../axiom-checks";
 import {divIsMulByOneOver, mulInverse, divBySame} from "../fraction-checks";
 import {
@@ -19,33 +15,7 @@ import {
 } from "../basic-checks";
 
 expect.addSnapshotSerializer(serializer);
-
-type ID = {
-    id: number;
-};
-
-const myParse = (text: string): Semantic.Expression => {
-    let node = Editor.print(parse(text)) as Editor.Row<Editor.Glyph, ID>;
-    if (node.type !== "row") {
-        node = Editor.row([node]);
-    }
-    return _parse(node);
-};
-
-expect.extend({
-    toParseLike(received, expected) {
-        if (deepEquals(received, myParse(expected))) {
-            return {
-                message: () => `expected steps not to match`,
-                pass: true,
-            };
-        }
-        return {
-            message: () => `expected steps not to match`,
-            pass: false,
-        };
-    },
-});
+expect.extend({toParseLike});
 
 describe("Fraction checks", () => {
     it("a * 1/b -> a / b", () => {

--- a/packages/step-checker/src/checks/__tests__/fraction-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/fraction-checks.test.ts
@@ -1,5 +1,8 @@
 import {serializer} from "@math-blocks/semantic";
 import {parse} from "@math-blocks/text-parser";
+import {parse as _parse} from "@math-blocks/editor-parser";
+import * as Editor from "@math-blocks/editor";
+import * as Semantic from "@math-blocks/semantic";
 
 import StepChecker from "../../step-checker";
 import {Context} from "../../types";
@@ -17,9 +20,21 @@ import {
 
 expect.addSnapshotSerializer(serializer);
 
+type ID = {
+    id: number;
+};
+
+const myParse = (text: string): Semantic.Expression => {
+    let node = Editor.print(parse(text)) as Editor.Row<Editor.Glyph, ID>;
+    if (node.type !== "row") {
+        node = Editor.row([node]);
+    }
+    return _parse(node);
+};
+
 expect.extend({
     toParseLike(received, expected) {
-        if (deepEquals(received, parse(expected))) {
+        if (deepEquals(received, myParse(expected))) {
             return {
                 message: () => `expected steps not to match`,
                 pass: true,

--- a/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
@@ -1,37 +1,9 @@
 import {serializer} from "@math-blocks/semantic";
-import {parse} from "@math-blocks/text-parser";
-import {parse as _parse} from "@math-blocks/editor-parser";
-import * as Editor from "@math-blocks/editor";
-import * as Semantic from "@math-blocks/semantic";
 
-import {checkStep} from "../test-util";
-import {deepEquals} from "../util";
+import {checkStep, toParseLike} from "../test-util";
 
 expect.addSnapshotSerializer(serializer);
-
-type ID = {
-    id: number;
-};
-
-const myParse = (text: string): Semantic.Expression => {
-    const node = Editor.print(parse(text)) as Editor.Row<Editor.Glyph, ID>;
-    return _parse(node);
-};
-
-expect.extend({
-    toParseLike(received, expected) {
-        if (deepEquals(received, myParse(expected))) {
-            return {
-                message: () => `expected steps not to match`,
-                pass: true,
-            };
-        }
-        return {
-            message: () => `expected steps not to match`,
-            pass: false,
-        };
-    },
-});
+expect.extend({toParseLike});
 
 describe("Integer checks", () => {
     it("a + -a -> 0", () => {

--- a/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/integer-checks.test.ts
@@ -1,14 +1,26 @@
 import {serializer} from "@math-blocks/semantic";
 import {parse} from "@math-blocks/text-parser";
+import {parse as _parse} from "@math-blocks/editor-parser";
+import * as Editor from "@math-blocks/editor";
+import * as Semantic from "@math-blocks/semantic";
 
 import {checkStep} from "../test-util";
 import {deepEquals} from "../util";
 
 expect.addSnapshotSerializer(serializer);
 
+type ID = {
+    id: number;
+};
+
+const myParse = (text: string): Semantic.Expression => {
+    const node = Editor.print(parse(text)) as Editor.Row<Editor.Glyph, ID>;
+    return _parse(node);
+};
+
 expect.extend({
     toParseLike(received, expected) {
-        if (deepEquals(received, parse(expected))) {
+        if (deepEquals(received, myParse(expected))) {
             return {
                 message: () => `expected steps not to match`,
                 pass: true,
@@ -26,6 +38,7 @@ describe("Integer checks", () => {
         const result = checkStep("a + -a", "0");
 
         expect(result).toBeTruthy();
+        expect(result.steps[0].nodes[0]).toParseLike("a + -a");
         expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`
             (add
               a

--- a/packages/step-checker/src/checks/test-util.ts
+++ b/packages/step-checker/src/checks/test-util.ts
@@ -1,7 +1,12 @@
+import * as Editor from "@math-blocks/editor";
+import * as Semantic from "@math-blocks/semantic";
+import {parse as _parse} from "@math-blocks/editor-parser";
 import {parse} from "@math-blocks/text-parser";
 
 import {checkStep as _checkStep} from "../step-checker";
 import {Result, Mistake} from "../types";
+
+import {deepEquals} from "./util";
 
 export const checkStep = (
     prev: string,
@@ -27,4 +32,29 @@ export const checkMistake = (prev: string, next: string): Mistake[] => {
         }
     }
     throw new Error("Unexpected result");
+};
+
+type ID = {
+    id: number;
+};
+
+const myParse = (text: string): Semantic.Expression => {
+    const node = Editor.print(parse(text)) as Editor.Row<Editor.Glyph, ID>;
+    return _parse(node);
+};
+
+export const toParseLike = (
+    received: string,
+    expected: string,
+): {message: () => string; pass: boolean} => {
+    if (deepEquals(received, myParse(expected))) {
+        return {
+            message: () => `expected steps not to match`,
+            pass: true,
+        };
+    }
+    return {
+        message: () => `expected steps not to match`,
+        pass: false,
+    };
 };

--- a/packages/step-checker/tsconfig.json
+++ b/packages/step-checker/tsconfig.json
@@ -7,5 +7,7 @@
   "references": [
     {"path": "../semantic"},
     {"path": "../text-parser"},
+    {"path": "../editor"},
+    {"path": "../editor-parser"},
   ]
 }


### PR DESCRIPTION
TODO:
- [x] ensure that `print` return a row
- [x] create a test helper that converts text -> Editor.Node -> Semantic.Node
- [x] add support for `eq` to `print`
