### PR TITLE
Replace 'nodes' with 'prevNodes', 'nextNodes' in Mistake

### DIFF
--- a/demo/src/step-checker-page.tsx
+++ b/demo/src/step-checker-page.tsx
@@ -11,6 +11,7 @@ import * as Semantic from "@math-blocks/semantic";
 
 import Step from "./step";
 import {StepType, StepState} from "./types";
+import {getPairs} from "./util";
 
 const question: Editor.Row = Editor.Util.row("2x+5=10");
 
@@ -63,10 +64,12 @@ export const App: React.SFC<{}> = () => {
             } else {
                 setSteps([
                     ...steps.slice(0, -1),
+                    // Set the last step to be "Correct"
                     {
                         ...steps[steps.length - 1],
                         state: StepState.Correct,
                     },
+                    // Add a new step that "Duplicate"s the last
                     {
                         ...steps[steps.length - 1],
                         state: StepState.Duplicate,
@@ -89,6 +92,7 @@ export const App: React.SFC<{}> = () => {
     };
 
     const isComplete = problemState === ProblemState.Complete;
+    const pairs = getPairs(steps);
 
     return (
         <div style={{width: 800, margin: "auto"}}>
@@ -113,14 +117,15 @@ export const App: React.SFC<{}> = () => {
                         ]);
                     }}
                 />
-                {steps.slice(1).flatMap((step, index) => {
-                    const isLast = index === steps.length - 2;
+                {pairs.map(([prevStep, step], index) => {
+                    const isLast = index === pairs.length - 1;
 
                     return (
                         <Step
                             key={`step-${index}`}
                             focus={isLast && mode === "solve"}
                             readonly={!isLast || isComplete}
+                            prevStep={prevStep}
                             step={step}
                             onSubmit={() => {
                                 return handleCheckStep(

--- a/demo/src/step.tsx
+++ b/demo/src/step.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Editor from "@math-blocks/editor";
 import {Icon, MathEditor} from "@math-blocks/react";
-import {MistakeId} from "@math-blocks/step-checker";
+import {MistakeId, Mistake} from "@math-blocks/step-checker";
 
 import {StepType, StepState} from "./types";
 import {HStack, VStack} from "./containers";
@@ -9,6 +9,8 @@ import {HStack, VStack} from "./containers";
 type Props = {
     focus: boolean;
     readonly: boolean;
+
+    prevStep: StepType;
     step: StepType;
 
     onSubmit: () => unknown;
@@ -92,6 +94,18 @@ const Step: React.SFC<Props> = (props) => {
         }
     }
 
+    const correctMistake = (mistake: Mistake): void => {
+        console.log("correcting: ", mistake);
+
+        // TODO:
+        // - [x] pass in both prev and next as props
+        // - [ ] refactor state updates to use a reducer + immer
+        // - [ ] move handleCheckStep from StepCheckerPage to Step
+        // - [ ] once we've done a check, we need to save the parsed versions
+        // - [ ] apply the correct to parsedNext
+        // - [ ] covert the corrected parsedNext back into an Editor.Row
+    };
+
     return (
         <VStack>
             <HStack
@@ -134,6 +148,11 @@ const Step: React.SFC<Props> = (props) => {
                             style={{fontFamily: "sans-serif", fontSize: 20}}
                         >
                             {MistakeMessages[mistake.id]}
+                            {mistake.corrections.length > 0 && (
+                                <button onClick={() => correctMistake(mistake)}>
+                                    Correct the mistake for me
+                                </button>
+                            )}
                         </HStack>
                     );
                 })}

--- a/demo/src/step.tsx
+++ b/demo/src/step.tsx
@@ -60,8 +60,8 @@ const Step: React.SFC<Props> = (props) => {
 
     if (step.state === StepState.Incorrect) {
         for (const mistake of step.mistakes) {
-            console.log(mistake);
-            for (const node of mistake.nodes) {
+            // TODO: also highlight nodes from mistake.prevNodes
+            for (const node of mistake.nextNodes) {
                 if (node.loc) {
                     const editNode = Editor.Util.nodeAtPath(
                         step.value,
@@ -69,6 +69,9 @@ const Step: React.SFC<Props> = (props) => {
                     );
                     if (editNode && Editor.Util.hasChildren(editNode)) {
                         for (let i = node.loc.start; i < node.loc.end; i++) {
+                            // NOTE: we shouldn't need this try-catch anymore
+                            // since we filter out all nodes that aren't in
+                            // next or prev.
                             try {
                                 colorMap.set(
                                     editNode.children[i].id,

--- a/demo/src/util.ts
+++ b/demo/src/util.ts
@@ -1,0 +1,12 @@
+export const getPairs = <T>(array: T[]): [T, T][] => {
+    if (array.length < 2) {
+        return [];
+    }
+
+    const result: [T, T][] = [];
+    for (let i = 0; i < array.length - 1; i++) {
+        result.push([array[i], array[i + 1]]);
+    }
+
+    return result;
+};

--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -296,9 +296,19 @@ describe("Axiom checks", () => {
 
             expect(mistakes).toHaveLength(1);
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
+            expect(mistakes[0].prevNodes).toHaveLength(0);
             expect(mistakes[0].nextNodes[0]).toParseLike("7");
             expect(mistakes[0].nextNodes).toHaveLength(1);
-            expect(mistakes[0].prevNodes).toHaveLength(0);
+        });
+
+        it("2(a + 7) -> 2a", () => {
+            const mistakes = checkMistake("2(a + 7)", "2a");
+
+            expect(mistakes).toHaveLength(1);
+            expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
+            expect(mistakes[0].prevNodes[0]).toParseLike("7");
+            expect(mistakes[0].prevNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes).toHaveLength(0);
         });
 
         it("2a + 2b -> 2(a + 7) + 2(b + 3)", () => {
@@ -436,8 +446,8 @@ describe("Axiom checks", () => {
             ]);
         });
 
-        it("a * b -> 2 * a * b", () => {
-            const mistakes = checkMistake("a * b", "2 * a * b");
+        it("ab -> 2ab", () => {
+            const mistakes = checkMistake("ab", "2ab");
 
             expect(mistakes).toHaveLength(1);
 
@@ -445,6 +455,17 @@ describe("Axiom checks", () => {
             expect(mistakes[0].prevNodes).toHaveLength(0);
             expect(mistakes[0].nextNodes).toHaveLength(1);
             expect(mistakes[0].nextNodes[0]).toParseLike("2");
+        });
+
+        it("2ab -> ab", () => {
+            const mistakes = checkMistake("2ab", "ab");
+
+            expect(mistakes).toHaveLength(1);
+
+            expect(mistakes[0].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
+            expect(mistakes[0].prevNodes).toHaveLength(1);
+            expect(mistakes[0].prevNodes[0]).toParseLike("2");
+            expect(mistakes[0].nextNodes).toHaveLength(0);
         });
 
         it("1 + ab -> 1 + 2ab", () => {

--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -296,23 +296,25 @@ describe("Axiom checks", () => {
 
             expect(mistakes).toHaveLength(1);
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[0].nodes[0]).toParseLike("7");
-            expect(mistakes[0].nodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("7");
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].prevNodes).toHaveLength(0);
         });
 
-        // TODO: This should report multiple mistakes
         it("2a + 2b -> 2(a + 7) + 2(b + 3)", () => {
             const mistakes = checkMistake("2a + 2b", "2(a + 7) + 2(b + 3)");
 
             expect(mistakes).toHaveLength(2);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[0].nodes[0]).toParseLike("7");
-            expect(mistakes[0].nodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("7");
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].prevNodes).toHaveLength(0);
 
             expect(mistakes[1].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[1].nodes[0]).toParseLike("3");
-            expect(mistakes[1].nodes).toHaveLength(1);
+            expect(mistakes[1].nextNodes[0]).toParseLike("3");
+            expect(mistakes[1].nextNodes).toHaveLength(1);
+            expect(mistakes[1].prevNodes).toHaveLength(0);
         });
 
         it("a + b -> a + b + 0", () => {
@@ -440,8 +442,9 @@ describe("Axiom checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("2");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("2");
         });
 
         it("1 + ab -> 1 + 2ab", () => {
@@ -450,8 +453,9 @@ describe("Axiom checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("2");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("2");
         });
     });
 

--- a/packages/step-checker/src/checks/__tests__/equation-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/equation-checks.test.ts
@@ -161,9 +161,22 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
+            expect(mistakes[0].prevNodes).toHaveLength(0);
             expect(mistakes[0].nextNodes).toHaveLength(2);
             expect(mistakes[0].nextNodes[0]).toParseLike("3");
             expect(mistakes[0].nextNodes[1]).toParseLike("7");
+        });
+
+        it("x + 3 = y + 7 -> x = y", () => {
+            const mistakes = checkMistake("x + 3 = y + 7", "x = y");
+
+            expect(mistakes).toHaveLength(1);
+
+            expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
+            expect(mistakes[0].prevNodes).toHaveLength(2);
+            expect(mistakes[0].prevNodes[0]).toParseLike("3");
+            expect(mistakes[0].prevNodes[1]).toParseLike("7");
+            expect(mistakes[0].nextNodes).toHaveLength(0);
         });
 
         it("x = y -> x = y + 7", () => {
@@ -419,6 +432,18 @@ describe("Equation checks", () => {
             expect(mistakes[0].nextNodes).toHaveLength(2);
             expect(mistakes[0].nextNodes[0]).toParseLike("3");
             expect(mistakes[0].nextNodes[1]).toParseLike("7");
+        });
+
+        it("3x = 7y -> x = y", () => {
+            const mistakes = checkMistake("3x = 7y", "x = y");
+
+            expect(mistakes).toHaveLength(1);
+
+            expect(mistakes[0].id).toEqual(MistakeId.EQN_MUL_DIFF);
+            expect(mistakes[0].prevNodes).toHaveLength(2);
+            expect(mistakes[0].prevNodes[0]).toParseLike("3");
+            expect(mistakes[0].prevNodes[1]).toParseLike("7");
+            expect(mistakes[0].nextNodes).toHaveLength(0);
         });
 
         it("xa = yb -> 3xa = 7yb", () => {

--- a/packages/step-checker/src/checks/__tests__/equation-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/equation-checks.test.ts
@@ -161,9 +161,9 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(2);
-            expect(mistakes[0].nodes[0]).toParseLike("3");
-            expect(mistakes[0].nodes[1]).toParseLike("7");
+            expect(mistakes[0].nextNodes).toHaveLength(2);
+            expect(mistakes[0].nextNodes[0]).toParseLike("3");
+            expect(mistakes[0].nextNodes[1]).toParseLike("7");
         });
 
         it("x = y -> x = y + 7", () => {
@@ -172,8 +172,8 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("7");
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("7");
         });
 
         it("x + y = x + y -> x + y = x + y + 7", () => {
@@ -182,8 +182,9 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("7");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("7");
         });
 
         it("2x + 5 = 10 -> 2x + 5 - 5 = 10 [incorrect]", () => {
@@ -192,13 +193,16 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toMatchInlineSnapshot(`(neg.sub 5)`);
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toMatchInlineSnapshot(
+                `(neg.sub 5)`,
+            );
         });
 
         // TODO: make this work
-        // The issue here is that we're swapping x and y before multiplying
-        // factors on each side.
+        // The issue here is that we're swapping x and y before adding terms
+        // on each side.
         it.skip("y = x -> x + 10 = y + 10", () => {
             const result = checkStep("y = x", "x + 10 = y + 10");
 
@@ -265,9 +269,14 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_ADD_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(2);
-            expect(mistakes[0].nodes[0]).toMatchInlineSnapshot(`(neg.sub 5)`);
-            expect(mistakes[0].nodes[1]).toMatchInlineSnapshot(`(neg.sub 10)`);
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(2);
+            expect(mistakes[0].nextNodes[0]).toMatchInlineSnapshot(
+                `(neg.sub 5)`,
+            );
+            expect(mistakes[0].nextNodes[1]).toMatchInlineSnapshot(
+                `(neg.sub 10)`,
+            );
         });
 
         it("2x + 5 - 5 = 10 - 5 -> 2x + 5 - 5 = 5", () => {
@@ -384,8 +393,9 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_MUL_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("7");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("7");
         });
 
         it("xa = yb -> xa = 7yb", () => {
@@ -394,8 +404,9 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_MUL_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("7");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("7");
         });
 
         it("x = y -> 3x = 7y", () => {
@@ -404,9 +415,10 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_MUL_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(2);
-            expect(mistakes[0].nodes[0]).toParseLike("3");
-            expect(mistakes[0].nodes[1]).toParseLike("7");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(2);
+            expect(mistakes[0].nextNodes[0]).toParseLike("3");
+            expect(mistakes[0].nextNodes[1]).toParseLike("7");
         });
 
         it("xa = yb -> 3xa = 7yb", () => {
@@ -415,9 +427,10 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EQN_MUL_DIFF);
-            expect(mistakes[0].nodes).toHaveLength(2);
-            expect(mistakes[0].nodes[0]).toParseLike("3");
-            expect(mistakes[0].nodes[1]).toParseLike("7");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(2);
+            expect(mistakes[0].nextNodes[0]).toParseLike("3");
+            expect(mistakes[0].nextNodes[1]).toParseLike("7");
         });
 
         // TODO: return an incorrect result for this test case
@@ -505,12 +518,12 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(2);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("1");
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("1");
 
             expect(mistakes[1].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[1].nodes).toHaveLength(1);
-            expect(mistakes[1].nodes[0]).toParseLike("2");
+            expect(mistakes[1].nextNodes).toHaveLength(1);
+            expect(mistakes[1].nextNodes[0]).toParseLike("2");
         });
 
         it("2x + 5 - 5 = 10 - 5 -> 2x = 3", () => {
@@ -529,12 +542,14 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(2);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("2");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("2");
 
             expect(mistakes[1].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[1].nodes).toHaveLength(1);
-            expect(mistakes[1].nodes[0]).toParseLike("2");
+            expect(mistakes[1].prevNodes).toHaveLength(0);
+            expect(mistakes[1].nextNodes).toHaveLength(1);
+            expect(mistakes[1].nextNodes[0]).toParseLike("2");
         });
 
         // This verifies that these mistakes are detected when the symmetric
@@ -545,12 +560,14 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(2);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("2");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("2");
 
             expect(mistakes[1].id).toEqual(MistakeId.EXPR_MUL_NON_IDENTITY);
-            expect(mistakes[1].nodes).toHaveLength(1);
-            expect(mistakes[1].nodes[0]).toParseLike("2");
+            expect(mistakes[1].prevNodes).toHaveLength(0);
+            expect(mistakes[1].nextNodes).toHaveLength(1);
+            expect(mistakes[1].nextNodes[0]).toParseLike("2");
         });
 
         it("2x -> 2(x + 1)", () => {
@@ -559,8 +576,9 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(1);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("1");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("1");
         });
 
         it("2x + 3y -> 2(x + 1) + 3(y + 1)", () => {
@@ -569,12 +587,14 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(2);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("1");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("1");
 
             expect(mistakes[1].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[1].nodes).toHaveLength(1);
-            expect(mistakes[1].nodes[0]).toParseLike("1");
+            expect(mistakes[1].prevNodes).toHaveLength(0);
+            expect(mistakes[1].nextNodes).toHaveLength(1);
+            expect(mistakes[1].nextNodes[0]).toParseLike("1");
         });
 
         // This test checks that error reporting works with the commutative
@@ -585,12 +605,14 @@ describe("Equation checks", () => {
             expect(mistakes).toHaveLength(2);
 
             expect(mistakes[0].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("1");
+            expect(mistakes[0].prevNodes).toHaveLength(0);
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("1");
 
             expect(mistakes[1].id).toEqual(MistakeId.EXPR_ADD_NON_IDENTITY);
-            expect(mistakes[1].nodes).toHaveLength(1);
-            expect(mistakes[1].nodes[0]).toParseLike("1");
+            expect(mistakes[1].prevNodes).toHaveLength(0);
+            expect(mistakes[1].nextNodes).toHaveLength(1);
+            expect(mistakes[1].nextNodes[0]).toParseLike("1");
         });
 
         // While the previous test case detected two mistakes, this test cases

--- a/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
@@ -312,6 +312,7 @@ describe("Eval (decomposition) checks", () => {
 
     describe("mistakes", () => {
         it("5 + 8 -> 11 (should be 13)", () => {
+            // TODO: include prev, next in the result of checkMistake
             const mistakes = checkMistake("5 + 8", "11");
 
             expect(mistakes).toHaveLength(1);
@@ -321,6 +322,8 @@ describe("Eval (decomposition) checks", () => {
             expect(mistakes[0].prevNodes[1]).toParseLike("8");
             expect(mistakes[0].nextNodes).toHaveLength(1);
             expect(mistakes[0].nextNodes[0]).toParseLike("11");
+            expect(mistakes[0].corrections).toHaveLength(1);
+            expect(mistakes[0].corrections[0].replacement).toParseLike("13");
         });
 
         it("11 -> 5 + 8 (decomp adds to 13)", () => {
@@ -333,6 +336,7 @@ describe("Eval (decomposition) checks", () => {
             expect(mistakes[0].nextNodes).toHaveLength(2);
             expect(mistakes[0].nextNodes[0]).toParseLike("5");
             expect(mistakes[0].nextNodes[1]).toParseLike("8");
+            expect(mistakes[0].corrections).toHaveLength(0);
         });
 
         it("6 * 8 = 42 (should be 48)", () => {
@@ -345,6 +349,8 @@ describe("Eval (decomposition) checks", () => {
             expect(mistakes[0].prevNodes[1]).toParseLike("8");
             expect(mistakes[0].nextNodes).toHaveLength(1);
             expect(mistakes[0].nextNodes[0]).toParseLike("42");
+            expect(mistakes[0].corrections).toHaveLength(1);
+            expect(mistakes[0].corrections[0].replacement).toParseLike("48");
         });
 
         it("42 = 6 * 8 (decomp multiplies to 48)", () => {
@@ -357,6 +363,7 @@ describe("Eval (decomposition) checks", () => {
             expect(mistakes[0].nextNodes).toHaveLength(2);
             expect(mistakes[0].nextNodes[0]).toParseLike("6");
             expect(mistakes[0].nextNodes[1]).toParseLike("8");
+            expect(mistakes[0].corrections).toHaveLength(0);
         });
     });
 });

--- a/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
@@ -316,8 +316,11 @@ describe("Eval (decomposition) checks", () => {
 
             expect(mistakes).toHaveLength(1);
             expect(mistakes[0].id).toEqual(MistakeId.EVAL_ADD);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("11");
+            expect(mistakes[0].prevNodes).toHaveLength(2);
+            expect(mistakes[0].prevNodes[0]).toParseLike("5");
+            expect(mistakes[0].prevNodes[1]).toParseLike("8");
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("11");
         });
 
         it("11 -> 5 + 8 (decomp adds to 13)", () => {
@@ -325,9 +328,11 @@ describe("Eval (decomposition) checks", () => {
 
             expect(mistakes).toHaveLength(1);
             expect(mistakes[0].id).toEqual(MistakeId.DECOMP_ADD);
-            expect(mistakes[0].nodes).toHaveLength(2);
-            expect(mistakes[0].nodes[0]).toParseLike("5");
-            expect(mistakes[0].nodes[1]).toParseLike("8");
+            expect(mistakes[0].prevNodes).toHaveLength(1);
+            expect(mistakes[0].prevNodes[0]).toParseLike("11");
+            expect(mistakes[0].nextNodes).toHaveLength(2);
+            expect(mistakes[0].nextNodes[0]).toParseLike("5");
+            expect(mistakes[0].nextNodes[1]).toParseLike("8");
         });
 
         it("6 * 8 = 42 (should be 48)", () => {
@@ -335,8 +340,11 @@ describe("Eval (decomposition) checks", () => {
 
             expect(mistakes).toHaveLength(1);
             expect(mistakes[0].id).toEqual(MistakeId.EVAL_MUL);
-            expect(mistakes[0].nodes).toHaveLength(1);
-            expect(mistakes[0].nodes[0]).toParseLike("42");
+            expect(mistakes[0].prevNodes).toHaveLength(2);
+            expect(mistakes[0].prevNodes[0]).toParseLike("6");
+            expect(mistakes[0].prevNodes[1]).toParseLike("8");
+            expect(mistakes[0].nextNodes).toHaveLength(1);
+            expect(mistakes[0].nextNodes[0]).toParseLike("42");
         });
 
         it("42 = 6 * 8 (decomp multiplies to 48)", () => {
@@ -344,9 +352,11 @@ describe("Eval (decomposition) checks", () => {
 
             expect(mistakes).toHaveLength(1);
             expect(mistakes[0].id).toEqual(MistakeId.DECOMP_MUL);
-            expect(mistakes[0].nodes).toHaveLength(2);
-            expect(mistakes[0].nodes[0]).toParseLike("6");
-            expect(mistakes[0].nodes[1]).toParseLike("8");
+            expect(mistakes[0].prevNodes).toHaveLength(1);
+            expect(mistakes[0].prevNodes[0]).toParseLike("42");
+            expect(mistakes[0].nextNodes).toHaveLength(2);
+            expect(mistakes[0].nextNodes[0]).toParseLike("6");
+            expect(mistakes[0].nextNodes[1]).toParseLike("8");
         });
     });
 });

--- a/packages/step-checker/src/checks/axiom-checks.ts
+++ b/packages/step-checker/src/checks/axiom-checks.ts
@@ -67,7 +67,8 @@ export const addZero: Check = (prev, next, context) => {
         ) {
             context.mistakes.push({
                 id: MistakeId.EXPR_ADD_NON_IDENTITY,
-                nodes: newNonIdentityTerms,
+                prevNodes: context.reversed ? newNonIdentityTerms : [],
+                nextNodes: context.reversed ? [] : newNonIdentityTerms,
             });
         }
         return;
@@ -175,7 +176,8 @@ export const mulOne: Check = (prev, next, context) => {
         ) {
             context.mistakes.push({
                 id: MistakeId.EXPR_MUL_NON_IDENTITY,
-                nodes: newNonIdentityFactors,
+                prevNodes: context.reversed ? newNonIdentityFactors : [],
+                nextNodes: context.reversed ? [] : newNonIdentityFactors,
             });
         }
         return;

--- a/packages/step-checker/src/checks/axiom-checks.ts
+++ b/packages/step-checker/src/checks/axiom-checks.ts
@@ -69,6 +69,7 @@ export const addZero: Check = (prev, next, context) => {
                 id: MistakeId.EXPR_ADD_NON_IDENTITY,
                 prevNodes: context.reversed ? newNonIdentityTerms : [],
                 nextNodes: context.reversed ? [] : newNonIdentityTerms,
+                corrections: [],
             });
         }
         return;
@@ -178,6 +179,7 @@ export const mulOne: Check = (prev, next, context) => {
                 id: MistakeId.EXPR_MUL_NON_IDENTITY,
                 prevNodes: context.reversed ? newNonIdentityFactors : [],
                 nextNodes: context.reversed ? [] : newNonIdentityFactors,
+                corrections: [],
             });
         }
         return;

--- a/packages/step-checker/src/checks/equation-checks.ts
+++ b/packages/step-checker/src/checks/equation-checks.ts
@@ -86,6 +86,7 @@ export const checkAddSub: Check = (prev, next, context) => {
                 nextNodes: context.reversed
                     ? []
                     : [...newTermsLHS, ...newTermsRHS],
+                corrections: [],
             });
             return;
         }
@@ -204,6 +205,7 @@ export const checkMul: Check = (prev, next, context) => {
                 nextNodes: context.reversed
                     ? []
                     : [...newFactorsLHS, ...newFactorsRHS],
+                corrections: [],
             });
             return;
         }

--- a/packages/step-checker/src/checks/equation-checks.ts
+++ b/packages/step-checker/src/checks/equation-checks.ts
@@ -78,7 +78,14 @@ export const checkAddSub: Check = (prev, next, context) => {
             context.mistakes.push({
                 id: MistakeId.EQN_ADD_DIFF,
                 // TODO: make structures that are specific to each mistake
-                nodes: [...newTermsLHS, ...newTermsRHS],
+                // In this case we might like to differentiate between new terms
+                // on the LHS from those on the RHS.
+                prevNodes: context.reversed
+                    ? [...newTermsLHS, ...newTermsRHS]
+                    : [],
+                nextNodes: context.reversed
+                    ? []
+                    : [...newTermsLHS, ...newTermsRHS],
             });
             return;
         }
@@ -189,7 +196,14 @@ export const checkMul: Check = (prev, next, context) => {
             context.mistakes.push({
                 id: MistakeId.EQN_MUL_DIFF,
                 // TODO: make structures that are specific to each mistake
-                nodes: [...newFactorsLHS, ...newFactorsRHS],
+                // In this case we might like to differentiate between new factors
+                // on the LHS from those on the RHS.
+                prevNodes: context.reversed
+                    ? [...newFactorsLHS, ...newFactorsRHS]
+                    : [],
+                nextNodes: context.reversed
+                    ? []
+                    : [...newFactorsLHS, ...newFactorsRHS],
             });
             return;
         }

--- a/packages/step-checker/src/checks/eval-checks.ts
+++ b/packages/step-checker/src/checks/eval-checks.ts
@@ -99,8 +99,8 @@ export const evalAdd: Check = (prev, next, context) => {
                 id: context.reversed
                     ? MistakeId.DECOMP_ADD
                     : MistakeId.EVAL_ADD,
-                // TODO: replace 'nodes' with 'prevNodes' and 'nextNodes'
-                nodes: context.reversed ? prevNumTerms : nextNumTerms,
+                prevNodes: context.reversed ? nextNumTerms : prevNumTerms,
+                nextNodes: context.reversed ? prevNumTerms : nextNumTerms,
             });
         }
 
@@ -201,8 +201,8 @@ export const evalMul: Check = (prev, next, context) => {
                 id: context.reversed
                     ? MistakeId.DECOMP_MUL
                     : MistakeId.EVAL_MUL,
-                // TODO: replace 'nodes' with 'prevNodes' and 'nextNodes'
-                nodes: context.reversed ? prevNumFactors : nextNumFactors,
+                prevNodes: context.reversed ? nextNumFactors : prevNumFactors,
+                nextNodes: context.reversed ? prevNumFactors : nextNumFactors,
             });
         }
 

--- a/packages/step-checker/src/types.ts
+++ b/packages/step-checker/src/types.ts
@@ -31,11 +31,16 @@ export const MISTAKE_PRIORITIES: Record<MistakeId, number> = {
     [MistakeId.DECOMP_MUL]: 1,
 };
 
+export type Correction = {
+    id: number;
+    replacement: Expression;
+};
+
 export type Mistake = {
     id: MistakeId;
     prevNodes: Expression[];
     nextNodes: Expression[];
-    corrections?: [number, Expression][]; // [id, replacement][]
+    corrections: Correction[];
 };
 
 export type Context = {

--- a/packages/step-checker/src/types.ts
+++ b/packages/step-checker/src/types.ts
@@ -33,7 +33,9 @@ export const MISTAKE_PRIORITIES: Record<MistakeId, number> = {
 
 export type Mistake = {
     id: MistakeId;
-    nodes: Expression[];
+    prevNodes: Expression[];
+    nextNodes: Expression[];
+    corrections?: [number, Expression][]; // [id, replacement][]
 };
 
 export type Context = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13612,9 +13612,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@3.9.x:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
TODO:
- [ ] ~actually make use of `corrections` (and show it off in the demo)~ I'm going to do this in a separate PR because it requires refactoring the demo to use `immer` + reducers for state management
- [x] add tests for the reversed case for more of the mistakes