### PR TITLE
add missing steps to a couple of the exponent check test cases

### DIFF
--- a/packages/step-checker/src/checks/__tests__/exp-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/exp-checks.test.ts
@@ -248,6 +248,48 @@ describe("Exponent checks", () => {
             const result = checkStep("1 / a^(-2)", "a^2");
 
             expect(result).toBeTruthy();
+            expect(result.steps.map((step) => step.message)).toEqual([
+                "A power with a negative exponent is the same as one over the power with the positive exponent",
+                "dividing by a fraction is the same as multiplying by the reciprocal",
+                "multiplication with identity",
+                "division by one",
+            ]);
+
+            expect(result.steps[0].nodes[0]).toParseLike("a^(-2)");
+            expect(result.steps[0].nodes[1]).toParseLike("1 / a^2");
+
+            expect(result.steps[1].nodes[0]).toParseLike("1 / (1 / a^2)");
+            expect(result.steps[1].nodes[1]).toParseLike("1 * a^2 / 1");
+
+            expect(result.steps[2].nodes[0]).toParseLike("1 * a^2 / 1");
+            expect(result.steps[2].nodes[1]).toParseLike("a^2 / 1");
+
+            expect(result.steps[3].nodes[0]).toParseLike("a^2 / 1");
+            expect(result.steps[3].nodes[1]).toParseLike("a^2");
+        });
+
+        it("a^2 -> 1 / a^(-2)", () => {
+            const result = checkStep("a^2", "1 / a^(-2)");
+
+            expect(result).toBeTruthy();
+            expect(result.steps.map((step) => step.message)).toEqual([
+                "division by one",
+                "multiplication with identity",
+                "dividing by a fraction is the same as multiplying by the reciprocal",
+                "A power with a negative exponent is the same as one over the power with the positive exponent",
+            ]);
+
+            expect(result.steps[0].nodes[0]).toParseLike("a^2");
+            expect(result.steps[0].nodes[1]).toParseLike("a^2 / 1");
+
+            expect(result.steps[1].nodes[0]).toParseLike("a^2 / 1");
+            expect(result.steps[1].nodes[1]).toParseLike("1 * a^2 / 1");
+
+            expect(result.steps[2].nodes[0]).toParseLike("1 * a^2 / 1");
+            expect(result.steps[2].nodes[1]).toParseLike("1 / (1 / a^2)");
+
+            expect(result.steps[3].nodes[0]).toParseLike("1 / a^2");
+            expect(result.steps[3].nodes[1]).toParseLike("a^(-2)");
         });
     });
 

--- a/packages/step-checker/src/checks/fraction-checks.ts
+++ b/packages/step-checker/src/checks/fraction-checks.ts
@@ -203,7 +203,27 @@ export const divByFrac: Check = (prev, next, context) => {
         return;
     }
 
-    return divByFrac(Semantic.div(numerator, newDenominator), next, context);
+    // We need a helper like correctResult but one that appends to the result.
+    const newPrev = Semantic.div(numerator, newDenominator);
+    const result = divByFrac(newPrev, next, context);
+
+    if (result) {
+        if (context.reversed) {
+            result.steps.push({
+                message:
+                    "A power with a negative exponent is the same as one over the power with the positive exponent",
+                nodes: [newDenominator, denominator],
+            });
+        } else {
+            result.steps.unshift({
+                message:
+                    "A power with a negative exponent is the same as one over the power with the positive exponent",
+                nodes: [denominator, newDenominator],
+            });
+        }
+
+        return result;
+    }
 };
 divByFrac.symmetric = true;
 

--- a/packages/step-checker/src/types.ts
+++ b/packages/step-checker/src/types.ts
@@ -4,7 +4,7 @@ import {MistakeId, Status} from "./enums";
 
 export type Step = {
     message: string;
-    nodes: Semantic.Types.Node[];
+    nodes: [Semantic.Types.Node, Semantic.Types.Node];
 };
 
 export type Result = {


### PR DESCRIPTION
In the future we'll need to figure out better patterns for calling convert functions from specific checks in order for the results to contain all of the steps.  This is good enough for now though.