### PR TITLE
add toHaveMessages and toHaveStepsLike test helpers

### DIFF
--- a/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/axiom-checks.test.ts
@@ -2,11 +2,17 @@ import {serializer} from "@math-blocks/semantic";
 
 import {MistakeId} from "../../enums";
 
-import {checkStep, checkMistake, toParseLike} from "../test-util";
+import {
+    checkStep,
+    checkMistake,
+    toParseLike,
+    toHaveStepsLike,
+    toHaveMessages,
+} from "../test-util";
 
 expect.addSnapshotSerializer(serializer);
 
-expect.extend({toParseLike});
+expect.extend({toParseLike, toHaveStepsLike, toHaveMessages});
 
 describe("Axiom checks", () => {
     describe("symmetricProperty", () => {
@@ -14,45 +20,38 @@ describe("Axiom checks", () => {
             const result = checkStep("a = 3", "3 = a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "symmetric property",
-            ]);
+            expect(result).toHaveMessages(["symmetric property"]);
         });
 
         it("a = b = c -> b = c = a", () => {
             const result = checkStep("a = b = c", "b = c = a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "symmetric property",
-            ]);
+            expect(result).toHaveMessages(["symmetric property"]);
         });
 
         it("a = b + 0 = c + 0 -> b = c = a", () => {
             const result = checkStep("a = b + 0 = c + 0", "b = c = a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "addition with identity",
                 "addition with identity",
                 "symmetric property",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("b + 0");
-            expect(result.steps[0].nodes[1]).toParseLike("b");
-
-            expect(result.steps[1].nodes[0]).toParseLike("c + 0");
-            expect(result.steps[1].nodes[1]).toParseLike("c");
-
-            expect(result.steps[2].nodes[0]).toParseLike("a = b = c");
-            expect(result.steps[2].nodes[1]).toParseLike("b = c = a");
+            expect(result).toHaveStepsLike([
+                ["b + 0", "b"],
+                ["c + 0", "c"],
+                ["a = b = c", "b = c = a"],
+            ]);
         });
 
         it("a = 1 + 2 -> 3 = a", () => {
             const result = checkStep("a = 1 + 2", "3 = a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "evaluation of addition",
                 "symmetric property",
             ]);
@@ -62,16 +61,14 @@ describe("Axiom checks", () => {
             const result = checkStep("x = x + 0", "x + 0 = x");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "symmetric property",
-            ]);
+            expect(result).toHaveMessages(["symmetric property"]);
         });
 
         it("x = y + 0 -> y = x * 1", () => {
             const result = checkStep("x = y + 0", "y = x * 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "addition with identity",
                 "multiplication with identity",
                 "symmetric property",
@@ -84,30 +81,25 @@ describe("Axiom checks", () => {
             const result = checkStep("1 + 2", "2 + 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("(2 - 1) + (1 + 1) -> 2 + 1", () => {
             const result = checkStep("(2 - 1) + (1 + 1)", "2 + 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 // TODO: change the message to "evaluation of subtraction"
                 "evaluation of addition",
                 "evaluation of addition",
                 "commutative property",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("2 - 1");
-            expect(result.steps[0].nodes[1]).toParseLike("1");
-
-            expect(result.steps[1].nodes[0]).toParseLike("1 + 1");
-            expect(result.steps[1].nodes[1]).toParseLike("2");
-
-            expect(result.steps[2].nodes[0]).toParseLike("1 + 2");
-            expect(result.steps[2].nodes[1]).toParseLike("2 + 1");
+            expect(result).toHaveStepsLike([
+                ["2 - 1", "1"],
+                ["1 + 1", "2"],
+                ["1 + 2", "2 + 1"],
+            ]);
         });
 
         // nested commutative property
@@ -115,7 +107,7 @@ describe("Axiom checks", () => {
             const result = checkStep("(1 + 2) + (a + b)", "(b + a) + (2 + 1)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "commutative property",
                 "commutative property",
                 "commutative property",
@@ -131,39 +123,28 @@ describe("Axiom checks", () => {
             const result = checkStep("2 + 0", "0 + 2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("x + (a + 2) -> x + (2 + a)", () => {
-            const before = "x + (a + 2)";
-            const after = "x + (2 + a)";
-
-            const result = checkStep(before, after);
+            const result = checkStep("x + (a + 2)", "x + (2 + a)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("x + a + 2 -> x + 2 + a", () => {
             const result = checkStep("x + a + 2", "x + 2 + a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("x + a + 2 -> a + x + 2", () => {
             const result = checkStep("x + a + 2", "a + x + 2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("x + a + 2 -> x + 2 + b [incorrect step]", () => {
@@ -177,58 +158,48 @@ describe("Axiom checks", () => {
             const result = checkStep("1 * 2", "2 * 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("2 * 3 -> 3 * 2", () => {
             const result = checkStep("2 * 3", "3 * 2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "commutative property",
-            ]);
+            expect(result).toHaveMessages(["commutative property"]);
         });
 
         it("(1 + 1) * (1 + 2) -> 3 * 2", () => {
             const result = checkStep("(1 + 1) * (1 + 2)", "3 * 2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "evaluation of addition",
                 "evaluation of addition",
                 "commutative property",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("1 + 1");
-            expect(result.steps[0].nodes[1]).toParseLike("2");
-
-            expect(result.steps[1].nodes[0]).toParseLike("1 + 2");
-            expect(result.steps[1].nodes[1]).toParseLike("3");
-
-            expect(result.steps[2].nodes[0]).toParseLike("2 * 3");
-            expect(result.steps[2].nodes[1]).toParseLike("3 * 2");
+            expect(result).toHaveStepsLike([
+                ["1 + 1", "2"],
+                ["1 + 2", "3"],
+                ["2 * 3", "3 * 2"],
+            ]);
         });
 
         it("3 * 2 -> (1 + 1) * (1 + 2)", () => {
             const result = checkStep("3 * 2", "(1 + 1) * (1 + 2)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "decompose sum",
                 "decompose sum",
                 "commutative property",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("3");
-            expect(result.steps[0].nodes[1]).toParseLike("1 + 2");
-
-            expect(result.steps[1].nodes[0]).toParseLike("2");
-            expect(result.steps[1].nodes[1]).toParseLike("1 + 1");
-
-            expect(result.steps[2].nodes[0]).toParseLike("(1 + 2) * (1 + 1)");
-            expect(result.steps[2].nodes[1]).toParseLike("(1 + 1) * (1 + 2)");
+            expect(result).toHaveStepsLike([
+                ["3", "1 + 2"],
+                ["2", "1 + 1"],
+                ["(1 + 2) * (1 + 1)", "(1 + 1) * (1 + 2)"],
+            ]);
         });
     });
 
@@ -237,27 +208,21 @@ describe("Axiom checks", () => {
             const result = checkStep("a + 0", "a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         it("2(a + 0) -> 2a", () => {
             const result = checkStep("2(a + 0)", "2a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         it("a -> a + 0", () => {
             const result = checkStep("a", "a + 0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         // nesting
@@ -265,7 +230,7 @@ describe("Axiom checks", () => {
             const result = checkStep("(a + b + 0) + c + 0", "(a + b) + c");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "addition with identity",
                 "addition with identity",
             ]);
@@ -276,7 +241,7 @@ describe("Axiom checks", () => {
             const result = checkStep("(a + b) + c", "(a + b + 0) + c + 0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "addition with identity",
                 "addition with identity",
             ]);
@@ -286,9 +251,7 @@ describe("Axiom checks", () => {
             const result = checkStep("2a", "2(a + 0)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         it("2a -> 2(a + 7)", () => {
@@ -331,44 +294,37 @@ describe("Axiom checks", () => {
             const result = checkStep("a + b", "a + b + 0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         it("a + b -> a + 0 + b", () => {
             const result = checkStep("a + b", "a + 0 + b");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         it("a + b -> b + a + 0 -> b + 0 + a", () => {
             const result = checkStep("a + b", "b + 0 + a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "commutative property",
                 "addition with identity",
                 // TODO: we're missing another "commutative property" step here
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a + b");
-            expect(result.steps[0].nodes[1]).toParseLike("b + a");
-
-            expect(result.steps[1].nodes[0]).toParseLike("b + a");
-            expect(result.steps[1].nodes[1]).toParseLike("b + 0 + a");
+            expect(result).toHaveStepsLike([
+                ["a + b", "b + a"],
+                ["b + a", "b + 0 + a"],
+            ]);
         });
 
         it("a + b -> a + 0 + b + 0", () => {
             const result = checkStep("a + b", "a + 0 + b + 0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
 
         // TODO: re-enable this once we're accumulating mistakes in the context
@@ -376,7 +332,7 @@ describe("Axiom checks", () => {
             const result = checkStep("a + b", "a + b + 7");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "adding a non-zero valid is not allowed",
             ]);
         });
@@ -387,9 +343,7 @@ describe("Axiom checks", () => {
             const result = checkStep("0 + (a + b)", "a + b");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "addition with identity",
-            ]);
+            expect(result).toHaveMessages(["addition with identity"]);
         });
     });
 
@@ -398,52 +352,43 @@ describe("Axiom checks", () => {
             const result = checkStep("1 * a", "a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplication with identity",
-            ]);
+            expect(result).toHaveMessages(["multiplication with identity"]);
         });
 
         it("a -> a * 1", () => {
             const result = checkStep("a", "a * 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplication with identity",
-            ]);
+            expect(result).toHaveMessages(["multiplication with identity"]);
         });
 
         it("1 * (a * b) -> a * b", () => {
             const result = checkStep("1 * (a * b)", "a * b");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplication with identity",
-            ]);
+            expect(result).toHaveMessages(["multiplication with identity"]);
         });
 
         it("a * b -> b * a * 1 -> b * 1 * a", () => {
             const result = checkStep("a * b", "b * 1 * a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "commutative property",
                 "multiplication with identity",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a * b");
-            expect(result.steps[0].nodes[1]).toParseLike("b * a");
-
-            expect(result.steps[1].nodes[0]).toParseLike("b * a");
-            expect(result.steps[1].nodes[1]).toParseLike("b * 1 * a");
+            expect(result).toHaveStepsLike([
+                ["a * b", "b * a"],
+                ["b * a", "b * 1 * a"],
+            ]);
         });
 
         it("a * b -> a * 1 * b * 1", () => {
             const result = checkStep("a * b", "a * 1 * b * 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplication with identity",
-            ]);
+            expect(result).toHaveMessages(["multiplication with identity"]);
         });
 
         it("ab -> 2ab", () => {
@@ -485,18 +430,14 @@ describe("Axiom checks", () => {
             const result = checkStep("a * (b + c)", "a * b + a * c");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("(b + c) * a -> b * a + c * a", () => {
             const result = checkStep("(b + c) * a", "b * a + c * a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("a * (b + c) -> a * b + c [incorrect]", () => {
@@ -507,38 +448,31 @@ describe("Axiom checks", () => {
             const result = checkStep("2(x + y)", "2x + 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("-2(x + y) -> -2x - 2y", () => {
             const result = checkStep("-2(x + y)", "-2x - 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "distribution",
                 "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("-2(x + y)");
-            expect(result.steps[0].nodes[1]).toParseLike("-2x + -2y");
-
-            expect(result.steps[1].nodes[0]).toParseLike("-2x + -2y");
-            expect(result.steps[1].nodes[1]).toParseLike("-2x + -(2y)");
-
-            expect(result.steps[2].nodes[0]).toParseLike("-2x + -(2y)");
-            expect(result.steps[2].nodes[1]).toParseLike("-2x - 2y");
+            expect(result).toHaveStepsLike([
+                ["-2(x + y)", "-2x + -2y"],
+                ["-2x + -2y", "-2x + -(2y)"],
+                ["-2x + -(2y)", "-2x - 2y"],
+            ]);
         });
 
         it("1 + 2(x + y) -> 1 + 2x + 2y", () => {
             const result = checkStep("1 + 2(x + y)", "1 + 2x + 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("2(x + y) + 3(a + b) -> 2x + 2y + 3a + 3b", () => {
@@ -548,17 +482,14 @@ describe("Axiom checks", () => {
             );
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution", "distribution"]);
         });
 
         it("1 - 2(x + y) -> 1 - 2x - 2y", () => {
             const result = checkStep("1 - 2(x + y)", "1 - 2x - 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "move negation inside multiplication",
                 "distribution",
@@ -572,28 +503,26 @@ describe("Axiom checks", () => {
             const result = checkStep("1 - 2(x + y)", "1 + -2(x + y)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "move negation inside multiplication",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("1 - 2(x + y)");
-            expect(result.steps[0].nodes[1]).toParseLike("1 + -(2(x + y))");
-
-            expect(result.steps[1].nodes[0]).toParseLike("-(2(x + y))");
-            expect(result.steps[1].nodes[1]).toParseLike("-2(x + y)");
+            expect(result).toHaveStepsLike([
+                ["1 - 2(x + y)", "1 + -(2(x + y))"],
+                ["-(2(x + y))", "-2(x +y)"],
+            ]);
         });
 
         it("1 + (-2)(x + y) -> 1 + -2x + -2y", () => {
             const result = checkStep("1 + -2(x + y)", "1 + -2x + -2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("1 + -2(x + y)");
-            expect(result.steps[0].nodes[1]).toParseLike("1 + -2x + -2y");
+            expect(result).toHaveStepsLike([
+                ["1 + -2(x + y)", "1 + -2x + -2y"],
+            ]);
         });
 
         it("1 + -2(x + y) -> 1 + -2x + -2y", () => {
@@ -601,16 +530,14 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
 
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("1 - (x + y) -> 1 - x - y", () => {
             const result = checkStep("1 - (x + y)", "1 - x - y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "negation is the same as multipling by negative one",
                 "distribution",
@@ -624,7 +551,7 @@ describe("Axiom checks", () => {
             const result = checkStep("2(x - y)", "2(x + -y)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
             ]);
         });
@@ -633,7 +560,7 @@ describe("Axiom checks", () => {
             const result = checkStep("2(x - y)", "2x - 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "distribution",
                 "move negative to first factor",
                 "move negation out of multiplication",
@@ -645,7 +572,7 @@ describe("Axiom checks", () => {
             const result = checkStep("2x + 2(-y)", "2x - 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "move negative to first factor",
                 "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
@@ -656,7 +583,7 @@ describe("Axiom checks", () => {
             const result = checkStep("-2(x - y)", "-2x + 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "distribution",
                 "multiplying two negatives is a positive",
             ]);
@@ -666,7 +593,7 @@ describe("Axiom checks", () => {
             const result = checkStep("1 - 2(x - y)", "1 - 2x + 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "move negation inside multiplication",
                 "distribution",
@@ -680,7 +607,7 @@ describe("Axiom checks", () => {
             const result = checkStep("1 - 2(x - y)", "1 - 2x + 2y");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "move negation inside multiplication",
                 "distribution",
@@ -698,7 +625,7 @@ describe("Axiom checks", () => {
             );
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "subtracting is the same as adding the inverse",
                 "negation is the same as multipling by negative one",
@@ -758,9 +685,7 @@ describe("Axiom checks", () => {
             );
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("(a + b) * (x + y) -> (a + b) * x + (a + b) * y", () => {
@@ -770,9 +695,7 @@ describe("Axiom checks", () => {
             );
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("(a + b) * (x + y) -> a * (x + y) + b * (x + y)", () => {
@@ -782,9 +705,7 @@ describe("Axiom checks", () => {
             );
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("a * (x + y) + b * (x + y) -> ax + ay + b * (x + y)", () => {
@@ -795,9 +716,7 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
             // TODO: make distribution parallel and pick the shortest path
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "distribution",
-            ]);
+            expect(result).toHaveMessages(["distribution"]);
         });
 
         it("(a + b) * (x + y) -> ax + ay + bx + by", () => {
@@ -856,7 +775,7 @@ describe("Axiom checks", () => {
             `);
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "distribution",
                 "distribution",
                 "distribution",
@@ -869,16 +788,14 @@ describe("Axiom checks", () => {
             const result = checkStep("a * b + a * c", "a * (b + c)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "factoring",
-            ]);
+            expect(result).toHaveMessages(["factoring"]);
         });
 
         it("ab + a -> a(b + 1)", () => {
             const result = checkStep("ab + a", "a(b + 1)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplication with identity", // a -> (a)(1)
                 "factoring",
             ]);
@@ -888,7 +805,7 @@ describe("Axiom checks", () => {
             const result = checkStep("a - ab", "(a)(1) + (-a)(b)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "multiplication with identity",
                 "move negation inside multiplication",
@@ -899,7 +816,7 @@ describe("Axiom checks", () => {
             const result = checkStep("a - ab", "a(1 - b)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "move negation inside multiplication",
                 "multiplication with identity",
@@ -912,66 +829,52 @@ describe("Axiom checks", () => {
             const result = checkStep("-a - ab", "-a(1 + b)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "move negation inside multiplication",
                 "multiplication with identity",
                 "factoring",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("-a - ab");
-            expect(result.steps[0].nodes[1]).toParseLike("-a + -(ab)");
-
-            expect(result.steps[1].nodes[0]).toParseLike("-a + -(ab)");
-            expect(result.steps[1].nodes[1]).toParseLike("-a + (-a)(b)");
-
-            expect(result.steps[2].nodes[0]).toParseLike("-a");
-            expect(result.steps[2].nodes[1]).toParseLike("(-a)(1)");
-
-            expect(result.steps[3].nodes[0]).toParseLike("(-a)(1) + (-a)(b)");
-            expect(result.steps[3].nodes[1]).toParseLike("-a(1 + b)");
+            expect(result).toHaveStepsLike([
+                ["-a - ab", "-a + -(ab)"],
+                ["-a + -(ab)", "-a + (-a)(b)"],
+                ["-a", "(-a)(1)"],
+                ["(-a)(1) + (-a)(b)", "-a(1 + b)"],
+            ]);
         });
 
         it("-a(1 + b) -> -a - ab", () => {
             const result = checkStep("-a(1 + b)", "-a - ab");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "distribution",
                 "multiplication with identity",
                 "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("-a(1 + b)");
-            expect(result.steps[0].nodes[1]).toParseLike("(-a)(1) + (-a)(b)");
-
-            expect(result.steps[1].nodes[0]).toParseLike("(-a)(1)");
-            expect(result.steps[1].nodes[1]).toParseLike("-a");
-
-            expect(result.steps[2].nodes[0]).toParseLike("-a + (-a)(b)");
-            expect(result.steps[2].nodes[1]).toParseLike("-a + -(ab)");
-
-            expect(result.steps[3].nodes[0]).toParseLike("-a + -(ab)");
-            expect(result.steps[3].nodes[1]).toParseLike("-a - ab");
+            expect(result).toHaveStepsLike([
+                ["-a(1 + b)", "(-a)(1) + (-a)(b)"],
+                ["(-a)(1)", "-a"],
+                ["-a + (-a)(b)", "-a + -(ab)"],
+                ["-a + -(ab)", "-a - ab"],
+            ]);
         });
 
         it("2x + 3x -> (2 + 3)x", () => {
             const result = checkStep("2x + 3x", "(2 + 3)x");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "factoring",
-            ]);
+            expect(result).toHaveMessages(["factoring"]);
         });
 
         it("(2 + 3)x -> 5x", () => {
             const result = checkStep("(2 + 3)x", "5x");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
     });
 
@@ -980,25 +883,21 @@ describe("Axiom checks", () => {
             const result = checkStep("0", "0 * a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplication by zero",
-            ]);
+            expect(result).toHaveMessages(["multiplication by zero"]);
         });
 
         it("a * 0 * b -> 0", () => {
             const result = checkStep("a * 0 * b", "0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplication by zero",
-            ]);
+            expect(result).toHaveMessages(["multiplication by zero"]);
         });
 
         it("1 + 0a + 0b -> 1", () => {
             const result = checkStep("1 + 0a + 0b", "1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplication by zero",
                 "multiplication by zero",
                 "addition with identity",
@@ -1009,7 +908,7 @@ describe("Axiom checks", () => {
             const result = checkStep("1 + (a - a)b", "1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
                 "adding inverse",
                 "multiplication by zero",

--- a/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
@@ -3,9 +3,14 @@ import {parse} from "@math-blocks/text-parser";
 import StepChecker from "../../step-checker";
 import {MistakeId} from "../../enums";
 
-import {checkStep, checkMistake, toParseLike} from "../test-util";
+import {
+    checkStep,
+    checkMistake,
+    toParseLike,
+    toHaveMessages,
+} from "../test-util";
 
-expect.extend({toParseLike});
+expect.extend({toParseLike, toHaveMessages});
 
 describe("Eval (decomposition) checks", () => {
     describe("evalAdd", () => {
@@ -13,16 +18,14 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("2 + 3", "5");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         it("5 - 2 -> 3", () => {
             const result = checkStep("5 - 2", "3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 // TODO: have an interim step showing 5 - 2 -> 5 + -2
                 "evaluation of addition",
             ]);
@@ -32,7 +35,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("2 + 3", "5 + 0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "evaluation of addition",
                 "addition with identity",
             ]);
@@ -42,16 +45,14 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("a + 2 + 3", "a + 5");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         it("a + 2 + 3 -> 5 + a", () => {
             const result = checkStep("a + 2 + 3", "5 + a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "evaluation of addition",
                 "commutative property",
             ]);
@@ -61,9 +62,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("1 + 2 + 3", "1 + 5");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         // Currently we're thinking about this in the following way:
@@ -74,9 +73,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("1 + 2 + 3 + 4", "3 + 7");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         // TODO: make this pass
@@ -84,9 +81,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("1 + 2 + 3 + 4", "1 + 6 + 3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         // TODO: the reason should be "evaluation of subtraction"
@@ -97,9 +92,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep(before, after);
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         // TODO: the reason should be "evaluation of subtraction"
@@ -110,9 +103,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep(before, after);
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         it("5 - 5/2 -> 5/2", () => {
@@ -122,43 +113,35 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep(before, after);
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         it("10 - 5 + 2 -> 7", () => {
             const result = checkStep("10 - 5 + 2", "7");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         it("10 - 5 + 2 -> 5 + 2", () => {
             const result = checkStep("10 - 5 + 2", "5 + 2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of addition",
-            ]);
+            expect(result).toHaveMessages(["evaluation of addition"]);
         });
 
         it("5 + -5 -> 0", () => {
             const result = checkStep("5 + -5", "0");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "adding inverse",
-            ]);
+            expect(result).toHaveMessages(["adding inverse"]);
         });
 
         it("1 + 5 + -5 -> 1", () => {
             const result = checkStep("1 + 5 + -5", "1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "adding inverse",
                 "addition with identity",
             ]);
@@ -168,7 +151,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("1 + a + -a", "1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "adding inverse",
                 "addition with identity",
             ]);
@@ -180,16 +163,14 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("2 * 3", "6");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of multiplication",
-            ]);
+            expect(result).toHaveMessages(["evaluation of multiplication"]);
         });
 
         it("2 * 3 -> 6 * 1", () => {
             const result = checkStep("2 * 3", "6 * 1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "evaluation of multiplication",
                 "multiplication with identity",
             ]);
@@ -199,7 +180,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("a * 2 * 3", "a * 6");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "evaluation of multiplication",
                 // TODO: remove unnecessary "commutative property" steps
                 "commutative property",
@@ -210,36 +191,28 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("2 * 3 * 4", "6 * 4");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of multiplication",
-            ]);
+            expect(result).toHaveMessages(["evaluation of multiplication"]);
         });
 
         it("1/2 * 1/3 -> 1/6", () => {
             const result = checkStep("1/2 * 1/3", "1/6");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of multiplication",
-            ]);
+            expect(result).toHaveMessages(["evaluation of multiplication"]);
         });
 
         it("2 * 1/3 -> 2/3", () => {
             const result = checkStep("2 * 1/3", "2/3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of multiplication",
-            ]);
+            expect(result).toHaveMessages(["evaluation of multiplication"]);
         });
 
         it("2/3 * 3/4 -> 6/12", () => {
             const result = checkStep("2/3 * 3/4", "6/12");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of multiplication",
-            ]);
+            expect(result).toHaveMessages(["evaluation of multiplication"]);
         });
 
         // TODO: provide a separate step simplifying the fraction
@@ -247,25 +220,21 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("2/3 * 3/4", "1/2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "evaluation of multiplication",
-            ]);
+            expect(result).toHaveMessages(["evaluation of multiplication"]);
         });
 
         it("5 * 1/5 -> 1", () => {
             const result = checkStep("5 * 1/5", "1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "multiplying the inverse",
-            ]);
+            expect(result).toHaveMessages(["multiplying the inverse"]);
         });
 
         it("2 * 5 * 1/5 -> 2", () => {
             const result = checkStep("2 * 5 * 1/5", "2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying fractions",
                 "fraction is the same as multiplying by one over",
                 "evaluation of multiplication",
@@ -286,7 +255,7 @@ describe("Eval (decomposition) checks", () => {
             if (!result) {
                 throw new Error("result is undefind");
             }
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying the inverse",
                 "multiplication with identity",
             ]);
@@ -296,7 +265,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("2 * a * 1/a", "2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying the inverse",
                 "multiplication with identity",
             ]);
@@ -308,16 +277,14 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("6", "2 * 3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "decompose product",
-            ]);
+            expect(result).toHaveMessages(["decompose product"]);
         });
 
         it("6 * 1 -> 2 * 3", () => {
             const result = checkStep("6 * 1", "2 * 3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplication with identity",
                 "decompose product",
             ]);
@@ -327,18 +294,14 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("6a", "2 * 3 * a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "decompose product",
-            ]);
+            expect(result).toHaveMessages(["decompose product"]);
         });
 
         it("4 * 6 -> 2 * 2 * 2 * 3", () => {
             const result = checkStep("4 * 6", "2 * 2 * 2 * 3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "decompose product",
-            ]);
+            expect(result).toHaveMessages(["decompose product"]);
         });
     });
 
@@ -347,16 +310,14 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("5", "2 + 3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "decompose sum",
-            ]);
+            expect(result).toHaveMessages(["decompose sum"]);
         });
 
         it("0 + 5 -> 2 + 3", () => {
             const result = checkStep("0 + 5", "2 + 3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "addition with identity",
                 "decompose sum",
             ]);
@@ -366,7 +327,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("5 + a", "2 + 3 + a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 // TODO: avoid unnecessary commutative property
                 "commutative property",
                 "decompose sum",
@@ -377,9 +338,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("5 + 10", "2 + 3 + 4 + 6");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "decompose sum",
-            ]);
+            expect(result).toHaveMessages(["decompose sum"]);
         });
 
         // This test checks that numbers can be ordered in any fashion
@@ -387,9 +346,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("10 + 5", "2 + 3 + 4 + 6");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
-                "decompose sum",
-            ]);
+            expect(result).toHaveMessages(["decompose sum"]);
         });
     });
 

--- a/packages/step-checker/src/checks/__tests__/fraction-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/fraction-checks.test.ts
@@ -4,7 +4,7 @@ import {parse} from "@math-blocks/text-parser";
 import StepChecker from "../../step-checker";
 import {Context} from "../../types";
 
-import {checkStep, toParseLike} from "../test-util";
+import {checkStep, toHaveMessages, toHaveStepsLike} from "../test-util";
 import {mulOne} from "../axiom-checks";
 import {divIsMulByOneOver, mulInverse, divBySame} from "../fraction-checks";
 import {
@@ -15,14 +15,14 @@ import {
 } from "../basic-checks";
 
 expect.addSnapshotSerializer(serializer);
-expect.extend({toParseLike});
+expect.extend({toHaveMessages, toHaveStepsLike});
 
 describe("Fraction checks", () => {
     it("a * 1/b -> a / b", () => {
         const result = checkStep("a * 1/b", "a / b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying by one over something results in a fraction",
         ]);
     });
@@ -31,7 +31,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a * 1/b * c", "a/b * c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying by one over something results in a fraction",
         ]);
     });
@@ -40,7 +40,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a * b * 1/c", "a * b/c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying by one over something results in a fraction",
         ]);
     });
@@ -49,7 +49,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a * b * 1/c", "a/c * b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "commutative property",
             "multiplying by one over something results in a fraction",
         ]);
@@ -59,7 +59,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a * b * 1/c", "ab / c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying fractions",
             "multiplication with identity",
         ]);
@@ -67,39 +67,32 @@ describe("Fraction checks", () => {
         // TODO: handle this differently depending on whether the multiplication
         // is explicit or implicit, e.g.
         // a * b * 1/c -> a * b/c vs. (a)(b)(1/c) -> ab / c
-        expect(result.steps[0].nodes[0]).toParseLike("a * b * 1/c");
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (div
-              (mul.imp a b 1)
-              c)
-        `);
-
-        expect(result.steps[1].nodes[0]).toParseLike("(a)(b)(1)");
-        expect(result.steps[1].nodes[1]).toParseLike("ab");
+        expect(result).toHaveStepsLike([
+            ["a * b * 1/c", "(a)(b)(1) / c"],
+            ["(a)(b)(1)", "ab"],
+        ]);
     });
 
     it("1/b * a -> a / b", () => {
         const result = checkStep("1/b * a", "a / b");
 
         expect(result).toBeTruthy();
-        expect(result.steps).toHaveLength(2);
-
-        expect(result.steps[0].message).toEqual("commutative property");
-        expect(result.steps[0].nodes[0]).toParseLike("1/b * a");
-        expect(result.steps[0].nodes[1]).toParseLike("a * 1/b");
-
-        expect(result.steps[1].message).toEqual(
+        expect(result).toHaveMessages([
+            "commutative property",
             "multiplying by one over something results in a fraction",
-        );
-        expect(result.steps[1].nodes[0]).toParseLike("a * 1/b");
-        expect(result.steps[1].nodes[1]).toParseLike("a / b");
+        ]);
+
+        expect(result).toHaveStepsLike([
+            ["1/b * a", "a * 1/b"],
+            ["a * 1/b", "a / b"],
+        ]);
     });
 
     it("a / b -> a * 1/b", () => {
         const result = checkStep("a / b", "a * 1/b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
         ]);
     });
@@ -109,7 +102,7 @@ describe("Fraction checks", () => {
         const result = checkStep("1/a * 1/b", "1 / ab");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying fractions",
             "multiplication with identity",
         ]);
@@ -119,18 +112,14 @@ describe("Fraction checks", () => {
         const result = checkStep("1", "a/a");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "division by the same value",
-        ]);
+        expect(result).toHaveMessages(["division by the same value"]);
     });
 
     it("a/a -> 1", () => {
         const result = checkStep("a/a", "1");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "division by the same value",
-        ]);
+        expect(result).toHaveMessages(["division by the same value"]);
     });
 
     describe("divBySame is equivalent to [divIsMulByOneOver, mulInverse]", () => {
@@ -165,7 +154,7 @@ describe("Fraction checks", () => {
             if (!result) {
                 throw new Error("result is undefind");
             }
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying the inverse",
                 "multiplying by one over something results in a fraction",
             ]);
@@ -178,7 +167,7 @@ describe("Fraction checks", () => {
             if (!result) {
                 throw new Error("result is undefind");
             }
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "fraction is the same as multiplying by one over",
                 "multiplying the inverse",
             ]);
@@ -191,7 +180,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a/a", "b/b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "division by the same value",
             "division by the same value",
         ]);
@@ -203,7 +192,7 @@ describe("Fraction checks", () => {
         const result = checkStep("b(a/b)", "a");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
             "multiplying the inverse",
             "multiplication with identity",
@@ -214,107 +203,90 @@ describe("Fraction checks", () => {
         const result = checkStep("a * b * 1/b", "a");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying the inverse",
             "multiplication with identity",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("a * b * 1/b");
-        expect(result.steps[0].nodes[1]).toParseLike("a * 1");
-
-        expect(result.steps[1].nodes[0]).toParseLike("a * 1");
-        expect(result.steps[1].nodes[1]).toParseLike("a");
+        expect(result).toHaveStepsLike([
+            ["a * b * 1/b", "a * 1"],
+            ["a * 1", "a"],
+        ]);
     });
 
     it("a * b * 1/a -> b", () => {
         const result = checkStep("a * b * 1/a", "b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying the inverse",
             "multiplication with identity",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("a * b * 1/a");
-        expect(result.steps[0].nodes[1]).toParseLike("1 * b");
-
-        expect(result.steps[1].nodes[0]).toParseLike("1 * b");
-        expect(result.steps[1].nodes[1]).toParseLike("b");
+        expect(result).toHaveStepsLike([
+            ["a * b * 1/a", "1 * b"],
+            ["1 * b", "b"],
+        ]);
     });
 
     it("a * b * c * 1/a * 1/c -> b", () => {
         const result = checkStep("a * b * c * 1/a * 1/c", "b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplying the inverse",
             "multiplication with identity",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("a * b * c * 1/a * 1/c");
-        expect(result.steps[0].nodes[1]).toParseLike("1 * b * 1");
-
-        expect(result.steps[1].nodes[0]).toParseLike("1 * b * 1");
-        expect(result.steps[1].nodes[1]).toParseLike("b");
+        expect(result).toHaveStepsLike([
+            ["a * b * c * 1/a * 1/c", "1 * b * 1"],
+            ["1 * b * 1", "b"],
+        ]);
     });
 
     it("a * b/c -> ab / b", () => {
         const result = checkStep("a * b/c", "ab / c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "multiplying fractions",
-        ]);
+        expect(result).toHaveMessages(["multiplying fractions"]);
     });
 
     it("a/b * c/d -> ac / bd", () => {
         const result = checkStep("a/b * c/d", "ac / bd");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "multiplying fractions",
-        ]);
+        expect(result).toHaveMessages(["multiplying fractions"]);
     });
 
     it("ac / bd -> a/b * c/d", () => {
         const result = checkStep("ac / bd", "a/b * c/d");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "multiplying fractions",
-        ]);
+        expect(result).toHaveMessages(["multiplying fractions"]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("ac / bd");
-        expect(result.steps[0].nodes[1]).toParseLike("a/b * c/d");
+        expect(result).toHaveStepsLike([["ac / bd", "a/b * c/d"]]);
     });
 
     it("ab/cd * e/f -> abe / cdf", () => {
         const result = checkStep("ab/cd * e/f", "abe / cdf");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "multiplying fractions",
-        ]);
+        expect(result).toHaveMessages(["multiplying fractions"]);
     });
 
     it("a/b * 1/d -> a*1 / bd -> a / bd", () => {
         const result = checkStep("a/b * 1/d", "a / bd");
 
         expect(result).toBeTruthy();
-        // expect(result.steps).toHaveLength(2);
+        expect(result).toHaveMessages([
+            "multiplying fractions",
+            "multiplication with identity",
+        ]);
 
-        expect(result.steps[0].message).toEqual("multiplying fractions");
-        expect(result.steps[0].nodes[0]).toParseLike("a/b * 1/d");
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (div
-              (mul.imp a 1)
-              (mul.imp b d))
-        `);
-        expect(result.steps[0].nodes[1]).toParseLike("(a)(1) / bd");
-
-        expect(result.steps[1].message).toEqual("multiplication with identity");
-        expect(result.steps[1].nodes[0]).toParseLike("(a)(1)");
-        expect(result.steps[1].nodes[1]).toParseLike("a");
+        expect(result).toHaveStepsLike([
+            ["a/b * 1/d", "(a)(1) / bd"],
+            ["(a)(1)", "a"],
+        ]);
     });
 
     it("30 / 6 -> 2*3*5 / 2*3 -> 2*3/2*3 * 5/1 -> 1 * 5/1 -> 5/1 -> 5", () => {
@@ -332,7 +304,7 @@ describe("Fraction checks", () => {
         }
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "prime factorization",
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -356,7 +328,7 @@ describe("Fraction checks", () => {
         }
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "prime factorization",
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -365,32 +337,14 @@ describe("Fraction checks", () => {
             "evaluation of multiplication",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("24 / 6");
-        expect(result.steps[0].nodes[1]).toParseLike("(2*2*2*3) / (2*3)");
-
-        expect(result.steps[1].nodes[0]).toParseLike("(2*2*2*3) / (2*3)");
-        expect(result.steps[1].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
-              (div
-                (mul.imp 2 3)
-                (mul.imp 2 3))
-              (div
-                (mul.imp 2 2)
-                1))
-        `);
-
-        expect(result.steps[2].nodes[0]).toParseLike("(2)(3) / (2)(3)");
-        expect(result.steps[2].nodes[1]).toParseLike("1");
-
-        expect(result.steps[3].nodes[0]).toParseLike("1 * (2)(2) / 1");
-        expect(result.steps[3].nodes[1]).toParseLike("(2 * 2) / 1");
-
-        expect(result.steps[4].nodes[0]).toParseLike("(2*2) / 1");
-        expect(result.steps[4].nodes[1]).toParseLike("(2*2)");
-
-        expect(result.steps[5].message).toEqual("evaluation of multiplication");
-        expect(result.steps[5].nodes[0]).toMatchInlineSnapshot(`(mul.exp 2 2)`);
-        expect(result.steps[5].nodes[1]).toParseLike("4");
+        expect(result).toHaveStepsLike([
+            ["24 / 6", "(2*2*2*3) / (2*3)"],
+            ["(2*2*2*3) / (2*3)", "(2)(3)/(2)(3) * (2)(2)/1"],
+            ["(2)(3) / (2)(3)", "1"],
+            ["1 * (2)(2) / 1", "(2 * 2) / 1"],
+            ["(2 * 2) / 1", "2 * 2"],
+            ["2 * 2", "4"],
+        ]);
     });
 
     it("(2)(2)(2)(3) / (2)(3) -> (2)(2)(2) / (2)", () => {
@@ -412,7 +366,7 @@ describe("Fraction checks", () => {
         }
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "extract common factors from numerator and denominator",
             "division by the same value",
             "multiplication with identity",
@@ -424,7 +378,7 @@ describe("Fraction checks", () => {
             const result = checkStep("a / (b/c)", "a * c/b");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing by a fraction is the same as multiplying by the reciprocal",
             ]);
         });
@@ -433,85 +387,75 @@ describe("Fraction checks", () => {
             const result = checkStep("a * c/b", "a / (b/c)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing by a fraction is the same as multiplying by the reciprocal",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a * c/b");
+            expect(result).toHaveStepsLike([["a * c/b", "a / (b/c)"]]);
         });
 
         it("1 / (a/b) -> b / a", () => {
             const result = checkStep("1 / (a/b)", "b / a");
 
             expect(result).toBeTruthy();
-            expect(result.steps).toHaveLength(2);
-
-            expect(result.steps[0].message).toEqual(
+            expect(result).toHaveMessages([
                 "dividing by a fraction is the same as multiplying by the reciprocal",
-            );
-            expect(result.steps[0].nodes[0]).toParseLike("1 / (a/b)");
-            expect(result.steps[0].nodes[1]).toParseLike("1 * b/a");
-
-            expect(result.steps[1].message).toEqual(
                 "multiplication with identity",
-            );
-            expect(result.steps[1].nodes[0]).toParseLike("1 * b/a");
-            expect(result.steps[1].nodes[1]).toParseLike("b / a");
+            ]);
+
+            expect(result).toHaveStepsLike([
+                ["1 / (a/b)", "1 * b/a"],
+                ["1 * b/a", "b / a"],
+            ]);
         });
 
         it("1 / (1/a) -> a", () => {
             const result = checkStep("1 / (1/a)", "a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing by a fraction is the same as multiplying by the reciprocal",
                 "multiplication with identity",
                 "division by one",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("1 / (1/a)");
-            expect(result.steps[0].nodes[1]).toParseLike("1 * a/1");
-
-            // TODO: fix these nodes
-            expect(result.steps[1].nodes[0]).toParseLike("1 * a/1");
-            expect(result.steps[1].nodes[1]).toParseLike("a/1");
-
-            expect(result.steps[2].nodes[0]).toParseLike("a/1");
-            expect(result.steps[2].nodes[1]).toParseLike("a");
+            expect(result).toHaveStepsLike([
+                ["1 / (1/a)", "1 * a/1"],
+                ["1 * a/1", "a/1"], // TODO: fix these nodes?
+                ["a/1", "a"],
+            ]);
         });
 
         it("a / (1/b) -> a * b/1 -> ab", () => {
             const result = checkStep("a / (1/b)", "ab");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing by a fraction is the same as multiplying by the reciprocal",
                 "division by one",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a / (1/b)");
-            expect(result.steps[0].nodes[1]).toParseLike("a * b/1");
-
-            expect(result.steps[1].nodes[0]).toParseLike("b/1");
-            expect(result.steps[1].nodes[1]).toParseLike("b");
+            expect(result).toHaveStepsLike([
+                ["a / (1/b)", "a * b/1"],
+                ["b/1", "b"],
+            ]);
         });
 
         it("a/b * b/a -> ab/ba -> ab/ab -> 1", () => {
             const result = checkStep("a/b * b/a", "1");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying fractions",
                 "commutative property",
                 "division by the same value",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a/b * b/a");
-            expect(result.steps[0].nodes[1]).toParseLike("ab/ba");
-            expect(result.steps[1].nodes[0]).toParseLike("ab");
-            expect(result.steps[1].nodes[1]).toParseLike("ba");
-            expect(result.steps[2].nodes[0]).toParseLike("ba/ba");
-            expect(result.steps[2].nodes[1]).toParseLike("1");
+            expect(result).toHaveStepsLike([
+                ["a/b * b/a", "ab/ba"],
+                ["ab", "ba"],
+                ["ba/ba", "1"],
+            ]);
         });
     });
 
@@ -519,7 +463,7 @@ describe("Fraction checks", () => {
         const result = checkStep("24ab / 6a", "4b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "prime factorization",
             "extract common factors from numerator and denominator",
             "division by the same value",
@@ -534,7 +478,7 @@ describe("Fraction checks", () => {
         const result = checkStep("2a/a", "2");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "extract common factors from numerator and denominator",
             "division by the same value",
             "multiplication with identity",
@@ -550,7 +494,7 @@ describe("Fraction checks", () => {
         const result = checkStep("2abc/ab", "2c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "extract common factors from numerator and denominator",
             "division by the same value",
             "multiplication with identity",
@@ -563,7 +507,7 @@ describe("Fraction checks", () => {
         const result = checkStep("2abc/ab", "2bc/b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "extract common factors from numerator and denominator",
             "division by the same value",
             "multiplication with identity",
@@ -574,7 +518,7 @@ describe("Fraction checks", () => {
         const result = checkStep("2abc/abd", "2c/d");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "extract common factors from numerator and denominator",
             "division by the same value",
             "multiplication with identity",
@@ -586,7 +530,7 @@ describe("Fraction checks", () => {
         const result = checkStep("ab/abde", "1/de");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "extract common factors from numerator and denominator",
             "division by the same value",
             "multiplication with identity",
@@ -597,7 +541,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a * b/b", "a");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "division by the same value",
             "multiplication with identity",
         ]);
@@ -607,16 +551,15 @@ describe("Fraction checks", () => {
         const result = checkStep("a", "a * b/b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "multiplication with identity",
             "division by the same value",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("a");
-        expect(result.steps[0].nodes[1]).toParseLike("a * 1");
-
-        expect(result.steps[1].nodes[0]).toParseLike("1");
-        expect(result.steps[1].nodes[1]).toParseLike("b/b");
+        expect(result).toHaveStepsLike([
+            ["a", "a * 1"],
+            ["1", "b/b"],
+        ]);
     });
 
     it("a -> a / 1", () => {
@@ -626,9 +569,7 @@ describe("Fraction checks", () => {
 
         // TODO: provide a way to group common steps together.
         // These three steps in this order is "division by one"
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "division by one",
-        ]);
+        expect(result).toHaveMessages(["division by one"]);
     });
 
     it("a / 1 -> a", () => {
@@ -638,9 +579,7 @@ describe("Fraction checks", () => {
 
         // TODO: provide a way to group common steps together.
         // These three steps in this order is "division by one"
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "division by one",
-        ]);
+        expect(result).toHaveMessages(["division by one"]);
     });
 
     describe("divByOne is equivalent to [divIsMulByOneOver, divBySame, mulOne]", () => {
@@ -683,7 +622,7 @@ describe("Fraction checks", () => {
             if (!result) {
                 throw new Error("result not defined");
             }
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplication with identity",
                 "division by the same value",
                 "multiplying by one over something results in a fraction",
@@ -704,7 +643,7 @@ describe("Fraction checks", () => {
             if (!result) {
                 throw new Error("result not defined");
             }
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "fraction is the same as multiplying by one over",
                 "division by the same value",
                 "multiplication with identity",
@@ -716,12 +655,9 @@ describe("Fraction checks", () => {
         const result = checkStep("ab", "ab / 1");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "division by one",
-        ]);
+        expect(result).toHaveMessages(["division by one"]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("ab");
-        expect(result.steps[0].nodes[1]).toParseLike("ab / 1");
+        expect(result).toHaveStepsLike([["ab", "ab / 1"]]);
     });
 
     // TODO: make sure distribution is including substeps
@@ -730,7 +666,7 @@ describe("Fraction checks", () => {
         const result = checkStep("(a + b) * 1/c", "a/c  + b/c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "distribution",
             "multiplying by one over something results in a fraction",
             "multiplying by one over something results in a fraction",
@@ -742,7 +678,7 @@ describe("Fraction checks", () => {
         const result = checkStep("a/c + b/c", "1/c * (a + b)");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
             "commutative property",
             "fraction is the same as multiplying by one over",
@@ -750,59 +686,47 @@ describe("Fraction checks", () => {
             "factoring",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("a/c");
-        expect(result.steps[0].nodes[1]).toParseLike("a * 1/c");
-
-        expect(result.steps[1].nodes[0]).toParseLike("a * 1/c");
-        expect(result.steps[1].nodes[1]).toParseLike("1/c * a");
-
-        expect(result.steps[2].nodes[0]).toParseLike("b/c");
-        expect(result.steps[2].nodes[1]).toParseLike("b * 1/c");
-
-        expect(result.steps[3].nodes[0]).toParseLike("b * 1/c");
-        expect(result.steps[3].nodes[1]).toParseLike("1/c * b");
-
-        expect(result.steps[4].nodes[0]).toParseLike("1/c * a + 1/c * b");
-        expect(result.steps[4].nodes[1]).toParseLike("1/c * (a + b)");
+        expect(result).toHaveStepsLike([
+            ["a/c", "a * 1/c"],
+            ["a * 1/c", "1/c * a"],
+            ["b/c", "b * 1/c"],
+            ["b * 1/c", "1/c * b"],
+            ["1/c * a + 1/c * b", "1/c * (a + b)"],
+        ]);
     });
 
     it("a/c -> 1/c * a", () => {
         const result = checkStep("a/c", "1/c * a");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
             "commutative property",
         ]);
 
-        expect(result.steps[0].nodes[0]).toParseLike("a/c");
-        expect(result.steps[0].nodes[1]).toParseLike("a * 1/c");
-
-        expect(result.steps[1].nodes[0]).toParseLike("a * 1/c");
-        expect(result.steps[1].nodes[1]).toParseLike("1/c * a");
+        expect(result).toHaveStepsLike([
+            ["a/c", "a * 1/c"],
+            ["a * 1/c", "1/c * a"],
+        ]);
     });
 
     it("a/1 + b/1 -> a + b", () => {
         const result = checkStep("a/1 + b/1", "a + b");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
-            "division by one",
-            "division by one",
+        expect(result).toHaveMessages(["division by one", "division by one"]);
+
+        expect(result).toHaveStepsLike([
+            ["a/1", "a"],
+            ["b/1", "b"],
         ]);
-
-        expect(result.steps[0].nodes[0]).toParseLike("a/1");
-        expect(result.steps[0].nodes[1]).toParseLike("a");
-
-        expect(result.steps[1].nodes[0]).toParseLike("b/1");
-        expect(result.steps[1].nodes[1]).toParseLike("b");
     });
 
     it("(a + b) / c -> (a + b) * 1/c -> a * 1/c + b * 1/c -> a/c + b/c", () => {
         const result = checkStep("(a + b) / c", "a/c + b/c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
             "distribution",
             "multiplying by one over something results in a fraction",
@@ -814,7 +738,7 @@ describe("Fraction checks", () => {
         const result = checkStep("(a + b) / c", "(a + b) * 1/c");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
         ]);
     });
@@ -825,28 +749,18 @@ describe("Fraction checks", () => {
         expect(result).toBeTruthy();
         expect(result.steps).toHaveLength(4);
 
-        expect(result.steps.map((reason) => reason.message)).toEqual([
+        expect(result).toHaveMessages([
             "fraction is the same as multiplying by one over",
             "fraction is the same as multiplying by one over",
             "factoring",
             "multiplying by one over something results in a fraction",
         ]);
 
-        expect(result.steps[0].nodes[0]).toMatchInlineSnapshot(`(div a c)`);
-        expect(result.steps[0].nodes[1]).toMatchInlineSnapshot(`
-            (mul.exp
-              a
-              (div 1 c))
-        `);
-        expect(result.steps[0].nodes[1]).toParseLike("a * 1/c");
-
-        expect(result.steps[1].nodes[0]).toParseLike("b / c");
-        expect(result.steps[1].nodes[1]).toParseLike("b * 1/c");
-
-        expect(result.steps[2].nodes[0]).toParseLike("a * 1/c + b * 1/c");
-        expect(result.steps[2].nodes[1]).toParseLike("(a + b) * 1/c");
-
-        expect(result.steps[3].nodes[0]).toParseLike("(a + b) * 1/c");
-        expect(result.steps[3].nodes[1]).toParseLike("(a + b)/c");
+        expect(result).toHaveStepsLike([
+            ["a / c", "a * 1/c"],
+            ["b / c", "b * 1/c"],
+            ["a * 1/c + b * 1/c", "(a + b) * 1/c"],
+            ["(a + b) * 1/c", "(a + b)/c"],
+        ]);
     });
 });

--- a/packages/step-checker/src/checks/__tests__/polynomial-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/polynomial-checks.test.ts
@@ -1,11 +1,13 @@
-import {checkStep} from "../test-util";
+import {checkStep, toHaveMessages} from "../test-util";
+
+expect.extend({toHaveMessages});
 
 describe.skip("polynomial checks", () => {
     it("2x + 3x -> 5x", () => {
         const result = checkStep("2x + 3x", "5x");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "factoring",
             "evaluation of addition",
             "commutative property",
@@ -16,7 +18,7 @@ describe.skip("polynomial checks", () => {
         const result = checkStep("1 + 2x + 3x", "1 + 5x");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "factoring",
             "evaluation of addition",
             "commutative property",
@@ -27,7 +29,7 @@ describe.skip("polynomial checks", () => {
         const result = checkStep("x + 3x", "4x");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "factoring",
             "evaluation of addition",
             "commutative property",
@@ -38,7 +40,7 @@ describe.skip("polynomial checks", () => {
         const result = checkStep("x^2 + 3x^2", "4x^2");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "factoring",
             "evaluation of addition",
             "commutative property",
@@ -49,7 +51,7 @@ describe.skip("polynomial checks", () => {
         const result = checkStep("xy + 3xy", "4xy");
 
         expect(result).toBeTruthy();
-        expect(result.steps.map((step) => step.message)).toEqual([
+        expect(result).toHaveMessages([
             "factoring",
             "evaluation of addition",
             "commutative property",

--- a/packages/step-checker/src/checks/__tests__/power-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/power-checks.test.ts
@@ -1,6 +1,11 @@
-import {checkStep, toParseLike, checkMistake} from "../test-util";
+import {
+    checkStep,
+    checkMistake,
+    toHaveMessages,
+    toHaveStepsLike,
+} from "../test-util";
 
-expect.extend({toParseLike});
+expect.extend({toHaveMessages, toHaveStepsLike});
 
 describe("Exponent checks", () => {
     // TODO: automatically generate tests for testing 'symmetric = true'
@@ -9,7 +14,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a*a*a", "a^3");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
             ]);
         });
@@ -18,7 +23,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a^3", "a*a*a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
             ]);
         });
@@ -27,7 +32,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a*a*a", "a * a^2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
             ]);
         });
@@ -36,7 +41,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a*a*a*a", "a * a^2 * a");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
                 "commutative property",
             ]);
@@ -46,7 +51,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a*a*a*b*b", "(a^3)(b^2)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
                 "multiplying a factor n-times is an exponent",
             ]);
@@ -56,7 +61,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^3)(b^2)", "a*a*a*b*b");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
                 "multiplying a factor n-times is an exponent",
             ]);
@@ -68,7 +73,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a*b*a*b*a", "(a^3)(b^2)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
                 "multiplying a factor n-times is an exponent",
             ]);
@@ -80,7 +85,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a*b*a*b*a", "(a^2)(b^2)(a)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
                 "multiplying a factor n-times is an exponent",
                 "commutative property",
@@ -93,7 +98,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^n)(a^m)", "a^(n+m)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying powers adds their exponents",
             ]);
         });
@@ -102,7 +107,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^n)(a^m)", "a^(m+n)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying powers adds their exponents",
                 "commutative property",
             ]);
@@ -112,7 +117,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^n)(a^m)(b^x)(b^y)", "a^(n+m)b^(x+y)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying powers adds their exponents",
             ]);
         });
@@ -121,7 +126,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^2)(a^3)", "a^5");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying powers adds their exponents",
                 "evaluation of addition",
             ]);
@@ -131,7 +136,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a^5", "(a^2)(a^3)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "decompose sum",
                 "multiplying powers adds their exponents",
             ]);
@@ -141,7 +146,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^2)(a^3)(a^4)", "(a^5)(a^4)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying powers adds their exponents",
                 "evaluation of addition",
                 "commutative property",
@@ -152,7 +157,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^2)(a^3)(a^4)", "(a^2)(a^7)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying powers adds their exponents",
                 "evaluation of addition",
             ]);
@@ -164,7 +169,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^5)/(a^3)", "a^(5-3)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing powers subtracts their exponents",
             ]);
         });
@@ -173,7 +178,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^m)/(a^n)", "a^(m-n)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing powers subtracts their exponents",
             ]);
         });
@@ -182,7 +187,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^5)/(a^3)", "a^2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing powers subtracts their exponents",
                 "evaluation of addition",
             ]);
@@ -192,7 +197,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a^(m-n)", "(a^m)/(a^n)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "dividing powers subtracts their exponents",
             ]);
         });
@@ -209,7 +214,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a^(-2)", "1 / a^2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "A power with a negative exponent is the same as one over the power with the positive exponent",
             ]);
         });
@@ -218,7 +223,7 @@ describe("Exponent checks", () => {
             const result = checkStep("1 / a^2", "a^(-2)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "A power with a negative exponent is the same as one over the power with the positive exponent",
             ]);
         });
@@ -239,7 +244,7 @@ describe("Exponent checks", () => {
             const result = checkStep("1 / a^(-2)", "1 / (1 / a^2)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "A power with a negative exponent is the same as one over the power with the positive exponent",
             ]);
         });
@@ -248,48 +253,38 @@ describe("Exponent checks", () => {
             const result = checkStep("1 / a^(-2)", "a^2");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "A power with a negative exponent is the same as one over the power with the positive exponent",
                 "dividing by a fraction is the same as multiplying by the reciprocal",
                 "multiplication with identity",
                 "division by one",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a^(-2)");
-            expect(result.steps[0].nodes[1]).toParseLike("1 / a^2");
-
-            expect(result.steps[1].nodes[0]).toParseLike("1 / (1 / a^2)");
-            expect(result.steps[1].nodes[1]).toParseLike("1 * a^2 / 1");
-
-            expect(result.steps[2].nodes[0]).toParseLike("1 * a^2 / 1");
-            expect(result.steps[2].nodes[1]).toParseLike("a^2 / 1");
-
-            expect(result.steps[3].nodes[0]).toParseLike("a^2 / 1");
-            expect(result.steps[3].nodes[1]).toParseLike("a^2");
+            expect(result).toHaveStepsLike([
+                ["a^(-2)", "1 / a^2"],
+                ["1 / (1 / a^2)", "1 * a^2 / 1"],
+                ["1 * a^2 / 1", "a^2 / 1"],
+                ["a^2 / 1", "a^2"],
+            ]);
         });
 
         it("a^2 -> 1 / a^(-2)", () => {
             const result = checkStep("a^2", "1 / a^(-2)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "division by one",
                 "multiplication with identity",
                 "dividing by a fraction is the same as multiplying by the reciprocal",
                 "A power with a negative exponent is the same as one over the power with the positive exponent",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a^2");
-            expect(result.steps[0].nodes[1]).toParseLike("a^2 / 1");
-
-            expect(result.steps[1].nodes[0]).toParseLike("a^2 / 1");
-            expect(result.steps[1].nodes[1]).toParseLike("1 * a^2 / 1");
-
-            expect(result.steps[2].nodes[0]).toParseLike("1 * a^2 / 1");
-            expect(result.steps[2].nodes[1]).toParseLike("1 / (1 / a^2)");
-
-            expect(result.steps[3].nodes[0]).toParseLike("1 / a^2");
-            expect(result.steps[3].nodes[1]).toParseLike("a^(-2)");
+            expect(result).toHaveStepsLike([
+                ["a^2", "a^2 / 1"],
+                ["a^2 / 1", "1 * a^2 / 1"],
+                ["1 * a^2 / 1", "1 / (1 / a^2)"],
+                ["1 / a^2", "a^(-2)"],
+            ]);
         });
     });
 
@@ -298,7 +293,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^n)^m", "a^(nm)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
             ]);
         });
@@ -307,7 +302,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^n)^m", "(a^m)^n");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
                 "commutative property",
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
@@ -318,7 +313,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^n)^m", "a^(mn)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
                 "commutative property",
             ]);
@@ -328,7 +323,7 @@ describe("Exponent checks", () => {
             const result = checkStep("a^(nm)", "(a^n)^m");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
             ]);
         });
@@ -337,7 +332,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^2)^3", "a^(2*3)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
             ]);
         });
@@ -346,7 +341,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(a^2)^3", "a^6");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
                 "evaluation of multiplication",
             ]);
@@ -356,7 +351,7 @@ describe("Exponent checks", () => {
             const result = checkStep("(x^(ab))^(cd)", "x^(abcd)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
             ]);
         });
@@ -365,7 +360,7 @@ describe("Exponent checks", () => {
             const result = checkStep("((a^x)^y)^z", "a^(xyz)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
             ]);
@@ -375,7 +370,7 @@ describe("Exponent checks", () => {
             const result = checkStep("((a^x)^y)^z", "a^(zyx)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((step) => step.message)).toEqual([
+            expect(result).toHaveMessages([
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
                 "raising a power to another exponent is the same raising the power once an multiplying the exponents",
                 "commutative property",
@@ -388,20 +383,17 @@ describe("Exponent checks", () => {
             const result = checkStep("a*a*a*a*a", "(a^2)(a^3)");
 
             expect(result).toBeTruthy();
-            expect(result.steps.map((reason) => reason.message)).toEqual([
+            expect(result).toHaveMessages([
                 "multiplying a factor n-times is an exponent",
                 "decompose sum",
                 "multiplying powers adds their exponents",
             ]);
 
-            expect(result.steps[0].nodes[0]).toParseLike("a*a*a*a*a");
-            expect(result.steps[0].nodes[1]).toParseLike("a^5");
-
-            expect(result.steps[1].nodes[0]).toParseLike("5");
-            expect(result.steps[1].nodes[1]).toParseLike("2+3");
-
-            expect(result.steps[2].nodes[0]).toParseLike("a^(2+3)");
-            expect(result.steps[2].nodes[1]).toParseLike("(a^2)(a^3)");
+            expect(result).toHaveStepsLike([
+                ["a*a*a*a*a", "a^5"],
+                ["5", "2 + 3"],
+                ["a^(2+3)", "a^2a^3"],
+            ]);
         });
     });
 

--- a/packages/step-checker/src/checks/test-util.ts
+++ b/packages/step-checker/src/checks/test-util.ts
@@ -54,3 +54,81 @@ export const toParseLike = (
         pass: false,
     };
 };
+
+export function toHaveMessages(
+    this: any,
+    received: Result,
+    expected: string[],
+): {message: () => string; pass: boolean} {
+    if (this.isNot) {
+        expect(received.steps.map((step) => step.message)).not.toEqual(
+            expected,
+        );
+    } else {
+        expect(received.steps.map((step) => step.message)).toEqual(expected);
+    }
+
+    // This point is reached when the above assertion was successful.
+    // The test should therefore always pass, that means it needs to be
+    // `true` when used normally, and `false` when `.not` was used.
+    return {message: () => "", pass: !this.isNot};
+}
+
+export const toHaveStepsLike = (
+    received: Result,
+    expected: [string, string][],
+): {message: () => string; pass: boolean} => {
+    if (received.steps.length !== expected.length) {
+        return {
+            message: () =>
+                `expected ${expected.length} steps but received ${received.steps.length}`,
+            pass: false,
+        };
+    }
+
+    const failures: {
+        step: number;
+        node: number;
+        received: Semantic.Types.Node;
+        expected: Semantic.Types.Node;
+    }[] = [];
+    for (let i = 0; i < expected.length; i++) {
+        if (!deepEquals(received.steps[i].nodes[0], myParse(expected[i][0]))) {
+            failures.push({
+                step: i,
+                node: 0,
+                received: received.steps[i].nodes[0],
+                expected: myParse(expected[i][0]),
+            });
+        }
+        if (!deepEquals(received.steps[i].nodes[1], myParse(expected[i][1]))) {
+            failures.push({
+                step: i,
+                node: 1,
+                received: received.steps[i].nodes[1],
+                expected: myParse(expected[i][1]),
+            });
+        }
+    }
+
+    if (failures.length > 0) {
+        return {
+            message: () =>
+                failures
+                    .map(({step, node, received, expected}) => {
+                        return `step ${step}, node ${node}: expected ${JSON.stringify(
+                            expected,
+                            null,
+                            2,
+                        )} but received ${JSON.stringify(received, null, 2)}`;
+                    })
+                    .join("\n"),
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => `steps matched`,
+        pass: true,
+    };
+};

--- a/packages/step-checker/src/matchers.d.ts
+++ b/packages/step-checker/src/matchers.d.ts
@@ -2,5 +2,7 @@ declare namespace jest {
     // eslint-disable-next-line @typescript-eslint/interface-name-prefix
     interface Matchers<R, T> {
         toParseLike(math: string): R;
+        toHaveStepsLike(steps: [string, string][]): R;
+        toHaveMessages(messages: string[]): R;
     }
 }


### PR DESCRIPTION
These helpers simplify the writing of many of the assertions we have in our step-checker tests.

TODO:
- [ ] ~add a printer to `text-parser` so that the failure messages are easier to read.~ I've created #208 to track this separately.