### PR TITLE
Add mulInverse check, improve editor-printer

### DIFF
--- a/packages/editor/src/__tests__/editor-printer.test.ts
+++ b/packages/editor/src/__tests__/editor-printer.test.ts
@@ -134,6 +134,49 @@ describe("print", () => {
         expect(node).toEqualMath(Util.row("(1)(2)(3)"));
     });
 
+    test("(-a)(-b)", () => {
+        const ast = Semantic.mul(
+            [
+                Semantic.neg(Semantic.identifier("a")),
+                Semantic.neg(Semantic.identifier("b")),
+            ],
+            true,
+        );
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(Util.row("(-a)(-b)"));
+    });
+
+    test("(a/b)(c/d)", () => {
+        const ast = Semantic.mul(
+            [
+                Semantic.div(
+                    Semantic.identifier("a"),
+                    Semantic.identifier("b"),
+                ),
+                Semantic.div(
+                    Semantic.identifier("c"),
+                    Semantic.identifier("d"),
+                ),
+            ],
+            true,
+        );
+
+        const node = print(ast);
+
+        expect(node).toEqualMath(
+            Editor.row([
+                Editor.glyph("("),
+                Util.frac("a", "b"),
+                Editor.glyph(")"),
+                Editor.glyph("("),
+                Util.frac("c", "d"),
+                Editor.glyph(")"),
+            ]),
+        );
+    });
+
     test("-1.2", () => {
         const ast = Semantic.number("-1.2");
 

--- a/packages/editor/src/editor-printer.ts
+++ b/packages/editor/src/editor-printer.ts
@@ -67,7 +67,10 @@ const print = (expr: Semantic.Types.Node): Editor.Node => {
                 if (arg.type === "number") {
                     return true;
                 }
-                if (arg.type === "neg" && arg.arg.type === "number") {
+                if (arg.type === "neg") {
+                    return true;
+                }
+                if (arg.type === "div") {
                     return true;
                 }
                 return false;

--- a/packages/step-checker/src/all-checks.ts
+++ b/packages/step-checker/src/all-checks.ts
@@ -32,6 +32,7 @@ import {
     cancelFrac,
     divByOne,
     divByFrac,
+    mulInverse,
 } from "./checks/new-fraction-checks";
 import {
     powDef,
@@ -69,6 +70,8 @@ export const ALL_CHECKS = [
     // checks first otherwise checkArgs would always find a solution first.
     checkArgs,
 
+    mulInverse,
+
     addZero,
     mulOne,
     mulByZero,
@@ -105,6 +108,7 @@ export const ALL_CHECKS = [
     // in parallel and picking the shortest path, but this would be very expensive
 
     // new fraction checks
+
     divByFrac,
     mulFrac,
     cancelFrac,

--- a/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/eval-checks.test.ts
@@ -227,10 +227,7 @@ describe("Eval (decomposition) checks", () => {
             const result = checkStep("5 * 1/5", "1");
 
             expect(result).toBeTruthy();
-            expect(result).toHaveMessages([
-                "multiplication of fractions",
-                "cancelling in fractions",
-            ]);
+            expect(result).toHaveMessages(["multiplying the inverse"]);
         });
 
         it("2 * 5 * 1/5 -> 2", () => {
@@ -238,8 +235,8 @@ describe("Eval (decomposition) checks", () => {
 
             expect(result).toBeTruthy();
             expect(result).toHaveMessages([
-                "multiplication of fractions",
-                "cancelling in fractions",
+                "multiplying the inverse",
+                "multiplication with identity",
             ]);
         });
 
@@ -258,8 +255,8 @@ describe("Eval (decomposition) checks", () => {
                 throw new Error("result is undefind");
             }
             expect(result).toHaveMessages([
-                "multiplication of fractions",
-                "cancelling in fractions",
+                "multiplying the inverse",
+                "multiplication with identity",
             ]);
         });
 
@@ -268,8 +265,8 @@ describe("Eval (decomposition) checks", () => {
 
             expect(result).toBeTruthy();
             expect(result).toHaveMessages([
-                "multiplication of fractions",
-                "cancelling in fractions",
+                "multiplying the inverse",
+                "multiplication with identity",
             ]);
         });
     });

--- a/packages/step-checker/src/checks/__tests__/new-fraction-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/new-fraction-checks.test.ts
@@ -170,15 +170,9 @@ describe("new fraction checks", () => {
             const result = checkStep("a * 1/a", "1");
 
             expect(result).toBeTruthy();
-            expect(result).toHaveMessages([
-                "multiplication of fractions",
-                "cancelling in fractions",
-            ]);
+            expect(result).toHaveMessages(["multiplying the inverse"]);
 
-            expect(result).toHaveStepsLike([
-                ["a * 1/a", "a/a"],
-                ["a/a", "1"],
-            ]);
+            expect(result).toHaveStepsLike([["a * 1/a", "1"]]);
         });
 
         it("a/a -> 1", () => {
@@ -439,6 +433,81 @@ describe("new fraction checks", () => {
             expect(result).toHaveStepsLike([
                 ["a / (1/b)", "a * b/1"],
                 ["b/1", "b"],
+            ]);
+        });
+    });
+
+    describe("mulInverse", () => {
+        it("a * b * 1/b * c -> a * 1 * c", () => {
+            const result = checkStep("a * b * 1/b * c", "a * 1 * c");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages(["multiplying the inverse"]);
+
+            expect(result).toHaveStepsLike([["a * b * 1/b * c", "a * 1 * c"]]);
+        });
+
+        it("a * b * 1/b * c -> a * c", () => {
+            const result = checkStep("a * b * 1/b * c", "a * c");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages([
+                "multiplying the inverse",
+                "multiplication with identity",
+            ]);
+
+            expect(result).toHaveStepsLike([
+                ["a * b * 1/b * c", "a * 1 * c"],
+                ["a * 1 * c", "a * c"],
+            ]);
+        });
+
+        it("(a)(b)(1/b)(c) -> ac", () => {
+            const result = checkStep("(a)(b)(1/b)(c)", "ac");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages([
+                "multiplying the inverse",
+                "multiplication with identity",
+            ]);
+
+            expect(result).toHaveStepsLike([
+                ["(a)(b)(1/b)(c)", "(a)(1)(c)"],
+                ["(a)(1)(c)", "ac"],
+            ]);
+        });
+
+        it("a * 1/a * b * 1/b -> 1", () => {
+            const result = checkStep("a * 1/a * b * 1/b", "1");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages([
+                "multiplying the inverse",
+                "multiplying the inverse",
+                "multiplication with identity",
+            ]);
+
+            expect(result).toHaveStepsLike([
+                ["a * 1/a * b * 1/b", "1 * b * 1/b"],
+                ["1 * b * 1/b", "1 * 1"],
+                ["1 * 1", "1"],
+            ]);
+        });
+
+        it("a * 1/a * a * 1/a -> 1", () => {
+            const result = checkStep("a * 1/a * a * 1/a", "1");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages([
+                "multiplying the inverse",
+                "multiplying the inverse",
+                "multiplication with identity",
+            ]);
+
+            expect(result).toHaveStepsLike([
+                ["a * 1/a * a * 1/a", "1 * a * 1/a"],
+                ["1 * a * 1/a", "1 * 1"],
+                ["1 * 1", "1"],
             ]);
         });
     });

--- a/packages/step-checker/src/checks/__tests__/new-fraction-checks.test.ts
+++ b/packages/step-checker/src/checks/__tests__/new-fraction-checks.test.ts
@@ -164,17 +164,6 @@ describe("new fraction checks", () => {
     });
 
     describe("cancelFrac", () => {
-        // TODO: it would be nice to handle this as a special case to reflect
-        // that we're multiplying by the inverse here.
-        it("a * 1/a -> 1", () => {
-            const result = checkStep("a * 1/a", "1");
-
-            expect(result).toBeTruthy();
-            expect(result).toHaveMessages(["multiplying the inverse"]);
-
-            expect(result).toHaveStepsLike([["a * 1/a", "1"]]);
-        });
-
         it("a/a -> 1", () => {
             const result = checkStep("a/a", "1");
 
@@ -438,6 +427,24 @@ describe("new fraction checks", () => {
     });
 
     describe("mulInverse", () => {
+        it("a * 1/a -> 1", () => {
+            const result = checkStep("a * 1/a", "1");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages(["multiplying the inverse"]);
+
+            expect(result).toHaveStepsLike([["a * 1/a", "1"]]);
+        });
+
+        it("1/a * a -> 1", () => {
+            const result = checkStep("1/a * a", "1");
+
+            expect(result).toBeTruthy();
+            expect(result).toHaveMessages(["multiplying the inverse"]);
+
+            expect(result).toHaveStepsLike([["1/a * a", "1"]]);
+        });
+
         it("a * b * 1/b * c -> a * 1 * c", () => {
             const result = checkStep("a * b * 1/b * c", "a * 1 * c");
 

--- a/packages/step-checker/src/checks/new-fraction-checks.ts
+++ b/packages/step-checker/src/checks/new-fraction-checks.ts
@@ -288,3 +288,51 @@ export const divByOne: Check = (prev, next, context) => {
     }
 };
 divByOne.symmetric = true;
+
+export const mulInverse: Check = (prev, next, context) => {
+    if (prev.type !== "mul") {
+        return undefined;
+    }
+
+    const {checker} = context;
+
+    const pairs: [
+        Semantic.Types.NumericNode,
+        Semantic.Types.NumericNode,
+    ][] = [];
+    for (let i = 0; i < prev.args.length - 1; i++) {
+        pairs.push([prev.args[i], prev.args[i + 1]]);
+    }
+
+    for (let i = 0; i < prev.args.length - 1; i++) {
+        const pair = pairs[i];
+        if (pair[0].type !== "div" && pair[1].type === "div") {
+            if (exactMatch(pair[0], pair[1].args[1], context)) {
+                const newPrev = Semantic.mulFactors(
+                    [
+                        ...prev.args.slice(0, i),
+                        Semantic.number("1"),
+                        ...prev.args.slice(i + 2),
+                    ],
+                    prev.implicit,
+                );
+
+                const result = checker.checkStep(newPrev, next, context);
+
+                if (result) {
+                    return correctResult(
+                        prev,
+                        newPrev,
+                        context.reversed,
+                        [],
+                        result.steps,
+                        "multiplying the inverse",
+                    );
+                }
+            }
+        }
+    }
+
+    return undefined;
+};
+mulInverse.symmetric = true;

--- a/packages/step-checker/src/checks/new-fraction-checks.ts
+++ b/packages/step-checker/src/checks/new-fraction-checks.ts
@@ -306,8 +306,36 @@ export const mulInverse: Check = (prev, next, context) => {
 
     for (let i = 0; i < prev.args.length - 1; i++) {
         const pair = pairs[i];
+        // a * 1/a -> 1
         if (pair[0].type !== "div" && pair[1].type === "div") {
             if (exactMatch(pair[0], pair[1].args[1], context)) {
+                const newPrev = Semantic.mulFactors(
+                    [
+                        ...prev.args.slice(0, i),
+                        Semantic.number("1"),
+                        ...prev.args.slice(i + 2),
+                    ],
+                    prev.implicit,
+                );
+
+                const result = checker.checkStep(newPrev, next, context);
+
+                if (result) {
+                    return correctResult(
+                        prev,
+                        newPrev,
+                        context.reversed,
+                        [],
+                        result.steps,
+                        "multiplying the inverse",
+                    );
+                }
+            }
+        }
+
+        // 1/a * a -> 1
+        if (pair[0].type === "div" && pair[1].type !== "div") {
+            if (exactMatch(pair[1], pair[0].args[1], context)) {
                 const newPrev = Semantic.mulFactors(
                     [
                         ...prev.args.slice(0, i),


### PR DESCRIPTION
This was one of the checks that was part of the origin fraction-checks.  This version though is slightly different.  It only detects multiplication of inverses when they're right next to each other in a mul node.  If they're further away then we fallback to `mulFrac`.