### PR TITLE
Add 'print' function to testing package, fixes #208

### DIFF
--- a/packages/editor/src/editor-printer.ts
+++ b/packages/editor/src/editor-printer.ts
@@ -78,6 +78,7 @@ const print = (expr: Semantic.Types.Node): Editor.Node => {
 
             for (const arg of expr.args) {
                 const node = print(arg);
+                // TODO: we probably also want to wrap things like (a * b)(x * y)
                 const wrap = (wrapAll && expr.implicit) || arg.type === "add";
 
                 if (wrap) {

--- a/packages/grader/src/checks/test-util.ts
+++ b/packages/grader/src/checks/test-util.ts
@@ -1,7 +1,7 @@
 import * as Editor from "@math-blocks/editor";
 import * as Semantic from "@math-blocks/semantic";
 import {parse as _parse} from "@math-blocks/editor-parser";
-import {parse} from "@math-blocks/testing";
+import {parse, print} from "@math-blocks/testing";
 
 import {checkStep as _checkStep} from "../step-checker";
 import {Result, Mistake} from "../types";
@@ -116,11 +116,9 @@ export const toHaveStepsLike = (
             message: () =>
                 failures
                     .map(({step, node, received, expected}) => {
-                        return `step ${step}, node ${node}: expected ${JSON.stringify(
+                        return `step ${step}, node ${node}: expected ${print(
                             expected,
-                            null,
-                            2,
-                        )} but received ${JSON.stringify(received, null, 2)}`;
+                        )} but received ${print(received)}`;
                     })
                     .join("\n"),
             pass: false,

--- a/packages/testing/src/__tests__/printer.test.ts
+++ b/packages/testing/src/__tests__/printer.test.ts
@@ -149,6 +149,30 @@ describe("printer", () => {
             expect(result).toEqual("(x + y)(a + b)");
         });
 
+        test("(a * b)(c * d)", () => {
+            const ast = parse("(a * b)(c * d)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(a * b)(c * d)");
+        });
+
+        test("(a * b) * (c * d)", () => {
+            const ast = parse("(a * b) * (c * d)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(a * b) * (c * d)");
+        });
+
+        test("ab * cd", () => {
+            const ast = parse("ab * cd");
+
+            const result = print(ast);
+
+            expect(result).toEqual("ab * cd");
+        });
+
         test("1 * 2 * 3", () => {
             const ast = parse("1 * 2 * 3");
 

--- a/packages/testing/src/__tests__/printer.test.ts
+++ b/packages/testing/src/__tests__/printer.test.ts
@@ -1,0 +1,255 @@
+import {print} from "../printer";
+import {parse} from "../text-parser";
+
+describe("printer", () => {
+    describe("add/sub", () => {
+        test("1 - x", () => {
+            const ast = parse("1 - x");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 - x");
+        });
+
+        test("1 + -x", () => {
+            const ast = parse("1 + -x");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 + -x");
+        });
+
+        test("1 - -x", () => {
+            const ast = parse("1 - -x");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 - -x");
+        });
+
+        test("1 - -2", () => {
+            const ast = parse("1 - -2");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 - -2");
+        });
+
+        test("1 - (x + y)", () => {
+            const ast = parse("1 - (x + y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 - (x + y)");
+        });
+
+        test("1 + -(x + y)", () => {
+            const ast = parse("1 + -(x + y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 + -(x + y)");
+        });
+
+        test("1 - -(x + y)", () => {
+            const ast = parse("1 - -(x + y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 - -(x + y)");
+        });
+
+        test("1 + (x + y)", () => {
+            const ast = parse("1 + (x + y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 + (x + y)");
+        });
+    });
+
+    describe("mul", () => {
+        test("abc", () => {
+            const ast = parse("abc");
+
+            const result = print(ast);
+
+            expect(result).toEqual("abc");
+        });
+
+        test("2xy", () => {
+            const ast = parse("2xy");
+
+            const result = print(ast);
+
+            expect(result).toEqual("2xy");
+        });
+
+        test("(x)(2)(y)", () => {
+            const ast = parse("(x)(2)(y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(x)(2)(y)");
+        });
+
+        test("-2xy", () => {
+            const ast = parse("-2xy");
+
+            const result = print(ast);
+
+            expect(result).toEqual("-2xy");
+        });
+
+        test("(x)(-2)(y)", () => {
+            const ast = parse("(x)(-2)(y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(x)(-2)(y)");
+        });
+
+        test("(1 / 2)(x)", () => {
+            const ast = parse("(1 / 2)(x)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(1 / 2)(x)");
+        });
+
+        test("(2)(x / y)", () => {
+            const ast = parse("(2)(x / y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(2)(x / y)");
+        });
+
+        test("(x + y)(a + b)", () => {
+            const ast = parse("(x + y)(a + b)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(x + y)(a + b)");
+        });
+
+        test("1 * 2 * 3", () => {
+            const ast = parse("1 * 2 * 3");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 * 2 * 3");
+        });
+    });
+
+    describe("div", () => {
+        test("ab / cd", () => {
+            const ast = parse("ab / cd");
+
+            const result = print(ast);
+
+            expect(result).toEqual("ab / cd");
+        });
+
+        test("a / b * c / d", () => {
+            const ast = parse("a / b * c / d");
+
+            const result = print(ast);
+
+            expect(result).toEqual("a / b * c / d");
+        });
+
+        // Don't bother with this case since "a / b / c / d" is confusing to being with
+        // test("a / b / c / d", () => {
+        //     const ast = parse("a / b / c / d");
+
+        //     const result = print(ast);
+
+        //     expect(result).toEqual("a / b / c / d");
+        // });
+
+        test("(a / b) / (c / d)", () => {
+            const ast = parse("(a / b) / (c / d)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(a / b) / (c / d)");
+        });
+
+        test("(x + y) / (a + b)", () => {
+            const ast = parse("(x + y) / (a + b)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(x + y) / (a + b)");
+        });
+    });
+
+    describe("pow", () => {
+        test("x^2", () => {
+            const ast = parse("x^2");
+
+            const result = print(ast);
+
+            expect(result).toEqual("x^2");
+        });
+
+        test("x^(-2)", () => {
+            const ast = parse("x^(-2)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("x^(-2)");
+        });
+
+        test("-x^2", () => {
+            const ast = parse("-x^2");
+
+            const result = print(ast);
+
+            expect(result).toEqual("-x^2");
+        });
+
+        test("(-x)^2", () => {
+            const ast = parse("(-x)^2");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(-x)^2");
+        });
+
+        test("(-x)^(-2)", () => {
+            const ast = parse("(-x)^(-2)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(-x)^(-2)");
+        });
+
+        test("(x + 1)^2", () => {
+            const ast = parse("(x + 1)^2");
+
+            const result = print(ast);
+
+            expect(result).toEqual("(x + 1)^2");
+        });
+    });
+
+    describe("eq", () => {
+        test("x = y = z", () => {
+            const ast = parse("x = y = z");
+
+            const result = print(ast);
+
+            expect(result).toEqual("x = y = z");
+        });
+
+        test("x + y = z - 5", () => {
+            const ast = parse("x + y = z - 5");
+
+            const result = print(ast);
+
+            expect(result).toEqual("x + y = z - 5");
+        });
+    });
+});

--- a/packages/testing/src/__tests__/printer.test.ts
+++ b/packages/testing/src/__tests__/printer.test.ts
@@ -19,12 +19,28 @@ describe("printer", () => {
             expect(result).toEqual("1 + -x");
         });
 
+        test("1 + --x", () => {
+            const ast = parse("1 + --x");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 + --x");
+        });
+
         test("1 - -x", () => {
             const ast = parse("1 - -x");
 
             const result = print(ast);
 
             expect(result).toEqual("1 - -x");
+        });
+
+        test("1 - --x", () => {
+            const ast = parse("1 - --x");
+
+            const result = print(ast);
+
+            expect(result).toEqual("1 - --x");
         });
 
         test("1 - -2", () => {
@@ -182,6 +198,32 @@ describe("printer", () => {
             const result = print(ast);
 
             expect(result).toEqual("(x + y) / (a + b)");
+        });
+    });
+
+    describe("neg", () => {
+        test("-a", () => {
+            const ast = parse("-a");
+
+            const result = print(ast);
+
+            expect(result).toEqual("-a");
+        });
+
+        test("--a", () => {
+            const ast = parse("--a");
+
+            const result = print(ast);
+
+            expect(result).toEqual("--a");
+        });
+
+        test("----a", () => {
+            const ast = parse("----a");
+
+            const result = print(ast);
+
+            expect(result).toEqual("----a");
         });
     });
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,1 +1,2 @@
 export {parse} from "./text-parser";
+export {print} from "./printer";

--- a/packages/testing/src/printer.ts
+++ b/packages/testing/src/printer.ts
@@ -84,8 +84,10 @@ export const print = (expr: Semantic.Types.Node): string => {
                     result += " * ";
                 }
 
-                // TODO: we probably also want to wrap things like (a * b)(x * y)
-                const wrap = (wrapAll && expr.implicit) || arg.type === "add";
+                const wrap =
+                    (wrapAll && expr.implicit) ||
+                    arg.type === "add" ||
+                    (arg.type === "mul" && !arg.implicit);
                 const node = print(arg);
 
                 if (wrap) {

--- a/packages/testing/src/printer.ts
+++ b/packages/testing/src/printer.ts
@@ -1,0 +1,154 @@
+/**
+ * Converts a Semantic AST to an Editor AST.
+ */
+import * as Semantic from "@math-blocks/semantic";
+
+// TODO: Use the operator precedence numbers from text-parser to determine when
+// to add parens (or not).
+
+export const print = (expr: Semantic.Types.Node): string => {
+    switch (expr.type) {
+        case "identifier": {
+            // TODO: handle multi-character identifiers, e.g. sin, cos, etc.
+            // TODO: handle subscripts
+
+            return expr.name;
+        }
+        case "number": {
+            // How do we avoid creating a bunch of ids that we immediately
+            // throw away because this number is part of a larger expression
+            // and thus contained within a larger row?
+            return expr.value;
+        }
+        case "add": {
+            let result = "";
+
+            for (let i = 0; i < expr.args.length; i++) {
+                const arg = expr.args[i];
+                if (i > 0) {
+                    if (Semantic.isSubtraction(arg)) {
+                        result += " - ";
+                    } else {
+                        result += " + ";
+                    }
+                }
+
+                if (
+                    arg.type === "number" ||
+                    arg.type === "identifier" ||
+                    arg.type === "mul" ||
+                    arg.type === "div" ||
+                    arg.type === "pow" ||
+                    (arg.type === "neg" && !arg.subtraction)
+                ) {
+                    result += print(arg);
+                } else if (Semantic.isSubtraction(arg)) {
+                    if (
+                        arg.arg.type === "number" ||
+                        arg.arg.type === "identifier" ||
+                        arg.arg.type === "mul" ||
+                        arg.arg.type === "div" ||
+                        arg.arg.type === "pow" ||
+                        (arg.arg.type === "neg" && !arg.arg.subtraction)
+                    ) {
+                        result += print(arg.arg);
+                    } else {
+                        result += `(${print(arg.arg)})`;
+                    }
+                } else {
+                    result += `(${print(arg)})`;
+                }
+            }
+
+            return result;
+        }
+        case "mul": {
+            let result = "";
+
+            const wrapAll = expr.args.some((arg, index) => {
+                if (arg.type === "number" && index > 0) {
+                    return true;
+                }
+                if (arg.type === "neg" && index > 0) {
+                    return true;
+                }
+                if (arg.type === "div") {
+                    return true;
+                }
+                return false;
+            });
+
+            for (let i = 0; i < expr.args.length; i++) {
+                const arg = expr.args[i];
+                if (!expr.implicit && i > 0) {
+                    result += " * ";
+                }
+
+                // TODO: we probably also want to wrap things like (a * b)(x * y)
+                const wrap = (wrapAll && expr.implicit) || arg.type === "add";
+                const node = print(arg);
+
+                if (wrap) {
+                    result += `(${node})`;
+                } else {
+                    result += node;
+                }
+            }
+
+            return result;
+        }
+        case "neg": {
+            const node = print(expr.arg);
+            if (
+                expr.arg.type === "number" ||
+                expr.arg.type === "identifier" ||
+                expr.arg.type === "pow" // pow has a higher precedence
+            ) {
+                return `-${node}`;
+            } else {
+                return `-(${node})`;
+            }
+        }
+        case "div": {
+            const numerator =
+                expr.args[0].type === "add" ||
+                (expr.args[0].type === "mul" && !expr.args[0].implicit) ||
+                expr.args[0].type === "div"
+                    ? `(${print(expr.args[0])})`
+                    : print(expr.args[0]);
+            const denominator =
+                expr.args[1].type === "add" ||
+                (expr.args[1].type === "mul" && !expr.args[1].implicit) ||
+                expr.args[1].type === "div"
+                    ? `(${print(expr.args[1])})`
+                    : print(expr.args[1]);
+
+            // TODO: change the spacing depending on the parent.
+            return `${numerator} / ${denominator}`;
+        }
+        case "eq": {
+            return expr.args.map(print).join(" = ");
+        }
+        case "pow": {
+            const {base, exp} = expr;
+
+            // 'number' nodes are never negative so this is okay
+            if (base.type === "identifier" || base.type === "number") {
+                if (exp.type === "identifier" || exp.type === "number") {
+                    return `${print(base)}^${print(exp)}`;
+                } else {
+                    return `${print(base)}^(${print(exp)})`;
+                }
+            } else {
+                if (exp.type === "identifier" || exp.type === "number") {
+                    return `(${print(base)})^${print(exp)}`;
+                } else {
+                    return `(${print(base)})^(${print(exp)})`;
+                }
+            }
+        }
+        default: {
+            throw new Error(`print doesn't handle ${expr.type} nodes yet`);
+        }
+    }
+};

--- a/packages/testing/src/printer.ts
+++ b/packages/testing/src/printer.ts
@@ -102,6 +102,7 @@ export const print = (expr: Semantic.Types.Node): string => {
             if (
                 expr.arg.type === "number" ||
                 expr.arg.type === "identifier" ||
+                (expr.arg.type === "neg" && !expr.arg.subtraction) ||
                 expr.arg.type === "pow" // pow has a higher precedence
             ) {
                 return `-${node}`;


### PR DESCRIPTION
This will be used to make error messages produced by `toParseLike` and `toHaveStepsLike` easier to understand.