### PR TITLE
Simplify linear expressions

### DIFF
--- a/demo/src/step.tsx
+++ b/demo/src/step.tsx
@@ -68,18 +68,17 @@ const findParent = (
 
     // traverse needs enter and exit semantics so that we can push/pop items
     // from the stack.
-    Semantic.traverse(
-        root,
-        (n) => {
+    Semantic.traverse(root, {
+        enter: (n) => {
             if (n === node) {
                 result = stack[stack.length - 1];
             }
             stack.push(n);
         },
-        (n) => {
+        exit: (n) => {
             stack.pop();
         },
-    );
+    });
 
     return result;
 };

--- a/packages/grader/src/checks/basic-checks.ts
+++ b/packages/grader/src/checks/basic-checks.ts
@@ -15,7 +15,6 @@ export const numberCheck: Check = (prev, next, context) => {
     }
     return;
 };
-numberCheck.unfilterable = true;
 
 export const identifierCheck: Check = (prev, next, context) => {
     if (
@@ -30,7 +29,6 @@ export const identifierCheck: Check = (prev, next, context) => {
     }
     return;
 };
-numberCheck.unfilterable = true;
 
 export const exactMatch: Check = (prev, next, context) => {
     if (deepEquals(prev, next)) {
@@ -40,7 +38,6 @@ export const exactMatch: Check = (prev, next, context) => {
         };
     }
 };
-exactMatch.unfilterable = true;
 
 // General check if the args are equivalent for things with args
 // than are an array and not a tuple.
@@ -133,4 +130,3 @@ export const checkArgs: Check = (prev, next, context) => {
 
     return;
 };
-checkArgs.unfilterable = true;

--- a/packages/grader/src/step-checker.ts
+++ b/packages/grader/src/step-checker.ts
@@ -72,8 +72,8 @@ const filterMistakes = (
     const prevIds: number[] = [];
     const nextIds: number[] = [];
 
-    Semantic.traverse(prev, (node) => prevIds.push(node.id));
-    Semantic.traverse(next, (node) => nextIds.push(node.id));
+    Semantic.traverse(prev, {enter: (node) => prevIds.push(node.id)});
+    Semantic.traverse(next, {enter: (node) => nextIds.push(node.id)});
 
     // For now we only allow mistakes that reference nodes in prev or next.  If
     // a mistakes references a node in an intermediate step we ignore that for

--- a/packages/grader/src/types.ts
+++ b/packages/grader/src/types.ts
@@ -75,8 +75,6 @@ export type Check<
     // Whether or not the check should be run by reversing the prev, next params.
     // Most checks are symmetric.
     symmetric?: boolean;
-
-    unfilterable?: boolean;
 };
 
 export type HasArgs =

--- a/packages/semantic/src/__tests__/traverse.test.ts
+++ b/packages/semantic/src/__tests__/traverse.test.ts
@@ -11,7 +11,7 @@ describe("traverse", () => {
         const enter = jest.fn();
         const exit = jest.fn();
 
-        traverse(num, enter, exit);
+        traverse(num, {enter, exit});
 
         expect(enter).toHaveBeenCalledTimes(1);
         expect(enter).toHaveBeenCalledWith(num);
@@ -36,14 +36,14 @@ describe("traverse", () => {
                 },
             ],
         };
-        const cb = jest.fn();
+        const enter = jest.fn();
 
-        traverse(add, cb);
+        traverse(add, {enter});
 
-        expect(cb).toHaveBeenCalledTimes(3);
-        expect(cb).toHaveBeenCalledWith(add);
-        expect(cb).toHaveBeenCalledWith(add.args[0]);
-        expect(cb).toHaveBeenCalledWith(add.args[1]);
+        expect(enter).toHaveBeenCalledTimes(3);
+        expect(enter).toHaveBeenCalledWith(add);
+        expect(enter).toHaveBeenCalledWith(add.args[0]);
+        expect(enter).toHaveBeenCalledWith(add.args[1]);
     });
 
     it("call traverse properties", () => {
@@ -61,14 +61,14 @@ describe("traverse", () => {
                 value: "3",
             },
         };
-        const cb = jest.fn();
+        const enter = jest.fn();
 
-        traverse(power, cb);
+        traverse(power, {enter});
 
-        expect(cb).toHaveBeenCalledTimes(3);
-        expect(cb).toHaveBeenCalledWith(power);
-        expect(cb).toHaveBeenCalledWith(power.base);
-        expect(cb).toHaveBeenCalledWith(power.exp);
+        expect(enter).toHaveBeenCalledTimes(3);
+        expect(enter).toHaveBeenCalledWith(power);
+        expect(enter).toHaveBeenCalledWith(power.base);
+        expect(enter).toHaveBeenCalledWith(power.exp);
     });
 
     it("should not call cb on location", () => {
@@ -82,11 +82,101 @@ describe("traverse", () => {
                 next: 2,
             },
         };
-        const cb = jest.fn();
+        const enter = jest.fn();
 
-        traverse(num, cb);
+        traverse(num, {enter});
 
-        expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith(num);
+        expect(enter).toHaveBeenCalledTimes(1);
+        expect(enter).toHaveBeenCalledWith(num);
+    });
+
+    it("supports making changes to a node on exit", () => {
+        const power: Types.Pow = {
+            id: 0,
+            type: "pow",
+            base: {
+                id: 1,
+                type: "identifier",
+                name: "x",
+            },
+            exp: {
+                id: 2,
+                type: "number",
+                value: "3",
+            },
+        };
+
+        traverse(power, {
+            exit: (node) => {
+                if (node.type === "identifier" && node.name === "x") {
+                    return {
+                        ...node,
+                        name: "y",
+                    };
+                }
+            },
+        });
+
+        expect(power).toEqual({
+            id: 0,
+            type: "pow",
+            base: {
+                id: 1,
+                type: "identifier",
+                name: "y",
+            },
+            exp: {
+                id: 2,
+                type: "number",
+                value: "3",
+            },
+        });
+    });
+
+    it("supports making changes to an element in an array on exit", () => {
+        const sum: Types.Add = {
+            id: 0,
+            type: "add",
+            args: [
+                {
+                    id: 1,
+                    type: "identifier",
+                    name: "x",
+                },
+                {
+                    id: 2,
+                    type: "number",
+                    value: "3",
+                },
+            ],
+        };
+
+        traverse(sum, {
+            exit: (node) => {
+                if (node.type === "identifier" && node.name === "x") {
+                    return {
+                        ...node,
+                        name: "y",
+                    };
+                }
+            },
+        });
+
+        expect(sum).toEqual({
+            id: 0,
+            type: "add",
+            args: [
+                {
+                    id: 1,
+                    type: "identifier",
+                    name: "y",
+                },
+                {
+                    id: 2,
+                    type: "number",
+                    value: "3",
+                },
+            ],
+        });
     });
 });

--- a/packages/semantic/src/traverse.ts
+++ b/packages/semantic/src/traverse.ts
@@ -1,26 +1,41 @@
 import * as Types from "./types";
 
+/**
+ * Traverse the nodes in a semantic tree.
+ *
+ * Traverse supports in place mutation of nodes within the tree.  If an `exit`
+ * callback is provided that returns a value, the return value will replace
+ * the node that was passed to it.
+ */
 export const traverse = (
     node: Types.Node,
-    enter: (node: Types.Node) => void,
-    exit?: (node: Types.Node) => void,
-): void => {
-    enter(node);
-    for (const value of Object.values(node)) {
+    callbacks: {
+        enter?: (node: Types.Node) => void;
+        exit?: (node: Types.Node) => Types.Node | void;
+    },
+): Types.Node => {
+    if (callbacks.enter) {
+        callbacks.enter(node);
+    }
+    for (const [key, value] of Object.entries(node)) {
         if (Array.isArray(value)) {
             // All arrays in the tree except for Location.path contain nodes.
             // Since we never pass a Location as an arg to traverse we should
             // be okey without doing additional checks.
-            value.forEach((child) => traverse(child, enter, exit));
+            node[key] = value.map((child) => traverse(child, callbacks));
         } else if (
             typeof value === "object" &&
             value != null &&
             value.hasOwnProperty("type")
         ) {
-            traverse(value as Types.Node, enter, exit);
+            node[key] = traverse(value as Types.Node, callbacks);
         }
     }
-    if (exit) {
-        exit(node);
+    if (callbacks.exit) {
+        const result = callbacks.exit(node);
+        if (result) {
+            return result;
+        }
     }
+    return node;
 };

--- a/packages/solver/global.d.ts
+++ b/packages/solver/global.d.ts
@@ -1,0 +1,2 @@
+type OneOrMore<T> = [T, ...T[]];
+type TwoOrMore<T> = [T, T, ...T[]];

--- a/packages/solver/src/__tests__/simplify.test.ts
+++ b/packages/solver/src/__tests__/simplify.test.ts
@@ -64,6 +64,22 @@ describe("simplify", () => {
             expect(print(result)).toEqual("3x + 3");
         });
 
+        test("(1 + 2)(x + 1) -> 3x + 3", () => {
+            const ast = parse("(1 + 2)(x + 1)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("3x + 3");
+        });
+
+        test("(6 * 1/2)(x + 1) -> 3x + 3", () => {
+            const ast = parse("(6 * 1/2)(x + 1)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("3x + 3");
+        });
+
         test("3 - (x + 1) -> x + 2", () => {
             const ast = parse("3 - (x + 1)");
 

--- a/packages/solver/src/__tests__/simplify.test.ts
+++ b/packages/solver/src/__tests__/simplify.test.ts
@@ -73,17 +73,20 @@ describe("simplify", () => {
             expect(print(result)).toEqual("-1x + 2");
         });
 
-        test.skip("3(x + 2(x - 1)) -> 3(3x - 2) -> 9x - 6", () => {
+        test("3(x + 2(x - 1)) -> 3(3x - 2) -> 9x - 6", () => {
             const ast = parse("3(x + 2(x - 1))");
 
             const result = simplify(ast);
 
-            // TODO: handle nesting
-            // right now this transforms to 3x + (3)(2)(x - 1)
-            // we could add a transform to handle this but we probably want to
-            // traverse the tree structure and apply rules from the innermost
-            // expression outwards
-            expect(print(result)).toEqual("3x + 7");
+            expect(print(result)).toEqual("9x - 6");
+        });
+
+        test("(3)(3)(x) - 6 -> 9x - 6", () => {
+            const ast = parse("(3)(3)(x) - 6");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("9x - 6");
         });
 
         test("3(x + 1) + 4(x - 1) -> 7x - 1", () => {
@@ -107,8 +110,6 @@ describe("simplify", () => {
 
             const result = simplify(ast);
 
-            // We consider subtraction simpler than adding the inverse
-            // TODO: add a transform from a + -b -> a - b
             expect(print(result)).toEqual("x - 2");
         });
     });

--- a/packages/solver/src/__tests__/simplify.test.ts
+++ b/packages/solver/src/__tests__/simplify.test.ts
@@ -112,5 +112,60 @@ describe("simplify", () => {
 
             expect(print(result)).toEqual("x - 2");
         });
+
+        test("(x + 1)(x + 3) -> x^2 + 4x + 3", () => {
+            const ast = parse("(x + 1)(x + 3)");
+
+            // Ideally I'd like to show the steps as:
+            // - (x + 1)(x + 3)
+            // - (x + 1)(x) + (x + 1)(3)
+            // - (x)(x) + (1)(x) + (x)(3) + (1)(3) ... this currently missing
+            // - x^2 + x + 3x + 3
+            // - x^2 + 4x + 3
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x^2 + 4x + 3");
+        });
+
+        test.skip("(x + 1)^2 -> x^2 + 2x + 1", () => {
+            const ast = parse("(x + 1)^2");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x^2 + 2x + 1");
+        });
+
+        test("(x)(x) -> x^2", () => {
+            const ast = parse("(x)(x)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x^2");
+        });
+
+        test("(3)(3) -> 9", () => {
+            const ast = parse("(3)(3)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("9");
+        });
+
+        test("banana -> ba^3n^2", () => {
+            const ast = parse("banana");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("ba^3n^2");
+        });
+
+        test.skip("(a^2)(a^3) -> a^5", () => {
+            const ast = parse("(a^2)(a^3)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("a^5");
+        });
     });
 });

--- a/packages/solver/src/__tests__/simplify.test.ts
+++ b/packages/solver/src/__tests__/simplify.test.ts
@@ -1,0 +1,115 @@
+import {parse, print} from "@math-blocks/testing";
+
+import {simplify} from "../simplify";
+
+describe("simplify", () => {
+    describe("collect like terms", () => {
+        test("3x + 4x -> 7x", () => {
+            const ast = parse("3x + 4x");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("7x");
+        });
+
+        test("4x + -3x - 1 -> 7x - 1", () => {
+            const ast = parse("4x + -3x - 1");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x - 1");
+        });
+
+        test("4x - 3x - 1 -> 7x - 1", () => {
+            const ast = parse("4x - 3x - 1");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x - 1");
+        });
+
+        test("x + 1 + 4 -> x + 5", () => {
+            const ast = parse("x + 1 + 4");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x + 5");
+        });
+
+        // drop parens
+        test("(x + 1) + 4 -> x + 5", () => {
+            const ast = parse("(x + 1) + 4");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("x + 5");
+        });
+
+        // TODO: add test case where terms can be collected with parens
+        // e.g. 1 - (2x + 3x) -> 1 - 5x
+
+        test("3(x + 1) + 4 -> 3x + 7", () => {
+            const ast = parse("3(x + 1) + 4");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("3x + 7");
+        });
+
+        test("3(x + 1) -> 3x + 3", () => {
+            const ast = parse("3(x + 1)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("3x + 3");
+        });
+
+        test("3 - (x + 1) -> x + 2", () => {
+            const ast = parse("3 - (x + 1)");
+
+            const result = simplify(ast);
+
+            // TODO: add a transform that does -1x -> x and 1x -> x
+            expect(print(result)).toEqual("-1x + 2");
+        });
+
+        test.skip("3(x + 2(x - 1)) -> 3(3x - 2) -> 9x - 6", () => {
+            const ast = parse("3(x + 2(x - 1))");
+
+            const result = simplify(ast);
+
+            // TODO: handle nesting
+            // right now this transforms to 3x + (3)(2)(x - 1)
+            // we could add a transform to handle this but we probably want to
+            // traverse the tree structure and apply rules from the innermost
+            // expression outwards
+            expect(print(result)).toEqual("3x + 7");
+        });
+
+        test("3(x + 1) + 4(x - 1) -> 7x - 1", () => {
+            const ast = parse("3(x + 1) + 4(x - 1)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("7x - 1");
+        });
+
+        test("3x + (3)(1) + 4x + (4)(-1)", () => {
+            const ast = parse("3x + (3)(1) + 4x + (4)(-1)");
+
+            const result = simplify(ast);
+
+            expect(print(result)).toEqual("7x - 1");
+        });
+
+        test("3(x + 1) - (2x + 5) -> x - 2", () => {
+            const ast = parse("3(x + 1) - (2x + 5)");
+
+            const result = simplify(ast);
+
+            // We consider subtraction simpler than adding the inverse
+            // TODO: add a transform from a + -b -> a - b
+            expect(print(result)).toEqual("x - 2");
+        });
+    });
+});

--- a/packages/solver/src/simplify.ts
+++ b/packages/solver/src/simplify.ts
@@ -1,0 +1,56 @@
+import * as Semantic from "@math-blocks/semantic";
+
+import {
+    collectLikeTerms,
+    dropParens,
+    distribute,
+    addNegToSub,
+} from "./transforms";
+
+// There are two things going on:
+// - outer loop: simplify each side of the equation until we reach a steady state
+//   - how do we determine if a change has occurred?
+// - inner loop: traverse the AST and simplify sub-expressions
+
+type Transform = (
+    node: Semantic.Types.NumericNode,
+) => Semantic.Types.NumericNode | undefined;
+
+// TODO: instead of just returning the new node, we should provide an array of
+// steps that describe how the solution was arrived at
+export const simplify = (node: Semantic.Types.Node): Semantic.Types.Node => {
+    const tranforms: Transform[] = [
+        distribute,
+        collectLikeTerms,
+        dropParens,
+
+        // We put this last so that we don't covert 3 + -(x + 1) to 3 - (x + 1)
+        // before distributing.
+        addNegToSub,
+    ];
+
+    if (Semantic.isNumeric(node)) {
+        let current: Semantic.Types.NumericNode = node;
+
+        let count = 0;
+
+        while (count < 10) {
+            let next: Semantic.Types.NumericNode | undefined;
+            for (const transform of tranforms) {
+                next = transform(current);
+                if (next) {
+                    break;
+                }
+            }
+            if (next) {
+                current = next;
+                count++;
+            } else {
+                return current;
+            }
+        }
+    }
+
+    // If we don't know how to simplify it we return the original node
+    return node;
+};

--- a/packages/solver/src/simplify.ts
+++ b/packages/solver/src/simplify.ts
@@ -6,6 +6,7 @@ import {
     distribute,
     addNegToSub,
     evalMul,
+    mulToPower,
 } from "./transforms";
 
 type Transform = (
@@ -19,7 +20,8 @@ export const simplify = (node: Semantic.Types.Node): Semantic.Types.Node => {
         collectLikeTerms,
         dropParens,
 
-        evalMul,
+        evalMul, // we want to eval multiplication before mulToPower to avoid (3)(3) -> 3^2
+        mulToPower,
 
         // We put this last so that we don't covert 3 + -(x + 1) to 3 - (x + 1)
         // before distributing.

--- a/packages/solver/src/transforms.ts
+++ b/packages/solver/src/transforms.ts
@@ -221,3 +221,19 @@ export const addNegToSub: Transform = (node) => {
     }
     return Semantic.addTerms(newTerms);
 };
+
+export const evalMul: Transform = (node) => {
+    const factors = Semantic.getFactors(node);
+
+    const numericFactors = factors.filter(Semantic.isNumber);
+    const nonNumericFactors = factors.filter((f) => !Semantic.isNumber(f));
+
+    if (numericFactors.length > 1) {
+        const mul = Semantic.mulFactors(numericFactors);
+        const coeff = Semantic.number(evalNode(mul).toString());
+
+        return Semantic.mulFactors([coeff, ...nonNumericFactors], true);
+    }
+
+    return undefined;
+};

--- a/packages/solver/src/transforms.ts
+++ b/packages/solver/src/transforms.ts
@@ -42,21 +42,16 @@ export const collectLikeTerms = (
             ? Semantic.getFactors(arg.arg)
             : Semantic.getFactors(arg);
 
+        // TODO: maybe restrict ourselves to nodes of type "number" or "neg"?
         const numericFactors = factors.filter(Semantic.isNumber);
         const nonNumericFactors = factors.filter((f) => !Semantic.isNumber(f));
 
         if (numericFactors.length > 0) {
             // If there's a single number factor then it's the coefficient
             if (numericFactors.length === 1) {
+                // We don't have to worry about evaluating this since it should
+                // be pre-evaluated by evalMul or one of the other transforms
                 coeff = numericFactors[0];
-                if (coeff.type === "add" || coeff.type === "mul") {
-                    const originalCoeff = coeff;
-                    coeff = Semantic.number(evalNode(coeff).toString());
-                    beforeSteps.push({
-                        message: "evaluate coefficient",
-                        nodes: [originalCoeff, coeff],
-                    });
-                }
             } else {
                 // If there a multiple factors that are numbers, multiply them
                 // together and evaluate them.

--- a/packages/solver/src/transforms.ts
+++ b/packages/solver/src/transforms.ts
@@ -1,0 +1,223 @@
+import * as Semantic from "@math-blocks/semantic";
+
+import {deepEquals, evalNode} from "./util";
+import {Step} from "./types";
+
+type Transform = (
+    node: Semantic.Types.NumericNode,
+) => Semantic.Types.NumericNode | undefined;
+
+// TODO: dedupe with polynomial-checks.ts in grader
+export const collectLikeTerms = (
+    node: Semantic.Types.NumericNode,
+): Semantic.Types.NumericNode | undefined => {
+    if (node.type !== "add") {
+        return;
+    }
+
+    // Map from variable part to an array of coefficients.
+    const map = new Map<
+        Semantic.Types.NumericNode,
+        {
+            coeff: Semantic.Types.NumericNode;
+            term: Semantic.Types.NumericNode;
+        }[]
+    >();
+
+    const newTerms: Semantic.Types.NumericNode[] = [];
+    const numberTerms: Semantic.Types.NumericNode[] = [];
+
+    const beforeSteps: Step[] = [];
+
+    for (const arg of node.args) {
+        if (Semantic.isNumber(arg)) {
+            numberTerms.push(arg);
+            continue;
+        }
+
+        let coeff: Semantic.Types.NumericNode;
+        let varPart: Semantic.Types.NumericNode;
+
+        const factors = Semantic.isSubtraction(arg)
+            ? Semantic.getFactors(arg.arg)
+            : Semantic.getFactors(arg);
+
+        const numericFactors = factors.filter(Semantic.isNumber);
+        const nonNumericFactors = factors.filter((f) => !Semantic.isNumber(f));
+
+        if (numericFactors.length > 0) {
+            // If there's a single number factor then it's the coefficient
+            if (numericFactors.length === 1) {
+                coeff = numericFactors[0];
+                if (coeff.type === "add" || coeff.type === "mul") {
+                    const originalCoeff = coeff;
+                    coeff = Semantic.number(evalNode(coeff).toString());
+                    beforeSteps.push({
+                        message: "evaluate coefficient",
+                        nodes: [originalCoeff, coeff],
+                    });
+                }
+            } else {
+                // If there a multiple factors that are numbers, multiply them
+                // together and evaluate them.
+                const mul = Semantic.mulFactors(numericFactors);
+                coeff = Semantic.number(evalNode(mul).toString());
+                beforeSteps.push({
+                    message: "evaluate multiplication",
+                    nodes: [mul, coeff],
+                });
+            }
+            varPart = Semantic.mulFactors(nonNumericFactors, true);
+        } else {
+            coeff = Semantic.number("1");
+            varPart = arg;
+        }
+
+        if (Semantic.isSubtraction(arg)) {
+            coeff = Semantic.neg(coeff, true);
+        }
+
+        let key: Semantic.Types.NumericNode | undefined;
+        for (const k of map.keys()) {
+            // TODO: add an option to ignore mul.implicit
+            if (deepEquals(k, varPart)) {
+                key = k;
+            }
+        }
+        if (!key) {
+            map.set(varPart, [{coeff, term: arg}]);
+        } else {
+            map.get(key)?.push({coeff, term: arg});
+        }
+    }
+
+    for (const [k, v] of map.entries()) {
+        if (v.length > 1) {
+            // Collect common terms
+            // TODO: make this evaluation be a sub-step
+            const newCoeff = Semantic.number(
+                evalNode(
+                    Semantic.addTerms(v.map(({coeff}) => coeff)),
+                ).toString(),
+            );
+            const implicit = true;
+            if (newCoeff.value === "1") {
+                newTerms.push(
+                    Semantic.mulFactors(Semantic.getFactors(k), implicit),
+                );
+            } else {
+                newTerms.push(
+                    Semantic.mulFactors(
+                        [newCoeff, ...Semantic.getFactors(k)],
+                        implicit,
+                    ),
+                );
+            }
+        } else {
+            // Pass through unique terms
+            newTerms.push(v[0].term);
+        }
+    }
+
+    const numbers =
+        numberTerms.length > 0
+            ? [
+                  Semantic.number(
+                      evalNode(Semantic.addTerms(numberTerms)).toString(),
+                  ),
+              ]
+            : [];
+
+    // If no terms have be collected together then return early.
+    if (
+        newTerms.length === 0 ||
+        newTerms.length + numbers.length === node.args.length
+    ) {
+        return undefined;
+    }
+
+    // Place numbers at the end which is a comment convention.
+    return Semantic.addTerms([...newTerms, ...numbers]);
+};
+
+export const dropParens: Transform = (node) => {
+    const terms = Semantic.getTerms(node);
+    let changed = false;
+    const newTerms = terms.flatMap((term) => {
+        if (term.type === "add") {
+            changed = true;
+            return term.args;
+        } else {
+            return [term];
+        }
+    });
+    if (!changed) {
+        return;
+    }
+    return Semantic.addTerms(newTerms);
+};
+
+export const distribute = (
+    node: Semantic.Types.NumericNode,
+): Semantic.Types.NumericNode | undefined => {
+    const nodes = Semantic.getTerms(node);
+    let changed = false;
+    const newNodes = nodes.flatMap((node) => {
+        if (node.type === "mul") {
+            if (node.args.length === 2 && node.args[1].type === "add") {
+                const add = node.args[1];
+                const terms = add.args.map((term) => {
+                    let newTerm: Semantic.Types.NumericNode = Semantic.mul(
+                        [node.args[0], ...Semantic.getFactors(term)],
+                        node.implicit,
+                    );
+                    if (Semantic.isNumber(newTerm)) {
+                        // TODO: report this as a substep
+                        newTerm = Semantic.number(evalNode(newTerm).toString());
+                    }
+                    return newTerm;
+                }) as TwoOrMore<Semantic.Types.NumericNode>;
+                changed = true;
+                return terms;
+            }
+        } else if (node.type === "neg" && node.arg.type === "add") {
+            const add = node.arg;
+            const terms = add.args.map((term) => {
+                let newTerm: Semantic.Types.NumericNode = Semantic.mul(
+                    [Semantic.number("-1"), ...Semantic.getFactors(term)],
+                    true,
+                );
+                if (Semantic.isNumber(newTerm)) {
+                    // TODO: report this as a substep
+                    newTerm = Semantic.number(evalNode(newTerm).toString());
+                }
+                return newTerm;
+            }) as TwoOrMore<Semantic.Types.NumericNode>;
+            changed = true;
+            return terms;
+        }
+
+        return [node];
+    });
+    if (!changed) {
+        return undefined;
+    }
+    return Semantic.addTerms(newNodes);
+};
+
+export const addNegToSub: Transform = (node) => {
+    const terms = Semantic.getTerms(node);
+    let changed = false;
+    const newTerms = terms.map((term, index) => {
+        if (index > 0 && term.type === "neg" && !term.subtraction) {
+            changed = true;
+            return Semantic.neg(term.arg, true);
+        } else {
+            return term;
+        }
+    });
+    if (!changed) {
+        return undefined;
+    }
+    return Semantic.addTerms(newTerms);
+};

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -1,0 +1,7 @@
+import * as Semantic from "@math-blocks/semantic";
+
+// TODO: dedupe with grader
+export type Step = {
+    message: string;
+    nodes: [Semantic.Types.Node, Semantic.Types.Node];
+};

--- a/packages/solver/src/util.ts
+++ b/packages/solver/src/util.ts
@@ -1,0 +1,57 @@
+import Fraction from "fraction.js";
+
+import * as Semantic from "@math-blocks/semantic";
+
+const isObject = (val: unknown): val is Record<string, unknown> => {
+    return typeof val === "object" && val != null;
+};
+
+// dedupe with grader
+export const deepEquals = (a: unknown, b: unknown): boolean => {
+    if (Array.isArray(a) && Array.isArray(b)) {
+        return (
+            a.length === b.length &&
+            a.every((val, index) => deepEquals(val, b[index]))
+        );
+    } else if (isObject(a) && isObject(b)) {
+        const aKeys = Object.keys(a).filter(
+            (key) => key !== "id" && key !== "loc" && key !== "source",
+        );
+        const bKeys = Object.keys(b).filter(
+            (key) => key !== "id" && key !== "loc" && key !== "source",
+        );
+        if (aKeys.length !== bKeys.length) {
+            return false;
+        }
+        return aKeys.every(
+            (key) =>
+                Object.prototype.hasOwnProperty.call(b, key) &&
+                deepEquals(a[key], b[key]),
+        );
+    } else {
+        return a === b;
+    }
+};
+
+// TODO: dedupe with grader
+export const evalNode = (node: Semantic.Types.Node): Fraction => {
+    if (node.type === "number") {
+        return new Fraction(node.value);
+    } else if (node.type === "neg") {
+        return evalNode(node.arg).mul(new Fraction("-1"));
+    } else if (node.type === "div") {
+        return evalNode(node.args[0]).div(evalNode(node.args[1]));
+    } else if (node.type === "add") {
+        return node.args.reduce(
+            (sum, term) => sum.add(evalNode(term)),
+            new Fraction("0"),
+        );
+    } else if (node.type === "mul") {
+        return node.args.reduce(
+            (sum, factor) => sum.mul(evalNode(factor)),
+            new Fraction("1"),
+        );
+    } else {
+        throw new Error(`cannot parse a number from ${node.type} node`);
+    }
+};

--- a/packages/solver/tsconfig.json
+++ b/packages/solver/tsconfig.json
@@ -3,5 +3,9 @@
     "compilerOptions": {
       "outDir": "../../out/solver",
       "rootDir": "."
-    }
+    },
+    "references": [
+      {"path": "../semantic"},
+      {"path": "../testing"}
+    ]
   }

--- a/packages/testing/src/__tests__/printer.test.ts
+++ b/packages/testing/src/__tests__/printer.test.ts
@@ -180,6 +180,14 @@ describe("printer", () => {
 
             expect(result).toEqual("1 * 2 * 3");
         });
+
+        test("a(b(c + d))", () => {
+            const ast = parse("a(b(c + d))");
+
+            const result = print(ast);
+
+            expect(result).toEqual("a(b(c + d))");
+        });
     });
 
     describe("div", () => {

--- a/packages/testing/src/printer.ts
+++ b/packages/testing/src/printer.ts
@@ -87,7 +87,8 @@ export const print = (expr: Semantic.Types.Node): string => {
                 const wrap =
                     (wrapAll && expr.implicit) ||
                     arg.type === "add" ||
-                    (arg.type === "mul" && !arg.implicit);
+                    (arg.type === "mul" && !arg.implicit) ||
+                    (expr.implicit && arg.type === "mul" && arg.implicit);
                 const node = print(arg);
 
                 if (wrap) {


### PR DESCRIPTION
This PR adds a `simplify` function to the new `@math-blocks/solver` package.  This function can only simplify linear expressions.  In a future PR we'll add a function to solve linear equations.