### PR TITLE
Change precedence of negative sign to be lower

### DIFF
--- a/packages/editor-parser/src/__tests__/editor-parser.test.ts
+++ b/packages/editor-parser/src/__tests__/editor-parser.test.ts
@@ -408,7 +408,7 @@ describe("EditorParser", () => {
         `);
     });
 
-    it("negation is higher precedence than implicit multiplication", () => {
+    it("negation is lower precedence than implicit multiplication", () => {
         // -ab
         const tokens = [
             Lexer.minus(location([], 0, 1)),
@@ -418,11 +418,7 @@ describe("EditorParser", () => {
 
         const ast = parser.parse(tokens);
 
-        expect(ast).toMatchInlineSnapshot(`
-            (mul.imp
-              (neg a)
-              b)
-        `);
+        expect(ast).toMatchInlineSnapshot(`(neg (mul.imp a b))`);
     });
 
     it("negation can be on individual factors when wrapped in parens", () => {
@@ -780,6 +776,48 @@ describe("EditorParser", () => {
             (mul.imp
               (root :radicand 2 :index 2)
               a)
+        `);
+    });
+
+    it("-1(a + b)", () => {
+        const tokens = [
+            Lexer.minus(location([], 0, 1)),
+            Lexer.number("1", location([], 1, 2)),
+            Lexer.lparens(location([], 2, 3)),
+            Lexer.identifier("a", location([], 3, 4)),
+            Lexer.plus(location([], 4, 5)),
+            Lexer.identifier("b", location([], 5, 6)),
+            Lexer.rparens(location([], 6, 7)),
+        ];
+
+        const ast = parser.parse(tokens);
+
+        expect(ast).toMatchInlineSnapshot(`
+            (neg (mul.imp
+              1
+              (add a b)))
+        `);
+    });
+
+    it("(-1)(a + b)", () => {
+        const tokens = [
+            Lexer.lparens(location([], 0, 1)),
+            Lexer.minus(location([], 1, 2)),
+            Lexer.number("1", location([], 2, 3)),
+            Lexer.rparens(location([], 3, 4)),
+            Lexer.lparens(location([], 4, 5)),
+            Lexer.identifier("a", location([], 5, 6)),
+            Lexer.plus(location([], 6, 7)),
+            Lexer.identifier("b", location([], 7, 8)),
+            Lexer.rparens(location([], 8, 9)),
+        ];
+
+        const ast = parser.parse(tokens);
+
+        expect(ast).toMatchInlineSnapshot(`
+            (mul.imp
+              (neg 1)
+              (add a b))
         `);
     });
 });

--- a/packages/editor-parser/src/editor-parser.ts
+++ b/packages/editor-parser/src/editor-parser.ts
@@ -363,11 +363,11 @@ const getOpPrecedence = (op: Operator): number => {
             return 3;
         case "mul.exp":
             return 5;
-        case "div":
+        case "div": // this is to encourage wrapping fractions in parens before a negative
             return 6;
-        case "mul.imp":
-            return 7;
         case "neg":
+            return 7;
+        case "mul.imp":
             return 8;
         case "supsub":
             return 10;

--- a/packages/grader/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/grader/src/checks/__tests__/axiom-checks.test.ts
@@ -456,15 +456,17 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
             expect(result).toHaveMessages([
+                "move negation inside multiplication",
                 "distribution",
                 "move negation out of multiplication",
                 "subtracting is the same as adding the inverse",
             ]);
 
             expect(result).toHaveStepsLike([
-                ["-2(x + y)", "-2x + -2y"],
-                ["-2x + -2y", "-2x + -(2y)"],
-                ["-2x + -(2y)", "-2x - 2y"],
+                ["-2(x + y)", "(-2)(x + y)"],
+                ["(-2)(x + y)", "(-2)(x) + (-2)(y)"],
+                ["(-2)(x) + (-2)(y)", "-2x + -2y"],
+                ["-2x + -2y", "-2x - 2y"],
             ]);
         });
 
@@ -505,23 +507,25 @@ describe("Axiom checks", () => {
             expect(result).toBeTruthy();
             expect(result).toHaveMessages([
                 "subtracting is the same as adding the inverse",
-                "move negation inside multiplication",
             ]);
 
-            expect(result).toHaveStepsLike([
-                ["1 - 2(x + y)", "1 + -(2(x + y))"],
-                ["-(2(x + y))", "-2(x +y)"],
-            ]);
+            expect(result).toHaveStepsLike([["1 - 2(x + y)", "1 + -2(x + y)"]]);
         });
 
         it("1 + (-2)(x + y) -> 1 + -2x + -2y", () => {
             const result = checkStep("1 + -2(x + y)", "1 + -2x + -2y");
 
             expect(result).toBeTruthy();
-            expect(result).toHaveMessages(["distribution"]);
+            expect(result).toHaveMessages([
+                "move negation inside multiplication",
+                "distribution",
+                "move negation out of multiplication",
+            ]);
 
             expect(result).toHaveStepsLike([
-                ["1 + -2(x + y)", "1 + -2x + -2y"],
+                ["1 + -2(x + y)", "1 + (-2)(x + y)"],
+                ["1 + (-2)(x + y)", "1 + (-2)(x) + (-2)(y)"],
+                ["1 + (-2)(x) + (-2)(y)", "1 + -2x + -2y"],
             ]);
         });
 
@@ -530,7 +534,11 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
 
-            expect(result).toHaveMessages(["distribution"]);
+            expect(result).toHaveMessages([
+                "move negation inside multiplication",
+                "distribution",
+                "move negation out of multiplication",
+            ]);
         });
 
         it("1 - (x + y) -> 1 - x - y", () => {
@@ -584,8 +592,10 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
             expect(result).toHaveMessages([
+                "move negation inside multiplication",
                 "distribution",
                 "multiplying two negatives is a positive",
+                "move negation out of multiplication",
             ]);
         });
 
@@ -657,21 +667,21 @@ describe("Axiom checks", () => {
                 "1 + -(x + y) + -(a + b)",
             );
             expect(result.steps[2].nodes[1]).toParseLike(
-                "1 + -1(x + y) + -1(a + b)",
+                "1 + (-1)(x + y) + (-1)(a + b)",
             );
 
             expect(result.steps[3].nodes[0]).toParseLike(
-                "1 + -1(x + y) + -1(a + b)",
+                "1 + (-1)(x + y) + (-1)(a + b)",
             );
             expect(result.steps[3].nodes[1]).toParseLike(
-                "1 + -1x + -1y + -1(a + b)",
+                "1 + (-1)(x) + (-1)(y) + (-1)(a + b)",
             );
 
             expect(result.steps[4].nodes[0]).toParseLike(
-                "1 + -1x + -1y + -1(a + b)",
+                "1 + (-1)(x) + (-1)(y) + (-1)(a + b)",
             );
             expect(result.steps[4].nodes[1]).toParseLike(
-                "1 + -1x + -1y + -1a + -1b",
+                "1 + (-1)(x) + (-1)(y) + (-1)(a) + (-1)(b)",
             );
 
             // TODO: finish writing this test
@@ -882,13 +892,15 @@ describe("Axiom checks", () => {
                 "move negation inside multiplication",
                 "multiplication with identity",
                 "factoring",
+                "move negation out of multiplication",
             ]);
 
             expect(result).toHaveStepsLike([
                 ["-a - ab", "-a + -(ab)"],
                 ["-a + -(ab)", "-a + (-a)(b)"],
                 ["-a", "(-a)(1)"],
-                ["(-a)(1) + (-a)(b)", "-a(1 + b)"],
+                ["(-a)(1) + (-a)(b)", "(-a)(1 + b)"],
+                ["(-a)(1 + b)", "-a(1 + b)"],
             ]);
         });
 
@@ -897,6 +909,7 @@ describe("Axiom checks", () => {
 
             expect(result).toBeTruthy();
             expect(result).toHaveMessages([
+                "move negation inside multiplication",
                 "distribution",
                 "multiplication with identity",
                 "move negation out of multiplication",
@@ -904,7 +917,8 @@ describe("Axiom checks", () => {
             ]);
 
             expect(result).toHaveStepsLike([
-                ["-a(1 + b)", "(-a)(1) + (-a)(b)"],
+                ["-a(1 + b)", "(-a)(1 + b)"],
+                ["(-a)(1 + b)", "(-a)(1) + (-a)(b)"],
                 ["(-a)(1)", "-a"],
                 ["-a + (-a)(b)", "-a + -(ab)"],
                 ["-a + -(ab)", "-a - ab"],

--- a/packages/grader/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/grader/src/checks/__tests__/integer-checks.test.ts
@@ -104,13 +104,9 @@ describe("Integer checks", () => {
         expect(result).toBeTruthy();
         expect(result).toHaveMessages([
             "subtracting is the same as adding the inverse",
-            "move negation inside multiplication",
         ]);
 
-        expect(result).toHaveStepsLike([
-            ["a - bc", "a + -(bc)"],
-            ["-(bc)", "-bc"],
-        ]);
+        expect(result).toHaveStepsLike([["a - bc", "a + -(bc)"]]);
     });
 
     it("a + -b -> a - b", () => {
@@ -278,21 +274,20 @@ describe("Integer checks", () => {
 
         expect(result).toBeTruthy();
         expect(result).toHaveMessages([
-            "move negation out of multiplication",
             "subtracting is the same as adding the inverse",
         ]);
 
-        expect(result).toHaveStepsLike([
-            ["-xy", "-(xy)"],
-            ["1 + -(xy)", "1 - xy"],
-        ]);
+        expect(result).toHaveStepsLike([["1 + -(xy)", "1 - xy"]]);
     });
 
     it("(x)(y)(-z) -> -xyz", () => {
         const result = checkStep("(x)(y)(-z)", "-xyz");
 
         expect(result).toBeTruthy();
-        expect(result).toHaveMessages(["move negative to first factor"]);
+        expect(result).toHaveMessages([
+            "move negative to first factor",
+            "move negation out of multiplication",
+        ]);
     });
 
     it("(x)(-y)(-z) -> xyz", () => {
@@ -359,9 +354,9 @@ describe("Integer checks", () => {
         ]);
 
         expect(result).toHaveStepsLike([
-            ["-(a + b)", "-1(a + b)"],
-            ["-1(a + b)", "-1a + -1b"],
-            ["-1a + -1b", "-a + -b"],
+            ["-(a + b)", "(-1)(a + b)"],
+            ["(-1)(a + b)", "(-1)(a) + (-1)(b)"],
+            ["(-1)(a) + (-1)(b)", "-a + -b"],
         ]);
     });
 
@@ -377,9 +372,9 @@ describe("Integer checks", () => {
         ]);
 
         expect(result).toHaveStepsLike([
-            ["-a + -b", "-1a + -1b"],
-            ["-1a + -1b", "-1(a + b)"],
-            ["-1(a + b)", "-(a + b)"],
+            ["-a + -b", "(-1)(a) + (-1)(b)"],
+            ["(-1)(a) + (-1)(b)", "(-1)(a + b)"],
+            ["(-1)(a + b)", "-(a + b)"],
         ]);
     });
 });

--- a/packages/grader/src/checks/__tests__/polynomial-checks.test.ts
+++ b/packages/grader/src/checks/__tests__/polynomial-checks.test.ts
@@ -28,6 +28,7 @@ describe("polynomial checks", () => {
 
         expect(result).toBeTruthy();
         expect(result).toHaveMessages([
+            "move negation inside multiplication",
             "collect like terms",
             "evaluation of addition",
         ]);

--- a/packages/grader/src/checks/test-util.ts
+++ b/packages/grader/src/checks/test-util.ts
@@ -35,7 +35,7 @@ export const checkMistake = (prev: string, next: string): Mistake[] => {
 };
 
 const myParse = (text: string): Semantic.Types.Node => {
-    const node = Editor.print(parse(text)) as Editor.Row;
+    const node = Editor.print(parse(text), true) as Editor.Row;
     return _parse(node);
 };
 
@@ -118,7 +118,8 @@ export const toHaveStepsLike = (
                     .map(({step, node, received, expected}) => {
                         return `step ${step}, node ${node}: expected ${print(
                             expected,
-                        )} but received ${print(received)}`;
+                            true,
+                        )} but received ${print(received, true)}`;
                     })
                     .join("\n"),
             pass: false,

--- a/packages/solver/src/__tests__/simplify.test.ts
+++ b/packages/solver/src/__tests__/simplify.test.ts
@@ -58,12 +58,33 @@ describe("simplify", () => {
             expect(print(result)).toEqual("a - 3x");
         });
 
-        test("2x - -3x -> 5x", () => {
-            const ast = parse("2x - -3x");
+        // TODO: add transform that converts (neg (mul 2 x)) to (mul (neg 2 x))
+        // or update how deal directly with the first and then add a transform that
+        // converts (mul (neg 2) x) to (neg (mul 2 x)).  The second option seems easier.
+        test("2x - (-3)(x) -> 5x", () => {
+            const ast = parse("2x - (-3)(x)");
 
             const result: Node = simplify(ast) ?? ast;
 
             expect(print(result)).toEqual("5x");
+        });
+
+        test("2x - -3x -> 5x", () => {
+            const ast = parse("2x - -3x");
+            console.log(JSON.stringify(ast, null, 4));
+
+            const result: Node = simplify(ast) ?? ast;
+
+            expect(print(result)).toEqual("5x");
+        });
+
+        test("5x + -3x -> 2x", () => {
+            const ast = parse("5x + -3x");
+            console.log(JSON.stringify(ast, null, 4));
+
+            const result: Node = simplify(ast) ?? ast;
+
+            expect(print(result)).toEqual("2x");
         });
 
         test("4x + -3x - 1 -> 7x - 1", () => {

--- a/packages/testing/src/__tests__/printer.test.ts
+++ b/packages/testing/src/__tests__/printer.test.ts
@@ -109,12 +109,56 @@ describe("printer", () => {
             expect(result).toEqual("(x)(2)(y)");
         });
 
+        // This and the next test both have the same result intentionally.  It
+        // is common for the result to be interpreted in both ways.  It doesn't
+        // make sense to produce multiple parse trees for this form.  Instead
+        // we interpret either in the same way when printing in order to provide
+        // users with a representation they're familiar with.
+        // (neg (mul 2 x y)) -> -2xy
         test("-2xy", () => {
             const ast = parse("-2xy");
 
             const result = print(ast);
 
             expect(result).toEqual("-2xy");
+        });
+
+        // TODO: figure out how to store (-2)(x)(y) when that's what someone has
+        // actually typed in.
+        // STOPSHIP: have an option we can pass to the print to produce the same
+        // output as the input and use it in the matcher so that we aren't
+        // confused when writing/debugging tests.
+        // (mul (neg 2) x y) -> -2xy
+        test("(-2)(x)(y)", () => {
+            const ast = parse("(-2)(x)(y)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("-2xy");
+        });
+
+        test("(-2)(x)(y), oneToOne = true", () => {
+            const ast = parse("(-2)(x)(y)");
+
+            const result = print(ast, true);
+
+            expect(result).toEqual("(-2)(x)(y)");
+        });
+
+        test("(-1)(a + b) w/ oneToOne true", () => {
+            const ast = parse("(-1)(a + b)");
+
+            const result = print(ast, true);
+
+            expect(result).toEqual("(-1)(a + b)");
+        });
+
+        test("(-1)(a + b) w/ oneToOne false", () => {
+            const ast = parse("(-1)(a + b)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("-1(a + b)");
         });
 
         test("(x)(-2)(y)", () => {
@@ -230,6 +274,14 @@ describe("printer", () => {
             const result = print(ast);
 
             expect(result).toEqual("(x + y) / (a + b)");
+        });
+
+        test("-a / b", () => {
+            const ast = parse("-(a / b)");
+
+            const result = print(ast);
+
+            expect(result).toEqual("-(a / b)");
         });
     });
 

--- a/packages/testing/src/__tests__/text-parser.test.ts
+++ b/packages/testing/src/__tests__/text-parser.test.ts
@@ -87,14 +87,26 @@ describe("TextParser", () => {
         expect(ast).toMatchInlineSnapshot(`(mul.imp a b)`);
     });
 
-    it("negation is higher precedence than implicit multplication", () => {
+    it("negation is lower precedence than implicit multplication", () => {
         const ast = parse("-ab");
 
+        expect(ast).toMatchInlineSnapshot(`(neg (mul.imp a b))`);
+    });
+
+    it("negation is higher precedence than division", () => {
+        const ast = parse("-a / b");
+
         expect(ast).toMatchInlineSnapshot(`
-            (mul.imp
+            (div
               (neg a)
               b)
         `);
+    });
+
+    it("negation is higher precedence than division (w/ parens)", () => {
+        const ast = parse("-(a / b)");
+
+        expect(ast).toMatchInlineSnapshot(`(neg (div a b))`);
     });
 
     // TODO: document this in the semantic README.md
@@ -115,9 +127,7 @@ describe("TextParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (add
               (mul.imp 7 x)
-              (mul.imp
-                (neg 5)
-                x))
+              (neg (mul.imp 5 x)))
         `);
     });
 

--- a/packages/testing/src/text-parser.ts
+++ b/packages/testing/src/text-parser.ts
@@ -234,11 +234,11 @@ const getOpPrecedence = (op: Operator): number => {
             return 3;
         case "mul.exp":
             return 5;
-        case "div":
+        case "div": // this is to encourage wrapping fractions in parens before a negative
             return 6;
-        case "mul.imp":
-            return 7;
         case "neg":
+            return 7;
+        case "mul.imp":
             return 8;
         case "caret":
             return 10;


### PR DESCRIPTION
This make things a bit more consistent in terms of how they're parsed, e.g.
```
a + -b -> (add a (neg b))
1 + -xy -> (add 1 (neg (mul x y)))
2 + -2x -> (add 1 (neg (mul 2 x)))
```
