### PR TITLE
remove schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "start": "webpack-dev-server --open",
     "prettier": "pretty-quick --stage",
     "test": "jest",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "coverage": "jest --coverage",
     "lint": "eslint 'packages/**/*.{ts,tsx}' 'demo/src/*.{ts,tsx}'",
     "start-storybook": "start-storybook -p 6006",

--- a/packages/editor-parser/src/editor-parser.ts
+++ b/packages/editor-parser/src/editor-parser.ts
@@ -1,6 +1,3 @@
-import Ajv from "ajv";
-
-import {semanticSchema} from "@math-blocks/schema";
 import * as Editor from "@math-blocks/editor";
 import * as Parser from "@math-blocks/parser-factory";
 import * as Semantic from "@math-blocks/semantic";
@@ -379,9 +376,6 @@ const editorParser = Parser.parserFactory<Token, Parser.Types.Node, Operator>(
     EOL,
 );
 
-const ajv = new Ajv({allErrors: true, verbose: true}); // options can be passed, e.g. {allErrors: true}
-const validate = ajv.compile(semanticSchema);
-
 // WARNING: This function mutates `node`.
 const removeExcessParens = (node: Semantic.Types.Node): Semantic.Types.Node => {
     const path: Semantic.Types.Node[] = [];
@@ -425,10 +419,6 @@ const removeExcessParens = (node: Semantic.Types.Node): Semantic.Types.Node => {
 export const parse = (input: Editor.Row): Semantic.Types.Node => {
     const tokenRow = Lexer.lexRow(input);
     const result = editorParser.parse(tokenRow.children);
-
-    if (!validate(result)) {
-        throw new Error("Invalid semantic structure");
-    }
 
     return removeExcessParens(result as Semantic.Types.Node);
 };

--- a/packages/testing/src/text-parser.ts
+++ b/packages/testing/src/text-parser.ts
@@ -1,6 +1,3 @@
-import Ajv from "ajv";
-
-import {semanticSchema} from "@math-blocks/schema";
 import * as Parser from "@math-blocks/parser-factory";
 import * as Semantic from "@math-blocks/semantic";
 
@@ -252,9 +249,6 @@ const textParser = Parser.parserFactory<Token, Node, Operator>(
     EOL,
 );
 
-const ajv = new Ajv({allErrors: true, verbose: true}); // options can be passed, e.g. {allErrors: true}
-const validate = ajv.compile(semanticSchema);
-
 // WARNING: This function mutates `node`.
 const removeExcessParens = (node: Semantic.Types.Node): Semantic.Types.Node => {
     const path: Semantic.Types.Node[] = [];
@@ -297,10 +291,5 @@ const removeExcessParens = (node: Semantic.Types.Node): Semantic.Types.Node => {
 
 export const parse = (input: string): Semantic.Types.Node => {
     const result = textParser.parse(lex(input));
-
-    if (!validate(result)) {
-        throw new Error("Invalid semantic structure");
-    }
-
     return removeExcessParens(result as Semantic.Types.Node);
 };


### PR DESCRIPTION
The current tooling makes it too slow to be used.  For some reason it takes `ajv` 30s to validate the parse tree from `3(x + 2(x - 1))`.  Not sure why that's the case, but it's unacceptable.