### PR TITLE
Collect sub-steps when calling `solve`, fixes #253

### DIFF
--- a/packages/solver/src/simplify/types.ts
+++ b/packages/solver/src/simplify/types.ts
@@ -1,13 +1,10 @@
 import * as Semantic from "@math-blocks/semantic";
 
-export type Step = {
-    message: string;
-    before: Semantic.Types.Node;
-    after: Semantic.Types.Node;
-    substeps: Step[];
-};
+import {Step} from "../types";
 
 export type Transform = (
     node: Semantic.Types.Node,
     path: Semantic.Types.Node[],
 ) => Step | undefined;
+
+export {Step};

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -4,10 +4,7 @@ import {parse, print} from "@math-blocks/testing";
 import {solve as _solve} from "../solve";
 import {Step} from "../types";
 
-const solve = (
-    node: Semantic.Types.Node,
-    ident: Semantic.Types.Ident,
-): Step => {
+const solve = (node: Semantic.Types.Eq, ident: Semantic.Types.Ident): Step => {
     const result = _solve(node, ident);
     if (!result) {
         throw new Error("no step returned");
@@ -15,10 +12,14 @@ const solve = (
     return result;
 };
 
+const parseEq = (input: string): Semantic.Types.Eq => {
+    return parse(input) as Semantic.Types.Eq;
+};
+
 describe("solve", () => {
     describe("linear equations", () => {
         test("2x + 3x = 7 - 4", () => {
-            const ast = parse("2x + 3x = 7 - 4");
+            const ast = parseEq("2x + 3x = 7 - 4");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -50,7 +51,7 @@ describe("solve", () => {
         });
 
         test("2x = 7 + 3x", () => {
-            const ast = parse("2x = 7 + 3x");
+            const ast = parseEq("2x = 7 + 3x");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -64,7 +65,7 @@ describe("solve", () => {
         });
 
         test("-x / -1 = -7", () => {
-            const ast = parse("-x / -1 = -7");
+            const ast = parseEq("-x / -1 = -7");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -75,7 +76,7 @@ describe("solve", () => {
         });
 
         test("7 + 3x = 2x", () => {
-            const ast = parse("7 + 3x = 2x");
+            const ast = parseEq("7 + 3x = 2x");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -87,7 +88,7 @@ describe("solve", () => {
         });
 
         test("2x + 5 = 7 + 3x", () => {
-            const ast = parse("2x + 5 = 7 + 3x");
+            const ast = parseEq("2x + 5 = 7 + 3x");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -101,7 +102,7 @@ describe("solve", () => {
         });
 
         test("2x + 1 = 7", () => {
-            const ast = parse("2x + 1 = 7");
+            const ast = parseEq("2x + 1 = 7");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -114,7 +115,7 @@ describe("solve", () => {
         });
 
         test("7 = 2x + 1", () => {
-            const ast = parse("7 = 2x + 1");
+            const ast = parseEq("7 = 2x + 1");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -127,7 +128,7 @@ describe("solve", () => {
         });
 
         test("x + 1 = -2x + 5", () => {
-            const ast = parse("x + 1 = -2x + 5");
+            const ast = parseEq("x + 1 = -2x + 5");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -141,7 +142,7 @@ describe("solve", () => {
         });
 
         test("-x + 1 = -2x + 5", () => {
-            const ast = parse("-x + 1 = -2x + 5");
+            const ast = parseEq("-x + 1 = -2x + 5");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -153,7 +154,7 @@ describe("solve", () => {
         });
 
         test("2 - x = 5", () => {
-            const ast = parse("2 - x = 5");
+            const ast = parseEq("2 - x = 5");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -166,7 +167,7 @@ describe("solve", () => {
         });
 
         test("2 - 2x = 5", () => {
-            const ast = parse("2 - 2x = 5");
+            const ast = parseEq("2 - 2x = 5");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -179,7 +180,7 @@ describe("solve", () => {
         });
 
         test("2 - x = 5 - 3x", () => {
-            const ast = parse("2 - x = 5 - 3x");
+            const ast = parseEq("2 - x = 5 - 3x");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -193,7 +194,7 @@ describe("solve", () => {
         });
 
         test("-x + 3x = 3", () => {
-            const ast = parse("-x + 3x = 3");
+            const ast = parseEq("-x + 3x = 3");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -206,7 +207,7 @@ describe("solve", () => {
         });
 
         test("2x + 3 = 3", () => {
-            const ast = parse("2x + 3 = 3");
+            const ast = parseEq("2x + 3 = 3");
 
             const result = solve(ast, Semantic.identifier("x"));
 
@@ -215,6 +216,18 @@ describe("solve", () => {
                 "move terms to one side",
                 "divide both sides",
                 "simplify both sides",
+            ]);
+        });
+
+        test("3 = 2x", () => {
+            const ast = parseEq("3 = 2x");
+
+            const result = solve(ast, Semantic.identifier("x"));
+
+            expect(print(result.after)).toEqual("3 / 2 = x");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "divide both sides",
+                "simplify the right hand side",
             ]);
         });
     });

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -28,6 +28,25 @@ describe("solve", () => {
                 "divide both sides",
                 "simplify the left hand side",
             ]);
+            expect(
+                result.substeps[0].substeps.map((step) => step.message),
+            ).toEqual([
+                "simplify the left hand side",
+                "simplify the right hand side",
+            ]);
+            expect(
+                result.substeps[0].substeps[0].substeps.map(
+                    (step) => step.message,
+                ),
+            ).toEqual(["collect like terms"]);
+            expect(
+                result.substeps[0].substeps[1].substeps.map(
+                    (step) => step.message,
+                ),
+            ).toEqual(["evaluate addition"]);
+            expect(
+                result.substeps[2].substeps.map((step) => step.message),
+            ).toEqual(["reduce fraction"]);
         });
 
         test("2x = 7 + 3x", () => {

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -1,122 +1,132 @@
 import * as Semantic from "@math-blocks/semantic";
 import {parse, print} from "@math-blocks/testing";
 
-import {solve} from "../solve";
+import {solve as _solve} from "../solve";
+import {Step} from "../types";
 
-type Node = Semantic.Types.Node;
+const solve = (
+    node: Semantic.Types.Node,
+    ident: Semantic.Types.Ident,
+): Step => {
+    const result = _solve(node, ident);
+    if (!result) {
+        throw new Error("no step returned");
+    }
+    return result;
+};
 
 describe("solve", () => {
     describe("linear equations", () => {
         test("2x + 3x = 7 - 4", () => {
             const ast = parse("2x + 3x = 7 - 4");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 3 / 5");
+            expect(print(result.after)).toEqual("x = 3 / 5");
         });
 
         test("2x = 7 + 3x", () => {
             const ast = parse("2x = 7 + 3x");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = -7");
+            expect(print(result.after)).toEqual("x = -7");
         });
 
         test("-x / -1 = -7", () => {
             const ast = parse("-x / -1 = -7");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = -7");
+            expect(print(result.after)).toEqual("x = -7");
         });
 
         test("7 + 3x = 2x", () => {
             const ast = parse("7 + 3x = 2x");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = -7");
+            expect(print(result.after)).toEqual("x = -7");
         });
 
         test("2x + 5 = 7 + 3x", () => {
             const ast = parse("2x + 5 = 7 + 3x");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = -2");
+            expect(print(result.after)).toEqual("x = -2");
         });
 
         test("2x + 1 = 7", () => {
             const ast = parse("2x + 1 = 7");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 3");
+            expect(print(result.after)).toEqual("x = 3");
         });
 
         test("7 = 2x + 1", () => {
             const ast = parse("7 = 2x + 1");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("3 = x");
+            expect(print(result.after)).toEqual("3 = x");
         });
 
         test("x + 1 = -2x + 5", () => {
             const ast = parse("x + 1 = -2x + 5");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 4 / 3");
+            expect(print(result.after)).toEqual("x = 4 / 3");
         });
 
         test("-x + 1 = -2x + 5", () => {
             const ast = parse("-x + 1 = -2x + 5");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 4");
+            expect(print(result.after)).toEqual("x = 4");
         });
 
         test("2 - x = 5", () => {
             const ast = parse("2 - x = 5");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = -3");
+            expect(print(result.after)).toEqual("x = -3");
         });
 
         test("2 - 2x = 5", () => {
             const ast = parse("2 - 2x = 5");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = -(3 / 2)");
+            expect(print(result.after)).toEqual("x = -(3 / 2)");
         });
 
         test("2 - x = 5 - 3x", () => {
             const ast = parse("2 - x = 5 - 3x");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 3 / 2");
+            expect(print(result.after)).toEqual("x = 3 / 2");
         });
 
         test("-x + 3x = 3", () => {
             const ast = parse("-x + 3x = 3");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 3 / 2");
+            expect(print(result.after)).toEqual("x = 3 / 2");
         });
 
         test("2x + 3 = 3", () => {
             const ast = parse("2x + 3 = 3");
 
-            const result: Node = solve(ast, Semantic.identifier("x"));
+            const result = solve(ast, Semantic.identifier("x"));
 
-            expect(print(result)).toEqual("x = 0");
+            expect(print(result.after)).toEqual("x = 0");
         });
     });
 });

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -23,6 +23,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 3 / 5");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "simplify both sides",
+                "divide both sides",
+                "simplify the left hand side",
+            ]);
         });
 
         test("2x = 7 + 3x", () => {
@@ -31,6 +36,12 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = -7");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "simplify the left hand side",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
 
         test("-x / -1 = -7", () => {
@@ -39,6 +50,9 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = -7");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "simplify the left hand side",
+            ]);
         });
 
         test("7 + 3x = 2x", () => {
@@ -47,6 +61,10 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = -7");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "simplify the left hand side",
+            ]);
         });
 
         test("2x + 5 = 7 + 3x", () => {
@@ -55,6 +73,12 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = -2");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "simplify both sides",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
 
         test("2x + 1 = 7", () => {
@@ -63,6 +87,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 3");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
 
         test("7 = 2x + 1", () => {
@@ -71,6 +100,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("3 = x");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
 
         test("x + 1 = -2x + 5", () => {
@@ -79,6 +113,12 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 4 / 3");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "simplify both sides",
+                "divide both sides",
+                "simplify the left hand side",
+            ]);
         });
 
         test("-x + 1 = -2x + 5", () => {
@@ -87,6 +127,10 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 4");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "simplify both sides",
+            ]);
         });
 
         test("2 - x = 5", () => {
@@ -95,6 +139,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = -3");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
 
         test("2 - 2x = 5", () => {
@@ -103,6 +152,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = -(3 / 2)");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
 
         test("2 - x = 5 - 3x", () => {
@@ -111,6 +165,12 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 3 / 2");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "simplify both sides",
+                "divide both sides",
+                "simplify the left hand side",
+            ]);
         });
 
         test("-x + 3x = 3", () => {
@@ -119,6 +179,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 3 / 2");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "simplify the left hand side",
+                "divide both sides",
+                "simplify the left hand side",
+            ]);
         });
 
         test("2x + 3 = 3", () => {
@@ -127,6 +192,11 @@ describe("solve", () => {
             const result = solve(ast, Semantic.identifier("x"));
 
             expect(print(result.after)).toEqual("x = 0");
+            expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
+                "divide both sides",
+                "simplify both sides",
+            ]);
         });
     });
 });

--- a/packages/solver/src/solve/solve.ts
+++ b/packages/solver/src/solve/solve.ts
@@ -3,14 +3,24 @@ import * as Semantic from "@math-blocks/semantic";
 import {divBothSides} from "./transforms/div-both-sides";
 import {moveTermsToOneSide} from "./transforms/move-terms-to-one-side";
 import {simplifyBothSides} from "./transforms/simplify-both-sides";
-import {Transform} from "./types";
+import {Step, Transform} from "./types";
 
-export const solve = (
-    node: Semantic.Types.Node,
-    ident: Semantic.Types.Ident,
-): Semantic.Types.Node => {
+/**
+ * Solve an equation for a given variable.
+ *
+ * Handles the following types of equations:
+ * - linear
+ *
+ * TODO:
+ * - linear inequality
+ * - quadratic
+ *
+ * @param node the equation (or system of equations) being solved
+ * @param ident the variable being solved for
+ */
+export const solve: Transform = (node, ident) => {
     if (node.type !== "eq") {
-        return node;
+        return undefined;
     }
 
     const transforms: Transform[] = [
@@ -19,27 +29,31 @@ export const solve = (
         divBothSides,
     ];
 
+    const substeps: Step[] = [];
     let current = node as Semantic.Types.Node;
-    for (const transform of transforms) {
-        const next = transform(current, ident);
-        if (next) {
-            current = next.after;
+    for (let i = 0; i < 10; i++) {
+        let changed = false;
+        for (const transform of transforms) {
+            const next = transform(current, ident);
+            if (next) {
+                changed = true;
+                current = next.after;
+                substeps.push(next);
+            }
+        }
+        if (!changed) {
+            break;
         }
     }
 
-    for (const transform of transforms) {
-        const next = transform(current, ident);
-        if (next) {
-            current = next.after;
-        }
+    if (substeps.length > 0) {
+        return {
+            message: "solve for variable", // TODO: include variable in message
+            before: node,
+            after: current,
+            substeps,
+        };
     }
 
-    for (const transform of transforms) {
-        const next = transform(current, ident);
-        if (next) {
-            current = next.after;
-        }
-    }
-
-    return current;
+    return undefined;
 };

--- a/packages/solver/src/solve/solve.ts
+++ b/packages/solver/src/solve/solve.ts
@@ -23,21 +23,21 @@ export const solve = (
     for (const transform of transforms) {
         const next = transform(current, ident);
         if (next) {
-            current = next;
+            current = next.after;
         }
     }
 
     for (const transform of transforms) {
         const next = transform(current, ident);
         if (next) {
-            current = next;
+            current = next.after;
         }
     }
 
     for (const transform of transforms) {
         const next = transform(current, ident);
         if (next) {
-            current = next;
+            current = next.after;
         }
     }
 

--- a/packages/solver/src/solve/solve.ts
+++ b/packages/solver/src/solve/solve.ts
@@ -30,14 +30,14 @@ export const solve: Transform = (node, ident) => {
     ];
 
     const substeps: Step[] = [];
-    let current = node as Semantic.Types.Node;
+    let current = node as Semantic.Types.Eq;
     for (let i = 0; i < 10; i++) {
         let changed = false;
         for (const transform of transforms) {
             const next = transform(current, ident);
             if (next) {
                 changed = true;
-                current = next.after;
+                current = next.after as Semantic.Types.Eq;
                 substeps.push(next);
             }
         }

--- a/packages/solver/src/solve/transforms/div-both-sides.ts
+++ b/packages/solver/src/solve/transforms/div-both-sides.ts
@@ -5,12 +5,12 @@ import {getCoeff, isTermOfIdent} from "../util";
 
 // TODO: mulBothSides for situations like x/4 = 5 -> x = 20
 
-export const divBothSides: Transform = (node, ident) => {
-    if (node.type !== "eq") {
+export const divBothSides: Transform = (before, ident) => {
+    if (before.type !== "eq") {
         return;
     }
 
-    const [left, right] = node.args as readonly Semantic.Types.NumericNode[];
+    const [left, right] = before.args as readonly Semantic.Types.NumericNode[];
 
     const leftTerms = Semantic.getTerms(left);
     const rightTerms = Semantic.getTerms(right);
@@ -33,28 +33,42 @@ export const divBothSides: Transform = (node, ident) => {
         const coeff = getCoeff(leftIdentTerms[0]);
 
         if (Semantic.deepEquals(coeff, Semantic.number("1"))) {
-            return node;
+            return undefined;
         }
 
-        return Semantic.eq(
-            (node.args.map((arg) =>
+        const after = Semantic.eq(
+            (before.args.map((arg) =>
                 Semantic.div(arg as Semantic.Types.NumericNode, coeff),
             ) as unknown) as TwoOrMore<Semantic.Types.NumericNode>,
         );
+
+        return {
+            message: "divide both sides",
+            before,
+            after,
+            substeps: [],
+        };
     }
 
     if (rightIdentTerms.length === 1 && rightNonIdentTerms.length === 0) {
         const coeff = getCoeff(rightIdentTerms[0]);
 
         if (Semantic.deepEquals(coeff, Semantic.number("1"))) {
-            return node;
+            return undefined;
         }
 
-        return Semantic.eq(
-            (node.args.map((arg) =>
+        const after = Semantic.eq(
+            (before.args.map((arg) =>
                 Semantic.div(arg as Semantic.Types.NumericNode, coeff),
             ) as unknown) as TwoOrMore<Semantic.Types.NumericNode>,
         );
+
+        return {
+            message: "divide both sides by",
+            before,
+            after,
+            substeps: [],
+        };
     }
 
     return undefined;

--- a/packages/solver/src/solve/transforms/div-both-sides.ts
+++ b/packages/solver/src/solve/transforms/div-both-sides.ts
@@ -64,7 +64,7 @@ export const divBothSides: Transform = (before, ident) => {
         );
 
         return {
-            message: "divide both sides by",
+            message: "divide both sides",
             before,
             after,
             substeps: [],

--- a/packages/solver/src/solve/transforms/div-both-sides.ts
+++ b/packages/solver/src/solve/transforms/div-both-sides.ts
@@ -6,10 +6,6 @@ import {getCoeff, isTermOfIdent} from "../util";
 // TODO: mulBothSides for situations like x/4 = 5 -> x = 20
 
 export const divBothSides: Transform = (before, ident) => {
-    if (before.type !== "eq") {
-        return;
-    }
-
     const [left, right] = before.args as readonly Semantic.Types.NumericNode[];
 
     const leftTerms = Semantic.getTerms(left);

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -17,10 +17,6 @@ import {isTermOfIdent, flipSign, convertSubTermToNeg} from "../util";
  *     opposite directions
  */
 export const moveTermsToOneSide: Transform = (before, ident) => {
-    if (before.type !== "eq") {
-        return;
-    }
-
     const [left, right] = before.args as readonly Semantic.Types.NumericNode[];
 
     const leftTerms = Semantic.getTerms(left);

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -73,7 +73,11 @@ export const moveTermsToOneSide: Transform = (before, ident) => {
         };
     }
 
-    if (leftIdentTerms.length === 1 && rightIdentTerms.length === 0) {
+    if (
+        leftIdentTerms.length === 1 &&
+        rightIdentTerms.length === 0 &&
+        leftNonIdentTerms.length > 0
+    ) {
         let left = leftIdentTerms[0];
         if (left.type === "neg") {
             left = convertSubTermToNeg(left);
@@ -94,7 +98,11 @@ export const moveTermsToOneSide: Transform = (before, ident) => {
         };
     }
 
-    if (leftIdentTerms.length === 0 && rightIdentTerms.length === 1) {
+    if (
+        leftIdentTerms.length === 0 &&
+        rightIdentTerms.length === 1 &&
+        rightNonIdentTerms.length > 0
+    ) {
         // Move non-identifiers to the left.
         const left = Semantic.addTerms([
             ...leftNonIdentTerms,

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -9,8 +9,12 @@ import {isTermOfIdent, flipSign, convertSubTermToNeg} from "../util";
  *
  * TODO:
  * - customize messages in steps
- * - add sub-steps for the case where we're moving both matching and non-matching
- *   terms in opposite directions
+ * - add sub-steps for:
+ *   - the addition/subtraction that needs to be done to both sides to
+ *     move something
+ *   - showing the cancelling of terms after the addition/subtraction
+ *   - the case where we're moving both matching and non-matching terms in
+ *     opposite directions
  */
 export const moveTermsToOneSide: Transform = (before, ident) => {
     if (before.type !== "eq") {

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -6,13 +6,18 @@ import {isTermOfIdent, flipSign, convertSubTermToNeg} from "../util";
 /**
  * Moves all terms matching `ident` to one side and those that don't to the
  * other side.
+ *
+ * TODO:
+ * - customize messages in steps
+ * - add sub-steps for the case where we're moving both matching and non-matching
+ *   terms in opposite directions
  */
-export const moveTermsToOneSide: Transform = (node, ident) => {
-    if (node.type !== "eq") {
+export const moveTermsToOneSide: Transform = (before, ident) => {
+    if (before.type !== "eq") {
         return;
     }
 
-    const [left, right] = node.args as readonly Semantic.Types.NumericNode[];
+    const [left, right] = before.args as readonly Semantic.Types.NumericNode[];
 
     const leftTerms = Semantic.getTerms(left);
     const rightTerms = Semantic.getTerms(right);
@@ -33,12 +38,13 @@ export const moveTermsToOneSide: Transform = (node, ident) => {
 
     if (leftIdentTerms.length > 1 || rightIdentTerms.length > 1) {
         // One (or both) of the sides hasn't been simplified
-        return;
+        return undefined;
     }
 
     if (leftIdentTerms.length === 1 && rightIdentTerms.length === 1) {
         // There's a term with the identifier we're trying to solve for on both sides
 
+        // TODO: create two sub-steps for each of these moves
         // Move identifiers to the left
         const left =
             leftIdentTerms[0].type === "neg"
@@ -58,7 +64,13 @@ export const moveTermsToOneSide: Transform = (node, ident) => {
             ...leftNonIdentTerms.map(flipSign),
         ]);
 
-        return Semantic.eq([left, right]);
+        const after = Semantic.eq([left, right]);
+        return {
+            message: "move terms to one side",
+            before,
+            after,
+            substeps: [],
+        };
     }
 
     if (leftIdentTerms.length === 1 && rightIdentTerms.length === 0) {
@@ -73,7 +85,13 @@ export const moveTermsToOneSide: Transform = (node, ident) => {
             ...leftNonIdentTerms.map(flipSign),
         ]);
 
-        return Semantic.eq([left, right]);
+        const after = Semantic.eq([left, right]);
+        return {
+            message: "move terms to one side",
+            before,
+            after,
+            substeps: [],
+        };
     }
 
     if (leftIdentTerms.length === 0 && rightIdentTerms.length === 1) {
@@ -88,7 +106,13 @@ export const moveTermsToOneSide: Transform = (node, ident) => {
             right = convertSubTermToNeg(right);
         }
 
-        return Semantic.eq([left, right]);
+        const after = Semantic.eq([left, right]);
+        return {
+            message: "move terms to one side",
+            before,
+            after,
+            substeps: [],
+        };
     }
 
     return undefined;

--- a/packages/solver/src/solve/transforms/simplify-both-sides.ts
+++ b/packages/solver/src/solve/transforms/simplify-both-sides.ts
@@ -4,14 +4,7 @@ import {Transform} from "../types";
 import {simplify} from "../../simplify/simplify";
 
 export const simplifyBothSides: Transform = (before, ident) => {
-    if (before.type !== "eq") {
-        return undefined;
-    }
-
     const left = simplify(before.args[0], []);
-    if (before.args[1] === undefined) {
-        console.log(before);
-    }
     const right = simplify(before.args[1], []);
 
     if (left && right) {

--- a/packages/solver/src/solve/transforms/simplify-both-sides.ts
+++ b/packages/solver/src/solve/transforms/simplify-both-sides.ts
@@ -3,25 +3,43 @@ import * as Semantic from "@math-blocks/semantic";
 import {Transform} from "../types";
 import {simplify} from "../../simplify/simplify";
 
-export const simplifyBothSides: Transform = (node, ident) => {
-    if (node.type !== "eq") {
+export const simplifyBothSides: Transform = (before, ident) => {
+    if (before.type !== "eq") {
         return undefined;
     }
 
-    const left = simplify(node.args[0], []);
-    if (node.args[1] === undefined) {
-        console.log(node);
+    const left = simplify(before.args[0], []);
+    if (before.args[1] === undefined) {
+        console.log(before);
     }
-    const right = simplify(node.args[1], []);
+    const right = simplify(before.args[1], []);
 
     if (left && right) {
-        return Semantic.eq([left.after, right.after]);
+        const after = Semantic.eq([left.after, right.after]);
+        return {
+            message: "simplify both sides",
+            before,
+            after,
+            substeps: [left, right],
+        };
     }
     if (left) {
-        return Semantic.eq([left.after, node.args[1]]);
+        const after = Semantic.eq([left.after, before.args[1]]);
+        return {
+            message: "simplify the left hand side",
+            before,
+            after,
+            substeps: [left],
+        };
     }
     if (right) {
-        return Semantic.eq([node.args[0], right.after]);
+        const after = Semantic.eq([before.args[0], right.after]);
+        return {
+            message: "simplify the right hand side",
+            before,
+            after,
+            substeps: [right],
+        };
     }
 
     return undefined;

--- a/packages/solver/src/solve/transforms/simplify-both-sides.ts
+++ b/packages/solver/src/solve/transforms/simplify-both-sides.ts
@@ -20,7 +20,16 @@ export const simplifyBothSides: Transform = (before, ident) => {
             message: "simplify both sides",
             before,
             after,
-            substeps: [left, right],
+            substeps: [
+                {
+                    ...left,
+                    message: "simplify the left hand side",
+                },
+                {
+                    ...right,
+                    message: "simplify the right hand side",
+                },
+            ],
         };
     }
     if (left) {
@@ -29,7 +38,7 @@ export const simplifyBothSides: Transform = (before, ident) => {
             message: "simplify the left hand side",
             before,
             after,
-            substeps: [left],
+            substeps: left.substeps,
         };
     }
     if (right) {
@@ -38,7 +47,7 @@ export const simplifyBothSides: Transform = (before, ident) => {
             message: "simplify the right hand side",
             before,
             after,
-            substeps: [right],
+            substeps: right.substeps,
         };
     }
 

--- a/packages/solver/src/solve/types.ts
+++ b/packages/solver/src/solve/types.ts
@@ -3,7 +3,7 @@ import * as Semantic from "@math-blocks/semantic";
 import {Step} from "../types";
 
 export type Transform = (
-    node: Semantic.Types.Node,
+    node: Semantic.Types.Eq,
     ident: Semantic.Types.Ident,
 ) => Step | undefined;
 

--- a/packages/solver/src/solve/types.ts
+++ b/packages/solver/src/solve/types.ts
@@ -1,6 +1,10 @@
 import * as Semantic from "@math-blocks/semantic";
 
+import {Step} from "../types";
+
 export type Transform = (
     node: Semantic.Types.Node,
     ident: Semantic.Types.Ident,
-) => Semantic.Types.Node | undefined;
+) => Step | undefined;
+
+export {Step};

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -1,0 +1,8 @@
+import * as Semantic from "@math-blocks/semantic";
+
+export type Step = {
+    message: string;
+    before: Semantic.Types.Node;
+    after: Semantic.Types.Node;
+    substeps: Step[];
+};


### PR DESCRIPTION
- [ ] ~collect sub-steps for `divBothSides` and `moveTermsToOneSide`~ neither of these currently have sub-steps.  `divBothSides` doesn't need them.  I added a TODO to add them to `moveTermsToOneSide` later.
- [x] testing