### PR TITLE
Reverse the order of root args so that index comes first in editor-core

### DIFF
--- a/packages/editor-core/src/builders.ts
+++ b/packages/editor-core/src/builders.ts
@@ -45,13 +45,13 @@ export function frac(
 // It would be nice if we could provide defaults to parameterized functions
 // We'd need type-classes for that but thye don't exist in JavaScript.
 export function root(
-    arg: types.Node[],
     index: types.Node[] | null,
+    radicand: types.Node[],
 ): types.Root {
     return {
         id: getId(),
         type: "root",
-        children: [row(arg), index ? row(index) : null],
+        children: [index ? row(index) : null, row(radicand)],
     };
 }
 

--- a/packages/editor-core/src/parser/__tests__/lexer.test.ts
+++ b/packages/editor-core/src/parser/__tests__/lexer.test.ts
@@ -157,8 +157,8 @@ describe("Lexer", () => {
             expect(tokenTree).toMatchInlineSnapshot(`
                 (row 
                   (root@[]:0:1 atom (row 
-                    (num@[0,0]:0:3 123)) (row 
-                    (ident@[0,1]:0:1 n))))
+                    (ident@[0,0]:0:1 n)) (row 
+                    (num@[0,1]:0:3 123))))
             `);
         });
 

--- a/packages/editor-core/src/parser/__tests__/parser.test.ts
+++ b/packages/editor-core/src/parser/__tests__/parser.test.ts
@@ -387,7 +387,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (root :radicand b :index 2))
+              (root :radicand 2 :index b))
         `);
 
         expect(ast.loc).toEqual({
@@ -433,8 +433,8 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (root :radicand b :index 2)
-              (root :radicand c :index 3))
+              (root :radicand 2 :index b)
+              (root :radicand 3 :index c))
         `);
     });
 
@@ -445,8 +445,8 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (root :radicand b :index 2)
-              (root :radicand c :index 3))
+              (root :radicand 2 :index b)
+              (root :radicand 3 :index c))
         `);
     });
 
@@ -494,7 +494,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               (root :radicand 2 :index 2)
-              (root :radicand 3 :index 2))
+              (root :radicand 2 :index 3))
         `);
     });
 

--- a/packages/editor-core/src/parser/lexer.ts
+++ b/packages/editor-core/src/parser/lexer.ts
@@ -278,12 +278,12 @@ const lex = (node: types.Node, path: number[], offset: number): Node => {
             };
         }
         case "root": {
-            const [radicand, index] = node.children;
+            const [index, radicand] = node.children;
             return {
                 type: "root",
                 children: [
-                    lexRow(radicand, [...path, offset, 0]),
                     index ? lexRow(index, [...path, offset, 1]) : null,
+                    lexRow(radicand, [...path, offset, 0]),
                 ],
                 loc: location(path, offset, offset + 1),
             };

--- a/packages/editor-core/src/parser/parser.ts
+++ b/packages/editor-core/src/parser/parser.ts
@@ -96,14 +96,14 @@ const getPrefixParselet = (
         case "root":
             return {
                 parse: () => {
-                    const [arg, index] = token.children;
+                    const [index, radicand] = token.children;
                     return index === null
                         ? Parser.builders.sqrt(
-                              editorParser.parse(arg.children),
+                              editorParser.parse(radicand.children),
                               token.loc,
                           )
                         : Parser.builders.root(
-                              editorParser.parse(arg.children),
+                              editorParser.parse(radicand.children),
                               editorParser.parse(index.children),
                               token.loc,
                           );
@@ -198,15 +198,15 @@ const parseNaryArgs = (
         }
     } else if (token.type === "root") {
         parser.consume();
-        const [arg, index] = token.children;
+        const [index, radicand] = token.children;
         const expr =
             index === null
                 ? Parser.builders.sqrt(
-                      editorParser.parse(arg.children),
+                      editorParser.parse(radicand.children),
                       token.loc,
                   )
                 : Parser.builders.root(
-                      editorParser.parse(arg.children),
+                      editorParser.parse(radicand.children),
                       editorParser.parse(index.children),
                       token.loc,
                   );

--- a/packages/editor-core/src/parser/test-util.ts
+++ b/packages/editor-core/src/parser/test-util.ts
@@ -44,13 +44,13 @@ export function frac(
 // It would be nice if we could provide defaults to parameterized functions
 // We'd need type-classes for that but thye don't exist in JavaScript.
 export function root(
-    arg: Node[],
+    radicand: Node[],
     index: Node[] | null,
     loc: SourceLocation,
 ): Root {
     return {
         type: "root",
-        children: [row(arg), index ? row(index) : null],
+        children: [index ? row(index) : null, row(radicand)],
         loc,
     };
 }
@@ -120,7 +120,7 @@ const print = (
             })`;
         }
         case "root": {
-            const [radicand, index] = ast.children;
+            const [index, radicand] = ast.children;
             return `(root@[${loc.path.map(String).join(",")}]:${loc.start}:${
                 loc.end
             } ${atom.name} ${print(radicand, serialize, indent)} ${

--- a/packages/editor-core/src/reducer/constants.ts
+++ b/packages/editor-core/src/reducer/constants.ts
@@ -2,4 +2,5 @@ export const SUB = 0;
 export const SUP = 1;
 export const NUMERATOR = 0;
 export const DENOMINATOR = 1;
-export const RADICAND = 0;
+export const INDEX = 0;
+export const RADICAND = 1;

--- a/packages/editor-core/src/reducer/reducers/backspace.ts
+++ b/packages/editor-core/src/reducer/reducers/backspace.ts
@@ -1,4 +1,5 @@
 import * as builders from "../../builders";
+import {RADICAND, INDEX} from "../constants";
 
 import {State} from "../row-reducer";
 import {
@@ -231,10 +232,10 @@ export const backspace = (currentNode: HasChildren, draft: State): void => {
 
             let newChildren = grandparent.children;
             if (index !== -1) {
-                if (parent.children[0] && !parent.children[1]) {
+                if (parent.children[RADICAND] && !parent.children[INDEX]) {
                     newChildren = [
                         ...grandparent.children.slice(0, index),
-                        ...parent.children[0].children,
+                        ...parent.children[RADICAND].children,
                         ...grandparent.children.slice(index + 1),
                     ];
                 } else {

--- a/packages/editor-core/src/reducer/reducers/move-left.ts
+++ b/packages/editor-core/src/reducer/reducers/move-left.ts
@@ -119,7 +119,7 @@ export const moveLeft = (
         }
 
         if (prevNode && prevNode.type === "root" && !selecting) {
-            const radicand = prevNode.children[0];
+            const radicand = prevNode.children[RADICAND];
             return enterFromRight(cursor, radicand, RADICAND);
         } else if (prevNode && prevNode.type === "frac" && !selecting) {
             // enter fraction (denominator)

--- a/packages/editor-core/src/reducer/reducers/move-right.ts
+++ b/packages/editor-core/src/reducer/reducers/move-right.ts
@@ -116,7 +116,7 @@ export const moveRight = (
         }
 
         if (nextNode && nextNode.type === "root" && !selecting) {
-            const radicand = nextNode.children[0];
+            const radicand = nextNode.children[RADICAND];
             // TODO: handle navigating into the index
             return enterFromLeft(cursor, radicand, RADICAND);
         } else if (nextNode && nextNode.type === "frac" && !selecting) {

--- a/packages/editor-core/src/reducer/reducers/root.ts
+++ b/packages/editor-core/src/reducer/reducers/root.ts
@@ -17,7 +17,7 @@ export const root = (currentNode: HasChildren, draft: State): void => {
             selectionStart,
         );
 
-        currentNode.children = [...head, builders.root(body, null), ...tail];
+        currentNode.children = [...head, builders.root(null, body), ...tail];
         draft.cursor = {
             path: [...cursor.path, head.length, RADICAND],
             prev: body.length > 0 ? body.length - 1 : -Infinity,
@@ -38,7 +38,7 @@ export const root = (currentNode: HasChildren, draft: State): void => {
     const newNode: types.Root = {
         id: getId(),
         type: "root",
-        children: [radicand, null /* index */],
+        children: [null /* index */, radicand],
     };
 
     currentNode.children = insertBeforeChildWithIndex(

--- a/packages/editor-core/src/reducer/util.ts
+++ b/packages/editor-core/src/reducer/util.ts
@@ -13,8 +13,8 @@ export const isEqual = (a: types.Node, b: types.Node): boolean => {
         const [bNum, bDen] = b.children;
         return isEqual(aNum, bNum) && isEqual(aDen, bDen);
     } else if (a.type === "root" && b.type === "root") {
-        const [aRad, aIndex] = a.children;
-        const [bRad, bIndex] = b.children;
+        const [aIndex, aRad] = a.children;
+        const [bIndex, bRad] = b.children;
         if (isEqual(aRad, bRad)) {
             return aIndex != null && bIndex != null
                 ? isEqual(aIndex, bIndex)
@@ -82,8 +82,8 @@ export const frac = (num: string, den: string): types.Frac =>
 
 export const sqrt = (radicand: string): types.Root =>
     builders.root(
-        radicand.split("").map((glyph) => builders.glyph(glyph)),
         null,
+        radicand.split("").map((glyph) => builders.glyph(glyph)),
     );
 
 export const root = (radicand: string, index: string): types.Root =>

--- a/packages/editor-core/src/shared-types.ts
+++ b/packages/editor-core/src/shared-types.ts
@@ -13,7 +13,7 @@ export type SubSup<A, C> = C & {
 export type Limits<A, C> = C & {
     type: "limits";
     inner: Node<A, C>;
-    children: readonly [Row<A, C>, Row<A, C> | null];
+    children: readonly [Row<A, C>, Row<A, C> | null]; // lower, upper
 };
 
 export type Frac<A, C> = C & {
@@ -23,7 +23,9 @@ export type Frac<A, C> = C & {
 
 export type Root<A, C> = C & {
     type: "root";
-    children: readonly [Row<A, C>, Row<A, C> | null];
+    // TODO: reverse the order so that we can enter the index from the left
+    // when there is one
+    children: readonly [Row<A, C> | null, Row<A, C>]; // radicand, index
 };
 
 export type Atom<A, C> = C & {

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 465.935546875 160.66015625" width="463.935546875" height="162.66015625">
-    <g transform="translate(0,107.1484375)" id="21">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 277.732421875 145.501953125" width="275.732421875" height="147.501953125">
+    <g transform="translate(0,91.990234375)" id="21">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             x
         </text>
@@ -23,43 +23,18 @@
                     </text>
                 </g>
                 <g transform="translate(123.251953125,0)" id="13">
-                    <g transform="translate(0,-29.904296875)" id="undefined">
+                    <g transform="translate(0,-14.74609375)" id="undefined">
                         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1">
                             √
                         </text>
                     </g>
                     <g transform="translate(26.4453125,0)" id="undefined">
-                        <g transform="translate(0,0)" id="14">
-                            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
-                                b
-                            </text>
-                            <g transform="translate(35.595703125,-10)" id="7">
-                                <g transform="translate(0,-22.2431640625)" id="8">
-                                    <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1">
-                                        2
-                                    </text>
-                                </g>
-                            </g>
-                            <g transform="translate(61.23046875,0)" id="9">
-                                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1">
-                                    −
-                                </text>
-                            </g>
-                            <text x="120.05859375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1">
-                                4
-                            </text>
-                            <text x="156.6796875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1">
-                                a
-                            </text>
-                            <text x="187.3828125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1">
-                                c
-                            </text>
-                        </g>
-                        <line type="line" x1="0" y1="-74.408203125" x2="218.203125" y2="-74.408203125" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
+                        <g transform="translate(0,0)" id="15"></g>
+                        <line type="line" x1="0" y1="-59.25" x2="30" y2="-59.25" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
                     </g>
                 </g>
             </g>
-            <g transform="translate(150.2880859375,58.021484375)" id="20">
+            <g transform="translate(56.1865234375,58.021484375)" id="20">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="16" style="opacity:1">
                     2
                 </text>
@@ -68,7 +43,7 @@
                 </text>
             </g>
             <g transform="translate(2.5,2.5)" id="undefined">
-                <line type="line" x1="0" y1="0" x2="362.900390625" y2="0" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
+                <line type="line" x1="0" y1="0" x2="174.697265625" y2="0" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
             </g>
         </g>
     </g>

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -7,6 +7,8 @@ import {Context, Options} from "./types";
 
 const DEBUG = typeof jest === "undefined";
 
+const RADICAND = 1;
+
 // Dedupe this with editor/src/util.ts
 export const isGlyph = (
     node: Editor.types.Node,
@@ -567,7 +569,7 @@ const _typeset = (node: Editor.types.Node, context: Context): Layout.Node => {
             return frac;
         }
         case "root": {
-            const radicand = typesetRow(node.children[0], context);
+            const radicand = typesetRow(node.children[RADICAND], context);
             const Eheight = 50;
             radicand.width = Math.max(radicand.width, 30 * multiplier);
             radicand.height = Math.max(radicand.height, Eheight * multiplier);


### PR DESCRIPTION
This is so that the args appear in the same (left-to-right) order that you'd seem them when rendering a root (and it's index).