### PR TITLE
Remove unreachable code in move-left/move-right

### DIFF
--- a/packages/editor-core/src/zipper/__tests__/move-selection.test.ts
+++ b/packages/editor-core/src/zipper/__tests__/move-selection.test.ts
@@ -158,6 +158,42 @@ describe("moveRight w/ selecting = true", () => {
             expect(result.breadcrumbs[0].row.right).toHaveLength(1);
         });
 
+        test("selecting to the right edge of the bottom breadcrumb", () => {
+            const zipper: Zipper = {
+                row: {
+                    id: 0,
+                    type: "zrow",
+                    left: [],
+                    right: builders.row([
+                        frac("1", "2"),
+                        builders.glyph("+"),
+                        builders.glyph("3"),
+                    ]).children,
+                    selection: null,
+                },
+                breadcrumbs: [],
+            };
+
+            const result = moveRight(
+                moveRight(
+                    moveRight(
+                        moveRight(moveRight(moveRight(zipper), true), true),
+                        true,
+                    ),
+                    true,
+                ),
+                true,
+            );
+
+            expect(result.row.left).toHaveLength(0);
+            expect(result.row.selection?.dir).toEqual("right");
+            expect(result.row.selection?.nodes).toHaveLength(1);
+            expect(result.breadcrumbs).toHaveLength(1);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual("right");
+            expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(2); // focus is selected
+            expect(result.breadcrumbs[0].row.right).toHaveLength(0);
+        });
+
         test("constricting the selection to the left from the first breadcrumb", () => {
             const zipper: Zipper = {
                 row: {
@@ -521,7 +557,7 @@ describe("moveLeft w/ selecting = true", () => {
             expect(result.breadcrumbs[0].row.left).toHaveLength(2);
         });
 
-        test("selecting to the right from the first breadcrumb", () => {
+        test("selecting to the left from the first breadcrumb", () => {
             const zipper: Zipper = {
                 row: {
                     id: 0,
@@ -549,6 +585,39 @@ describe("moveLeft w/ selecting = true", () => {
             expect(result.breadcrumbs[0].row.selection?.dir).toEqual("left");
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(1); // focus is selected
             expect(result.breadcrumbs[0].row.left).toHaveLength(1);
+        });
+
+        test("selecting to the left edge of the bottom breadcrumb", () => {
+            const zipper: Zipper = {
+                row: {
+                    id: 0,
+                    type: "zrow",
+                    left: builders.row([
+                        builders.glyph("1"),
+                        builders.glyph("+"),
+                        frac("2", "3"),
+                    ]).children,
+                    selection: null,
+                    right: [],
+                },
+                breadcrumbs: [],
+            };
+
+            const result = moveLeft(
+                moveLeft(
+                    moveLeft(moveLeft(moveLeft(moveLeft(zipper)), true), true),
+                    true,
+                ),
+                true,
+            );
+
+            expect(result.row.right).toHaveLength(1);
+            expect(result.row.selection?.dir).toEqual("left");
+            expect(result.row.selection?.nodes).toHaveLength(0);
+            expect(result.breadcrumbs).toHaveLength(1);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual("left");
+            expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(2); // focus is selected
+            expect(result.breadcrumbs[0].row.left).toHaveLength(0);
         });
 
         test("constricting the selection to the left from the first breadcrumb", () => {

--- a/packages/editor-core/src/zipper/move-left.ts
+++ b/packages/editor-core/src/zipper/move-left.ts
@@ -1,6 +1,6 @@
 import {UnreachableCaseError} from "@math-blocks/core";
 
-import {Breadcrumb, Focus, Zipper, ZRow} from "./types";
+import {Breadcrumb, Focus, Zipper, ZRow, ZRowWithSelection} from "./types";
 import * as types from "../types";
 import * as util from "./util";
 import {crumbMoveLeft, startSelection, stopSelection} from "./selection-util";
@@ -179,6 +179,10 @@ const cursorLeft = (zipper: Zipper): Zipper => {
     return zipper;
 };
 
+function hasSelection(row: ZRow): row is ZRowWithSelection {
+    return row.selection !== null;
+}
+
 const selectionLeft = (zipper: Zipper): Zipper => {
     // INVARIANT: selections in crumbs can only exist from last crumb (top) back
     // to the first crumb (bottom), there can be no gaps either
@@ -188,13 +192,12 @@ const selectionLeft = (zipper: Zipper): Zipper => {
     // - expand a selection (possibly moving out to a yet to be selected focus)
     // - contract a selection (possible moving in to an already selected focus)
 
-    const rowsWithSelections = zipper.breadcrumbs
+    const rowsWithSelections: ZRowWithSelection[] = zipper.breadcrumbs
         .map((crumb) => crumb.row)
-        .filter((row) => row.selection);
+        .filter(hasSelection);
     if (zipper.row.selection) {
         rowsWithSelections.push(zipper.row);
     }
-    rowsWithSelections.reverse();
 
     if (rowsWithSelections.length === 0) {
         const {row} = zipper;
@@ -219,10 +222,12 @@ const selectionLeft = (zipper: Zipper): Zipper => {
             };
         }
     } else if (rowsWithSelections.length === 1) {
-        // our selection is in the current row (top of zipper)
+        // Our selection is in the current row (top of zipper).
 
-        if (zipper.row.selection?.dir === "left") {
-            if (zipper.row.left.length > 0) {
+        const row = rowsWithSelections[0]; // same as zipper.row
+
+        if (row.selection.dir === "left") {
+            if (row.left.length > 0) {
                 return crumbMoveLeft(zipper);
             } else {
                 const index = zipper.breadcrumbs.length - 1;
@@ -239,8 +244,8 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                     ),
                 };
             }
-        } else if (zipper.row.selection?.dir === "right") {
-            if (zipper.row.selection.nodes.length > 0) {
+        } else {
+            if (row.selection.nodes.length > 0) {
                 const result = crumbMoveLeft(zipper);
                 if (result.row.selection?.nodes.length === 0) {
                     // we're back at original cursor position, stop selecting
@@ -255,17 +260,15 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                 // This might happen if we started our selection at the edge
                 return stopSelection(zipper);
             }
-        } else {
-            return zipper;
         }
     } else {
-        // our selection is in the one of the breadcrumb rows
+        // Our selection is in the one of the breadcrumb rows.
 
         let index = zipper.breadcrumbs.length - rowsWithSelections.length + 1;
         const crumb = zipper.breadcrumbs[index];
-        const {row} = crumb;
+        const row = rowsWithSelections[0]; // same as crumb.row
 
-        if (row.selection?.dir === "left") {
+        if (row.selection.dir === "left") {
             if (row.left.length > 0) {
                 const updatedCrumb = crumbMoveLeft(crumb);
                 return {
@@ -277,15 +280,17 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                     ),
                 };
             } else {
-                // move out to start a selection in the parent crumb
+                // Move out to start a selection in the parent crumb.
                 index = index - 1;
+
+                // We've reached the start of the bottom crumb so there's
+                // nowhere to go.
                 if (index < 0) {
                     return zipper;
                 }
 
                 const crumb = zipper.breadcrumbs[index];
                 const updatedCrumb = startSelection(crumb, "left");
-
                 return {
                     ...zipper,
                     breadcrumbs: replaceItem(
@@ -295,7 +300,7 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                     ),
                 };
             }
-        } else if (row.selection?.dir === "right") {
+        } else {
             if (row.selection.nodes.length > 0) {
                 const updatedCrumb = crumbMoveLeft(crumb);
                 return {
@@ -307,7 +312,7 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                     ),
                 };
             } else {
-                const updatedCrumb: Breadcrumb = stopSelection(crumb);
+                const updatedCrumb = stopSelection(crumb);
                 const result: Zipper = {
                     ...zipper,
                     breadcrumbs: replaceItem(
@@ -316,22 +321,21 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                         index,
                     ),
                 };
+
                 // If there are no selections in any of the breadcrumbs and the
                 // selection in the result.row is empty then clear the selection
                 // there as well.
                 if (
+                    result.row.selection?.nodes.length === 0 &&
                     result.breadcrumbs.every(
                         (crumb) => crumb.row.selection === null,
                     )
                 ) {
-                    if (result.row.selection?.nodes.length === 0) {
-                        return stopSelection(result);
-                    }
+                    return stopSelection(result);
                 }
+
                 return result;
             }
-        } else {
-            return zipper;
         }
     }
 };

--- a/packages/editor-core/src/zipper/types.ts
+++ b/packages/editor-core/src/zipper/types.ts
@@ -5,13 +5,23 @@ type Selection = {
     nodes: types.Node[];
 };
 
-export type ZRow = {
+export type ZRowWithoutSelection = {
     id: number;
     type: "zrow";
     left: types.Node[];
-    selection: Selection | null;
+    selection: null;
     right: types.Node[];
 };
+
+export type ZRowWithSelection = {
+    id: number;
+    type: "zrow";
+    left: types.Node[];
+    selection: Selection;
+    right: types.Node[];
+};
+
+export type ZRow = ZRowWithoutSelection | ZRowWithSelection;
 
 export type ZFrac = {
     id: number;


### PR DESCRIPTION
This includes a couple of addition tests for selection manipulation in the zipper editor-core.