### PR TITLE
Update stories to use typesetZipper

### DIFF
--- a/.storybook/aliases-preset.js
+++ b/.storybook/aliases-preset.js
@@ -1,4 +1,6 @@
 const path = require("path");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
 const webpackConfig = require(path.resolve(__dirname, "../webpack.config.js"));
 
 module.exports = {
@@ -15,6 +17,8 @@ module.exports = {
             config.resolve.alias,
             webpackConfig.resolve.alias,
         );
+        config.module.rules = webpackConfig.module.rules;
+        config.plugins.push(new MiniCssExtractPlugin());
         return config;
     },
     babel: async (config, options) => {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ const path = require("path");
 module.exports = {
     stories: [
         "../**/stories/**/*.stories.mdx",
-        "../**/stories/**/*.stories.@(js|jsx|ts|tsx)",
+        "../**/stories/**/*.stories.@(ts|tsx)",
     ],
     addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
     presets: [path.resolve(__dirname, "./aliases-preset.js")],

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -12,4 +12,5 @@ export {parse} from "./parser/parser";
 export {isEqual, layoutCursorFromState} from "./reducer/util"; // TODO: dedupe methods in editor and util
 
 export {zipperReducer} from "./zipper/reducer";
+export {Dir} from "./zipper/enums";
 export type {Breadcrumb, Focus, Zipper, ZRow, ZFrac} from "./zipper/types";

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
-    <g transform="translate(0,45.673828125)" id="7">
-        <rect type="rect" x="36.62109375" y="-54.4" width="2" height="64"></rect>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
+    <g transform="translate(0,54.4)" id="7">
+        <rect type="rect" x="35.62109375" y="-54.4" width="2" height="64"></rect>
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             2
         </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 60" width="291.73828125" height="62">
-    <g transform="translate(0,51)" id="7">
-        <rect type="rect" x="35.62109375" y="-54.4" width="2" height="64"></rect>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
+    <g transform="translate(0,45.673828125)" id="7">
+        <rect type="rect" x="0" y="-54.4" width="2" height="64"></rect>
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             2
         </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
     <g transform="translate(0,45.673828125)" id="7">
-        <rect type="rect" x="0" y="-54.4" width="2" height="64"></rect>
+        <rect type="rect" x="36.62109375" y="-54.4" width="2" height="64"></rect>
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             2
         </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 60" width="291.73828125" height="62">
-    <g transform="translate(0,51)" id="7">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
+    <g transform="translate(0,45.673828125)" id="7">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             2
         </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
-    <g transform="translate(0,45.673828125)" id="7">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
+    <g transform="translate(0,54.4)" id="7">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             2
         </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 50.392578125 148.16015625" width="48.392578125" height="150.16015625">
-    <g transform="translate(0,76.51171875)" style="color:darkcyan" id="5">
-        <g transform="translate(10.6904296875,-7.490234375)" id="6">
-            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
-                1
-            </text>
-        </g>
-        <g transform="translate(0,76.158203125)" style="color:orange" id="7">
-            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
-                2
-            </text>
-            <g transform="translate(36.62109375,-10)" id="3">
-                <g transform="translate(0,-22.2431640625)" style="color:pink" id="4">
-                    <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1">
-                        i
-                    </text>
+    <g transform="translate(0,76.51171875)" id="8">
+        <g transform="translate(0,-22)" style="color:darkcyan" id="5">
+            <g transform="translate(10.6904296875,-7.490234375)" id="6">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+                    1
+                </text>
+            </g>
+            <g transform="translate(0,76.158203125)" style="color:orange" id="7">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+                    2
+                </text>
+                <g transform="translate(36.62109375,-10)" id="3">
+                    <g transform="translate(0,-22.2431640625)" style="color:pink" id="4">
+                        <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1">
+                            i
+                        </text>
+                    </g>
                 </g>
             </g>
-        </g>
-        <g transform="translate(2.5,2.5)" id="undefined">
-            <line type="line" x1="0" y1="0" x2="43.392578125" y2="0" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
+            <g transform="translate(2.5,2.5)" id="undefined">
+                <line type="line" x1="0" y1="0" x2="43.392578125" y2="0" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
+            </g>
         </g>
     </g>
 </svg>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 50.392578125 148.16015625" width="48.392578125" height="150.16015625">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 50.392578125 148.16015625" width="50.392578125" height="148.16015625">
     <g transform="translate(0,76.51171875)" id="8">
         <g transform="translate(0,-22)" style="color:darkcyan" id="5">
             <g transform="translate(10.6904296875,-7.490234375)" id="6">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 465.935546875 160.66015625" width="463.935546875" height="162.66015625">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 465.935546875 160.66015625" width="465.935546875" height="160.66015625">
     <g transform="translate(0,107.1484375)" id="20">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             x

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 277.732421875 145.501953125" width="275.732421875" height="147.501953125">
-    <g transform="translate(0,91.990234375)" id="21">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 465.935546875 160.66015625" width="463.935546875" height="162.66015625">
+    <g transform="translate(0,107.1484375)" id="20">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             x
         </text>
@@ -9,8 +9,8 @@
                 =
             </text>
         </g>
-        <g transform="translate(96.03515625,-22)" id="18">
-            <g transform="translate(0,-7.490234375)" id="19">
+        <g transform="translate(96.03515625,-22)" id="17">
+            <g transform="translate(0,-7.490234375)" id="18">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
                     −
                 </text>
@@ -23,27 +23,52 @@
                     </text>
                 </g>
                 <g transform="translate(123.251953125,0)" id="13">
-                    <g transform="translate(0,-14.74609375)" id="undefined">
+                    <g transform="translate(0,-29.904296875)" id="undefined">
                         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1">
                             √
                         </text>
                     </g>
                     <g transform="translate(26.4453125,0)" id="undefined">
-                        <g transform="translate(0,0)" id="15"></g>
-                        <line type="line" x1="0" y1="-59.25" x2="30" y2="-59.25" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
+                        <g transform="translate(0,0)" id="14">
+                            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+                                b
+                            </text>
+                            <g transform="translate(35.595703125,-10)" id="7">
+                                <g transform="translate(0,-22.2431640625)" id="8">
+                                    <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1">
+                                        2
+                                    </text>
+                                </g>
+                            </g>
+                            <g transform="translate(61.23046875,0)" id="9">
+                                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1">
+                                    −
+                                </text>
+                            </g>
+                            <text x="120.05859375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1">
+                                4
+                            </text>
+                            <text x="156.6796875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1">
+                                a
+                            </text>
+                            <text x="187.3828125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1">
+                                c
+                            </text>
+                        </g>
+                        <line type="line" x1="0" y1="-74.408203125" x2="218.203125" y2="-74.408203125" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
                     </g>
                 </g>
             </g>
-            <g transform="translate(56.1865234375,58.021484375)" id="20">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="16" style="opacity:1">
+            <g transform="translate(150.2880859375,58.021484375)" id="19">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="15" style="opacity:1">
                     2
                 </text>
-                <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="17" style="opacity:1">
+                <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="16" style="opacity:1">
                     a
                 </text>
             </g>
             <g transform="translate(2.5,2.5)" id="undefined">
-                <line type="line" x1="0" y1="0" x2="174.697265625" y2="0" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
+                <line type="line" x1="0" y1="0" x2="362.900390625" y2="0" stroke="currentColor" stroke-width="5" stroke-linecap="round"></line>
             </g>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 140.943359375 109.158203125" width="138.943359375" height="111.158203125">
-    <g transform="translate(0,51)" id="11">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 140.943359375 99.9296875" width="138.943359375" height="101.9296875">
+    <g transform="translate(0,47.138671875)" id="11">
         <g transform="translate(0,0)" id="8">
-            <g transform="translate(0,45.9150390625)" id="9">
+            <g transform="translate(0,40.5478515625)" id="9">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1">
                     x
                 </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 140.943359375 99.9296875" width="138.943359375" height="101.9296875">
-    <g transform="translate(0,47.138671875)" id="11">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 140.943359375 99.9296875" width="140.943359375" height="99.9296875">
+    <g transform="translate(0,54.4)" id="11">
         <g transform="translate(0,0)" id="8">
             <g transform="translate(0,40.5478515625)" id="9">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 109.2294921875 167.3671875" width="107.2294921875" height="169.3671875">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 109.2294921875 167.3671875" width="109.2294921875" height="167.3671875">
     <g transform="translate(0,95.71875)" id="16">
         <g transform="translate(0,0)" id="5">
             <g transform="translate(11.84326171875,-62.8037109375)" id="7">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 60" width="291.73828125" height="62">
-    <g transform="translate(0,51)" id="7">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
+    <g transform="translate(0,45.673828125)" id="7">
         <rect type="rect" x="167.490234375" y="-54.4" width="60.615234375" height="64" fill="rgba(0,64,255,0.3)"></rect>
         <rect type="rect" x="130.869140625" y="-54.4" width="36.62109375" height="64" fill="rgba(0,64,255,0.3)"></rect>
         <rect type="rect" x="72.041015625" y="-54.4" width="58.828125" height="64" fill="rgba(0,64,255,0.3)"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 47.51953125" width="291.73828125" height="49.51953125">
-    <g transform="translate(0,45.673828125)" id="7">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
+    <g transform="translate(0,54.4)" id="7">
         <rect type="rect" x="167.490234375" y="-54.4" width="60.615234375" height="64" fill="rgba(0,64,255,0.3)"></rect>
         <rect type="rect" x="130.869140625" y="-54.4" width="36.62109375" height="64" fill="rgba(0,64,255,0.3)"></rect>
         <rect type="rect" x="72.041015625" y="-54.4" width="58.828125" height="64" fill="rgba(0,64,255,0.3)"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-subtracting-from-both-sides.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-subtracting-from-both-sides.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 412.56640625 120" width="410.56640625" height="122">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 412.56640625 120" width="412.56640625" height="120">
     <g transform="translate(0,51)" id="undefined">
         <g transform="translate(0,0)" id="14">
             <text x="30" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 67.091796875" width="293.466796875" height="69.091796875">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 67.091796875" width="295.466796875" height="67.091796875">
     <g transform="translate(0,65.158203125)" id="14">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             a

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 74.158203125" width="293.466796875" height="76.158203125">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 67.091796875" width="293.466796875" height="69.091796875">
     <g transform="translate(0,65.158203125)" id="14">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             a

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 364.408203125 100.31640625" width="362.408203125" height="102.31640625">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 364.408203125 100.31640625" width="364.408203125" height="100.31640625">
     <g transform="translate(0,65.158203125)" id="18">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
             a

--- a/packages/react/src/math-renderer.tsx
+++ b/packages/react/src/math-renderer.tsx
@@ -97,8 +97,8 @@ const MathRenderer: React.FunctionComponent<Props> = (props) => {
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox={viewBox}
-            width={width}
-            height={height + CURSOR_WIDTH}
+            width={width + CURSOR_WIDTH}
+            height={height}
             style={style}
         >
             <Group {...scene} />

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import * as Editor from "@math-blocks/editor-core";
 import * as Semantic from "@math-blocks/semantic";
-import {typeset, typesetWithWork} from "@math-blocks/typesetter";
+import {typesetZipper, typesetWithWork} from "@math-blocks/typesetter";
 import fontMetrics from "@math-blocks/metrics";
 
 import MathRenderer from "../math-renderer";
@@ -15,6 +15,19 @@ export default {
 };
 
 type EmptyProps = Record<string, never>;
+
+const zipperFromRow = (row: Editor.types.Row): Editor.Zipper => {
+    return {
+        row: {
+            type: "zrow",
+            id: row.id,
+            left: [],
+            right: row.children,
+            selection: null,
+        },
+        breadcrumbs: [],
+    };
+};
 
 export const Small: React.FunctionComponent<EmptyProps> = () => {
     // TODO: write a function to convert a Semantic AST into an Editor AST
@@ -34,7 +47,7 @@ export const Small: React.FunctionComponent<EmptyProps> = () => {
         multiplier: 1.0,
         cramped: false,
     };
-    const scene = typeset(math, context);
+    const scene = typesetZipper(zipperFromRow(math), context);
 
     return <MathRenderer scene={scene} />;
 };
@@ -57,7 +70,7 @@ export const Equation: React.FunctionComponent<EmptyProps> = () => {
         multiplier: 1.0,
         cramped: false,
     };
-    const scene = typeset(math, context);
+    const scene = typesetZipper(zipperFromRow(math), context);
 
     return <MathRenderer scene={scene} />;
 };
@@ -190,12 +203,6 @@ export const LinearEquations: React.FunctionComponent<EmptyProps> = () => {
 };
 
 export const Cursor: React.FunctionComponent<EmptyProps> = () => {
-    const cursor: Editor.types.Cursor = {
-        path: [],
-        prev: 0,
-        next: 1,
-    };
-
     const math = row([
         glyph("2"),
         glyph("x"),
@@ -205,6 +212,7 @@ export const Cursor: React.FunctionComponent<EmptyProps> = () => {
         glyph("1"),
         glyph("0"),
     ]);
+    const zipper = zipperFromRow(math);
 
     const fontSize = 60;
     const context = {
@@ -213,32 +221,16 @@ export const Cursor: React.FunctionComponent<EmptyProps> = () => {
         multiplier: 1.0,
         cramped: false,
     };
-
     const options = {
-        cursor: Editor.layoutCursorFromState({
-            math,
-            cursor,
-        }),
+        showCursor: true,
     };
 
-    const scene = typeset(math, context, options);
+    const scene = typesetZipper(zipper, context, options);
 
     return <MathRenderer scene={scene} />;
 };
 
 export const Selection: React.FunctionComponent<EmptyProps> = () => {
-    const cursor: Editor.types.Cursor = {
-        path: [],
-        prev: 0,
-        next: 1,
-    };
-
-    const selectionStart = {
-        path: [],
-        prev: 4,
-        next: 5,
-    };
-
     const math = row([
         glyph("2"),
         glyph("x"),
@@ -248,6 +240,19 @@ export const Selection: React.FunctionComponent<EmptyProps> = () => {
         glyph("1"),
         glyph("0"),
     ]);
+    const zipper: Editor.Zipper = {
+        row: {
+            type: "zrow",
+            id: math.id,
+            left: math.children.slice(0, 1),
+            selection: {
+                dir: Editor.Dir.Right,
+                nodes: math.children.slice(1, 5),
+            },
+            right: math.children.slice(5),
+        },
+        breadcrumbs: [],
+    };
 
     const fontSize = 60;
     const context = {
@@ -257,15 +262,7 @@ export const Selection: React.FunctionComponent<EmptyProps> = () => {
         cramped: false,
     };
 
-    const options = {
-        cursor: Editor.layoutCursorFromState({
-            math,
-            cursor,
-            selectionStart,
-        }),
-    };
-
-    const scene = typeset(math, context, options);
+    const scene = typesetZipper(zipper, context);
 
     return <MathRenderer scene={scene} />;
 };
@@ -279,17 +276,19 @@ export const Pythagoras: React.FunctionComponent<EmptyProps> = () => {
         cramped: false,
     };
 
-    const pythagoras = typeset(
-        row([
-            glyph("a"),
-            Editor.util.sup("2"),
-            glyph("+"),
-            glyph("b"),
-            Editor.util.sup("2"),
-            glyph("="),
-            glyph("c"),
-            Editor.util.sup("2"),
-        ]),
+    const pythagoras = typesetZipper(
+        zipperFromRow(
+            row([
+                glyph("a"),
+                Editor.util.sup("2"),
+                glyph("+"),
+                glyph("b"),
+                Editor.util.sup("2"),
+                glyph("="),
+                glyph("c"),
+                Editor.util.sup("2"),
+            ]),
+        ),
         context,
     );
 
@@ -305,30 +304,29 @@ export const QuadraticEquation: React.FunctionComponent<EmptyProps> = () => {
         cramped: false,
     };
 
-    const quadraticEquation = typeset(
-        row([
-            glyph("x"),
-            glyph("="),
-            frac(
-                [
-                    glyph("\u2212"),
-                    glyph("b"),
-                    glyph("\u00B1"),
-                    root(
-                        [
+    const quadraticEquation = typesetZipper(
+        zipperFromRow(
+            row([
+                glyph("x"),
+                glyph("="),
+                frac(
+                    [
+                        glyph("\u2212"),
+                        glyph("b"),
+                        glyph("\u00B1"),
+                        root(null, [
                             glyph("b"),
                             Editor.util.sup("2"),
                             glyph("\u2212"),
                             glyph("4"),
                             glyph("a"),
                             glyph("c"),
-                        ],
-                        [],
-                    ),
-                ],
-                [glyph("2"), glyph("a")],
-            ),
-        ]),
+                        ]),
+                    ],
+                    [glyph("2"), glyph("a")],
+                ),
+            ]),
+        ),
         context,
     );
 
@@ -344,16 +342,18 @@ export const Limit: React.FunctionComponent<EmptyProps> = () => {
         cramped: false,
     };
 
-    const lim = typeset(
-        row([
-            limits(row([glyph("l"), glyph("i"), glyph("m")]), [
+    const lim = typesetZipper(
+        zipperFromRow(
+            row([
+                limits(row([glyph("l"), glyph("i"), glyph("m")]), [
+                    glyph("x"),
+                    glyph("—"),
+                    glyph(">"),
+                    glyph("0"),
+                ]),
                 glyph("x"),
-                glyph("—"),
-                glyph(">"),
-                glyph("0"),
             ]),
-            glyph("x"),
-        ]),
+        ),
         context,
     );
 
@@ -369,15 +369,17 @@ export const Summation: React.FunctionComponent<EmptyProps> = () => {
         cramped: false,
     };
 
-    const sum = typeset(
-        row([
-            limits(
-                glyph("\u03a3"),
-                [glyph("i"), glyph("="), glyph("0")],
-                [glyph("\u221e")],
-            ),
-            frac([glyph("1")], [glyph("2"), Editor.util.sup("i")]),
-        ]),
+    const sum = typesetZipper(
+        zipperFromRow(
+            row([
+                limits(
+                    glyph("\u03a3"),
+                    [glyph("i"), glyph("="), glyph("0")],
+                    [glyph("\u221e")],
+                ),
+                frac([glyph("1")], [glyph("2"), Editor.util.sup("i")]),
+            ]),
+        ),
         context,
     );
 
@@ -404,7 +406,7 @@ export const ColorizedFraction: React.FunctionComponent<EmptyProps> = () => {
         colorMap.set(subsup.children[1].id, "pink");
     }
 
-    const sum = typeset(fracNode, context);
+    const sum = typesetZipper(zipperFromRow(row([fracNode])), context);
 
     return <MathRenderer scene={sum} />;
 };
@@ -439,7 +441,7 @@ export const ColorizedSum: React.FunctionComponent<EmptyProps> = () => {
         cramped: false,
         colorMap: colorMap,
     };
-    const prod = typeset(editNode, context);
+    const prod = typesetZipper(zipperFromRow(editNode), context);
 
     return <MathRenderer scene={prod} />;
 };
@@ -474,7 +476,7 @@ export const SimpleSemanticColoring: React.FunctionComponent<EmptyProps> = () =>
         cramped: false,
         colorMap: colorMap,
     };
-    const prod = typeset(editNode, context);
+    const prod = typesetZipper(zipperFromRow(editNode), context);
 
     return <MathRenderer scene={prod} />;
 };
@@ -515,7 +517,7 @@ export const NestedSemanticColoring: React.FunctionComponent<EmptyProps> = () =>
         cramped: false,
         colorMap: colorMap,
     };
-    const prod = typeset(editNode, context);
+    const prod = typesetZipper(zipperFromRow(editNode), context);
 
     return <MathRenderer scene={prod} />;
 };

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -212,7 +212,16 @@ export const Cursor: React.FunctionComponent<EmptyProps> = () => {
         glyph("1"),
         glyph("0"),
     ]);
-    const zipper = zipperFromRow(math);
+    const zipper: Editor.Zipper = {
+        row: {
+            type: "zrow",
+            id: math.id,
+            left: math.children.slice(0, 1),
+            right: math.children.slice(1),
+            selection: null,
+        },
+        breadcrumbs: [],
+    };
 
     const fontSize = 60;
     const context = {

--- a/packages/react/src/zipper-editor.tsx
+++ b/packages/react/src/zipper-editor.tsx
@@ -89,7 +89,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
         colorMap: props.colorMap,
     };
 
-    const options = {};
+    const options = {showCursor: active};
 
     const scene = typesetZipper(zipper, context, options);
 

--- a/packages/typesetter/src/zipper/scene-graph.ts
+++ b/packages/typesetter/src/zipper/scene-graph.ts
@@ -81,6 +81,10 @@ export type LayoutCursor = {
     selection: boolean;
 };
 
+// TODO: get font size from options
+const FONT_SIZE = 64;
+const CURSOR_WIDTH = 2;
+
 const processHBox = (box: Layout.Box, loc: Point, options: Options): Group => {
     const pen = {x: 0, y: 0};
     const {multiplier} = box;
@@ -110,10 +114,10 @@ const processHBox = (box: Layout.Box, loc: Point, options: Options): Group => {
             // Draw the cursor.
             belowLayer.push({
                 type: "rect",
-                x: pen.x,
-                y: pen.y - 64 * 0.85 * multiplier,
-                width: 2,
-                height: 64 * multiplier,
+                x: pen.x - CURSOR_WIDTH / 2,
+                y: pen.y - FONT_SIZE * 0.85 * multiplier,
+                width: CURSOR_WIDTH,
+                height: FONT_SIZE * multiplier,
             });
         }
 
@@ -126,12 +130,12 @@ const processHBox = (box: Layout.Box, loc: Point, options: Options): Group => {
             if (isSelection) {
                 const yMin = -Math.max(
                     Layout.getHeight(node),
-                    64 * 0.85 * multiplier,
+                    FONT_SIZE * 0.85 * multiplier,
                 );
 
                 const height = Math.max(
                     Layout.getHeight(node) + Layout.getDepth(node),
-                    64 * multiplier,
+                    FONT_SIZE * multiplier,
                 );
 
                 selectionBoxes.push({
@@ -289,5 +293,13 @@ const _processBox = (box: Layout.Box, loc: Point, options: Options): Group => {
 export const processBox = (box: Layout.Box, options: Options = {}): Group => {
     const loc = {x: 0, y: Layout.getHeight(box)};
 
-    return _processBox(box, loc, options);
+    const scene = _processBox(box, loc, options);
+
+    const y = Math.max(scene.y, FONT_SIZE * 0.85);
+    const height = Math.max(scene.height, FONT_SIZE);
+
+    scene.y = y;
+    scene.height = height;
+
+    return scene;
 };

--- a/packages/typesetter/src/zipper/typeset.ts
+++ b/packages/typesetter/src/zipper/typeset.ts
@@ -5,7 +5,7 @@ import * as Layout from "./layout";
 import {processBox} from "./scene-graph";
 
 import type {Context} from "../types";
-import type {Group, Point} from "./scene-graph";
+import type {Group} from "./scene-graph";
 
 // Dedupe this with editor/src/util.ts
 export const isGlyph = (
@@ -305,8 +305,8 @@ const _typeset = (node: Editor.types.Node, context: Context): Layout.Node => {
 
     switch (node.type) {
         case "row": {
-            // ignore
-            throw new Error("we shouldn't be processing rows here");
+            // The only time this can happen is if limits.inner is a row
+            return typesetRow(node, context);
         }
         case "frac": {
             const newMultiplier = cramped ? 0.5 : 1.0;
@@ -668,9 +668,7 @@ const _typesetZipper = (
 };
 
 type Options = {
-    // cursor?: LayoutCursor | undefined;
-    // cancelRegions?: LayoutCursor[] | undefined;
-    loc?: Point | undefined;
+    showCursor?: boolean;
 };
 
 export const typesetZipper = (
@@ -679,5 +677,5 @@ export const typesetZipper = (
     options: Options = {},
 ): Group => {
     const box = _typesetZipper(zipper, context) as Layout.Box;
-    return processBox({box, ...options});
+    return processBox(box, options);
 };


### PR DESCRIPTION
This PR also fixes some rendering issues with selections in typesetZipper's output, namely:
- when selecting across multiple levels in the hierarchy, there would be multiple selection rectangles overlapping
- when selecting from the edge of a inner row, the cursor would still be rendered as well as the selections

TODO:
- [ ] include missing ascent and descent in typesetting output