### PR TITLE
Generate MathML from semantic tree use it in an accessible math renderer

### DIFF
--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -4,6 +4,7 @@ import {Link, Switch, Route, BrowserRouter as Router} from "react-router-dom";
 
 import EditorPage from "./editor/editor-page";
 import ZipperEditorPage from "./zipper-editor/zipper-editor-page";
+import MathmlPage from "./mathml/mathml-page";
 import HandwritingPage from "./handwriting/handwriting-page";
 import SolverPage from "./solver/solver-page";
 import TutorPage from "./tutor/tutor-page";
@@ -20,7 +21,10 @@ ReactDOM.render(
             <Route path="/zipper-editor">
                 <ZipperEditorPage />
             </Route>
-            <Route path="/editor-test">
+            <Route path="/mathml">
+                <MathmlPage />
+            </Route>
+            <Route path="/multirow-editor-test">
                 <EditorPage />
             </Route>
             <Route path="/handwriting">
@@ -39,7 +43,12 @@ ReactDOM.render(
                         <Link to="/zipper-editor">Zipper Editor</Link>
                     </li>
                     <li>
-                        <Link to="/editor-test">Editor test</Link>
+                        <Link to="/mathml">Mathml</Link>
+                    </li>
+                    <li>
+                        <Link to="/multirow-editor-test">
+                            Multi-row Editor test
+                        </Link>
                     </li>
                     <li>
                         <Link to="/handwriting">Handwriting input</Link>

--- a/demo/src/mathml/accessible-math.tsx
+++ b/demo/src/mathml/accessible-math.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import {MathmlRenderer, MathRenderer} from "@math-blocks/react";
+import * as Editor from "@math-blocks/editor-core";
+import {typesetZipper} from "@math-blocks/typesetter";
+import fontMetrics from "@math-blocks/metrics";
+
+type Props = {
+    math: Editor.types.Row;
+};
+
+const AccessibleMath: React.FC<Props> = (props) => {
+    const {math} = props;
+
+    const zipper: Editor.Zipper = {
+        breadcrumbs: [],
+        row: {
+            id: math.id,
+            type: "zrow",
+            left: [],
+            selection: null,
+            right: math.children,
+        },
+    };
+
+    const fontSize = 64;
+    const context = {
+        fontMetrics,
+        baseFontSize: fontSize,
+        multiplier: 1.0,
+        cramped: false,
+        colorMap: undefined,
+    };
+
+    const options = {showCursor: false};
+
+    const scene = typesetZipper(zipper, context, options);
+    const node = Editor.parse(math);
+    console.log(node);
+
+    const mathRef = React.useRef<SVGSVGElement>(null);
+    const mathmlRef = React.useRef<HTMLElement>(null);
+
+    const [transform, setTransform] = React.useState<string>("scale(1, 1)");
+
+    React.useEffect(() => {
+        if (mathRef.current && mathmlRef.current) {
+            const svg = mathRef.current;
+            const math = mathmlRef.current;
+
+            const svgBounds = svg.getBoundingClientRect();
+            const mathBounds = math.getBoundingClientRect();
+
+            // TODO: grab the bounds from the scene graph instead, then we don't
+            // need to use ref shenanigans.
+            const scaleX = svgBounds.width / mathBounds.width;
+            const scaleY = svgBounds.height / mathBounds.height;
+
+            setTransform(`scale(${scaleX}, ${scaleY})`);
+        }
+    }, [mathRef, mathmlRef]);
+
+    const DEBUG = false;
+
+    return (
+        <div style={{position: "relative"}}>
+            <MathRenderer scene={scene} ref={mathRef} />
+            <div
+                style={{
+                    position: "absolute",
+                    left: 0,
+                    top: 0,
+                    opacity: DEBUG ? 0.25 : 1.0,
+                    transformOrigin: "left top",
+                    transform: transform,
+                }}
+            >
+                <MathmlRenderer
+                    math={node}
+                    style={{
+                        fontSize: 60,
+                        opacity: DEBUG ? 1.0 : 0.0,
+                        fontFamily: "Comic Sans MS",
+                    }}
+                    ref={mathmlRef}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default AccessibleMath;

--- a/demo/src/mathml/mathml-page.tsx
+++ b/demo/src/mathml/mathml-page.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+
+import * as Editor from "@math-blocks/editor-core";
+const {row, glyph, frac, root} = Editor.builders;
+
+import AccessibleMath from "./accessible-math";
+
+const MathmlPage: React.FunctionComponent = () => {
+    const linearEquation = Editor.util.row("2x+5=10");
+    const pythagoras = row([
+        glyph("a"),
+        Editor.util.sup("2"),
+        glyph("+"),
+        glyph("b"),
+        Editor.util.sup("2"),
+        glyph("="),
+        glyph("c"),
+        Editor.util.sup("2"),
+    ]);
+    const quadraticEquation = row([
+        glyph("x"),
+        glyph("="),
+        frac(
+            [
+                glyph("\u2212"),
+                glyph("b"),
+                glyph("\u00B1"),
+                root(null, [
+                    glyph("b"),
+                    Editor.util.sup("2"),
+                    glyph("\u2212"),
+                    glyph("4"),
+                    glyph("a"),
+                    glyph("c"),
+                ]),
+            ],
+            [glyph("2"), glyph("a")],
+        ),
+    ]);
+    const factoring = Editor.util.row("(x-1)(x+1)=0");
+
+    return (
+        <div>
+            <h1>MathML Test Page</h1>
+            <div
+                style={{
+                    display: "grid",
+                    gridTemplateColumns: "auto auto",
+                    rowGap: 60,
+                }}
+            >
+                <h2>Linear Equation</h2>
+                <AccessibleMath math={linearEquation} />
+                <h2>Pythagoras Theorem</h2>
+                <AccessibleMath math={pythagoras} />
+                <h2>Quadratic Equation</h2>
+                <AccessibleMath math={quadraticEquation} />
+                <h2>Factoring</h2>
+                <AccessibleMath math={factoring} />
+            </div>
+        </div>
+    );
+};
+
+export default MathmlPage;

--- a/demo/src/zipper-editor/zipper-editor-page.tsx
+++ b/demo/src/zipper-editor/zipper-editor-page.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 
-import {ZipperEditor, MathKeypad} from "@math-blocks/react";
+import {
+    ZipperEditor,
+    MathKeypad,
+    MathmlRenderer,
+    MathRenderer,
+} from "@math-blocks/react";
 import * as Editor from "@math-blocks/editor-core";
+import {typesetZipper} from "@math-blocks/typesetter";
+import fontMetrics from "@math-blocks/metrics";
 
 // import EditingPanel from "./editing-panel";
 
@@ -35,6 +42,7 @@ const allNodeTypes = Editor.builders.row([
     Editor.builders.glyph("\u2212"),
     Editor.builders.glyph("y"),
 ]);
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const nestedFractions = Editor.builders.row([
     Editor.builders.glyph("a"),
     Editor.builders.glyph("+"),
@@ -56,7 +64,7 @@ const nestedFractions = Editor.builders.row([
         ],
         [Editor.builders.glyph("1")],
     ),
-    Editor.builders.glyph("-"),
+    Editor.builders.glyph("\u2212"),
     Editor.builders.glyph("b"),
 ]);
 
@@ -71,22 +79,63 @@ const zipper: Editor.Zipper = {
     },
 };
 
-const EditorPage: React.FunctionComponent = () => (
-    <div>
-        <ZipperEditor
-            readonly={false}
-            zipper={zipper}
-            focus={true}
-            onChange={(value) => {
-                console.log(value);
-            }}
-        />
-        <div style={{position: "fixed", bottom: 0, left: 0}}>
-            {/* <EditingPanel /> */}
-            <div style={{height: 8}} />
-            <MathKeypad />
+const EditorPage: React.FunctionComponent = () => {
+    const [value, setValue] = React.useState(nestedFractions);
+    let node = null;
+    try {
+        node = Editor.parse(value);
+        console.log(node);
+    } catch (e) {
+        // drop the error
+    }
+
+    const fontSize = 64;
+    const context = {
+        fontMetrics,
+        baseFontSize: fontSize,
+        multiplier: 1.0,
+        cramped: false,
+        colorMap: undefined,
+    };
+
+    const options = {showCursor: false};
+
+    const scene = typesetZipper(zipper, context, options);
+
+    return (
+        <div>
+            <div style={{display: "flex", alignItems: "center"}}>
+                <ZipperEditor
+                    readonly={false}
+                    zipper={zipper}
+                    focus={true}
+                    onChange={(value) => {
+                        // console.log(value);
+                        setValue(value);
+                    }}
+                />
+                <div style={{position: "relative"}}>
+                    <MathRenderer scene={scene} />
+                    <div
+                        style={{
+                            position: "absolute",
+                            left: 0,
+                            top: 0,
+                            transform:
+                                "scale(1.13, 1.18) translate(25px, 12px)",
+                        }}
+                    >
+                        <MathmlRenderer math={node} />
+                    </div>
+                </div>
+            </div>
+            <div style={{position: "fixed", bottom: 0, left: 0}}>
+                {/* <EditingPanel /> */}
+                <div style={{height: 8}} />
+                <MathKeypad />
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default EditorPage;

--- a/packages/editor-core/src/parser/lexer.ts
+++ b/packages/editor-core/src/parser/lexer.ts
@@ -31,6 +31,7 @@ type Ident = {kind: "identifier"; name: string};
 type Num = {kind: "number"; value: string};
 type Plus = {kind: "plus"};
 type Minus = {kind: "minus"};
+type PlusMinus = {kind: "plusminus"};
 type Times = {kind: "times"};
 type Equal = {kind: "eq"};
 type LParens = {kind: "lparens"};
@@ -61,6 +62,9 @@ export const plus = (loc: SourceLocation): Atom => atom({kind: "plus"}, loc);
 
 export const minus = (loc: SourceLocation): Atom => atom({kind: "minus"}, loc);
 
+export const plusminus = (loc: SourceLocation): Atom =>
+    atom({kind: "plusminus"}, loc);
+
 export const times = (loc: SourceLocation): Atom => atom({kind: "times"}, loc);
 
 export const lparens = (loc: SourceLocation): Atom =>
@@ -79,6 +83,7 @@ export type Token =
     | Num
     | Plus
     | Minus
+    | PlusMinus
     | Times
     | Equal
     | LParens
@@ -89,7 +94,7 @@ export type Token =
     | Lim
     | EOL;
 
-const TOKEN_REGEX = /([1-9]*[0-9]\.?[0-9]*|\.[0-9]+)|(\*|\u00B7|\+|\u2212|=|\(|\)|\.\.\.)|(sin|cos|tan|[a-z])/gi;
+const TOKEN_REGEX = /([1-9]*[0-9]\.?[0-9]*|\.[0-9]+)|(\*|\u00B7|\u00B1|\+|\u2212|=|\(|\)|\.\.\.)|(sin|cos|tan|[a-z])/gi;
 
 // TODO: include ids of source glyphs in parsed tokens
 
@@ -138,6 +143,9 @@ const processGlyphs = (
                         break;
                     case "\u2212":
                         tokens.push(minus(loc));
+                        break;
+                    case "\u00B1":
+                        tokens.push(plusminus(loc));
                         break;
                     case "...":
                         tokens.push(ellipsis(loc));

--- a/packages/editor-core/src/parser/types.ts
+++ b/packages/editor-core/src/parser/types.ts
@@ -7,11 +7,13 @@ export type SourceLocation = {
 
 import * as sharedTypes from "../shared-types";
 
+// TODO: dedupe with lexer.ts
 export type Token =
     | {kind: "identifier"; name: string}
     | {kind: "number"; value: string}
     | {kind: "plus"}
     | {kind: "minus"}
+    | {kind: "plusminus"}
     | {kind: "times"}
     | {kind: "eq"}
     | {kind: "lparens"}

--- a/packages/parser-factory/src/builders.ts
+++ b/packages/parser-factory/src/builders.ts
@@ -76,6 +76,18 @@ export const neg = (
     loc,
 });
 
+export const plusminus = (
+    arg: types.Node,
+    arity: "unary" | "binary",
+    loc?: types.SourceLocation,
+): types.PlusMinus => ({
+    type: "plusminus",
+    id: getId(),
+    arg,
+    arity,
+    loc,
+});
+
 export const div = (
     num: types.Node,
     den: types.Node,

--- a/packages/parser-factory/src/types.ts
+++ b/packages/parser-factory/src/types.ts
@@ -23,6 +23,8 @@ export type NumericNode =
     | Pow
     | Log
     | Neg
+    | PlusMinus
+    | MinusPlus
     | Abs
     | Parens
     | Sum
@@ -77,7 +79,19 @@ export type Mul = Common & {
 export type Neg = Common & {
     type: "neg";
     arg: Node;
-    subtraction: boolean;
+    subtraction: boolean; // TODO: change this to `arity: "unary" | "binary";`
+};
+
+export type PlusMinus = Common & {
+    type: "plusminus";
+    arg: Node;
+    arity: "unary" | "binary";
+};
+
+export type MinusPlus = Common & {
+    type: "minusplus";
+    arg: Node;
+    arity: "unary" | "binary";
 };
 
 /**
@@ -541,7 +555,7 @@ export interface Common {
     source?: string;
 }
 
-// TODO: dedup with editor-core and semantic
+// TODO: dedupe with editor-core and parser-factory
 export interface SourceLocation {
     path: readonly number[];
     start: number;

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
@@ -2,29 +2,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
     <g transform="translate(0,54.4)" id="7">
         <rect type="rect" x="35.62109375" y="-54.4" width="2" height="64"></rect>
-        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             2
         </text>
-        <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+        <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
             x
         </text>
         <g transform="translate(72.041015625,0)" id="2">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                 +
             </text>
         </g>
-        <text x="130.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1">
+        <text x="130.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1" aria-hidden="true">
             5
         </text>
         <g transform="translate(167.490234375,0)" id="4">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                 =
             </text>
         </g>
-        <text x="228.10546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+        <text x="228.10546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
             1
         </text>
-        <text x="255.1171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1">
+        <text x="255.1171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
             0
         </text>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
     <g transform="translate(0,54.4)" id="7">
-        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             2
         </text>
-        <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+        <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
             x
         </text>
         <g transform="translate(72.041015625,0)" id="2">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                 +
             </text>
         </g>
-        <text x="130.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1">
+        <text x="130.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1" aria-hidden="true">
             5
         </text>
         <g transform="translate(167.490234375,0)" id="4">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                 =
             </text>
         </g>
-        <text x="228.10546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+        <text x="228.10546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
             1
         </text>
-        <text x="255.1171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1">
+        <text x="255.1171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
             0
         </text>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
@@ -3,17 +3,17 @@
     <g transform="translate(0,76.51171875)" id="8">
         <g transform="translate(0,-22)" style="color:darkcyan" id="5">
             <g transform="translate(10.6904296875,-7.490234375)" id="6">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
                     1
                 </text>
             </g>
             <g transform="translate(0,76.158203125)" style="color:orange" id="7">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     2
                 </text>
                 <g transform="translate(36.62109375,-10)" id="3">
                     <g transform="translate(0,-22.2431640625)" style="color:pink" id="4">
-                        <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1">
+                        <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                             i
                         </text>
                     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 465.935546875 160.66015625" width="465.935546875" height="160.66015625">
     <g transform="translate(0,107.1484375)" id="20">
-        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             x
         </text>
         <g transform="translate(35.419921875,0)" id="1">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                 =
             </text>
         </g>
         <g transform="translate(96.03515625,-22)" id="17">
             <g transform="translate(0,-7.490234375)" id="18">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                     −
                 </text>
-                <text x="28.828125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1">
+                <text x="28.828125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1" aria-hidden="true">
                     b
                 </text>
                 <g transform="translate(64.423828125,0)" id="4">
-                    <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+                    <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                         ±
                     </text>
                 </g>
                 <g transform="translate(123.251953125,0)" id="13">
                     <g transform="translate(0,-29.904296875)" id="undefined">
-                        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1">
+                        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true">
                             √
                         </text>
                     </g>
                     <g transform="translate(26.4453125,0)" id="undefined">
                         <g transform="translate(0,0)" id="14">
-                            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+                            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
                                 b
                             </text>
                             <g transform="translate(35.595703125,-10)" id="7">
                                 <g transform="translate(0,-22.2431640625)" id="8">
-                                    <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1">
+                                    <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                                         2
                                     </text>
                                 </g>
                             </g>
                             <g transform="translate(61.23046875,0)" id="9">
-                                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1">
+                                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1" aria-hidden="true">
                                     −
                                 </text>
                             </g>
-                            <text x="120.05859375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1">
+                            <text x="120.05859375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1" aria-hidden="true">
                                 4
                             </text>
-                            <text x="156.6796875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1">
+                            <text x="156.6796875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1" aria-hidden="true">
                                 a
                             </text>
-                            <text x="187.3828125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1">
+                            <text x="187.3828125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1" aria-hidden="true">
                                 c
                             </text>
                         </g>
@@ -60,10 +60,10 @@
                 </g>
             </g>
             <g transform="translate(150.2880859375,58.021484375)" id="19">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="15" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="15" style="opacity:1" aria-hidden="true">
                     2
                 </text>
-                <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="16" style="opacity:1">
+                <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="16" style="opacity:1" aria-hidden="true">
                     a
                 </text>
             </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
@@ -3,34 +3,34 @@
     <g transform="translate(0,54.4)" id="11">
         <g transform="translate(0,0)" id="8">
             <g transform="translate(0,40.5478515625)" id="9">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                     x
                 </text>
-                <text x="24.7939453125" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="5" style="opacity:1">
+                <text x="24.7939453125" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
                     —
                 </text>
-                <text x="61.8720703125" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1">
+                <text x="61.8720703125" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                     &gt;
                 </text>
-                <text x="77.888671875" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="7" style="opacity:1">
+                <text x="77.888671875" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="7" style="opacity:1" aria-hidden="true">
                     0
                 </text>
             </g>
             <g transform="translate(0,0)" id="undefined">
                 <g transform="translate(11.830078125,0)" id="3">
-                    <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+                    <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
                         l
                     </text>
-                    <text x="16.435546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+                    <text x="16.435546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                         i
                     </text>
-                    <text x="33.251953125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
+                    <text x="33.251953125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                         m
                     </text>
                 </g>
             </g>
         </g>
-        <text x="103.5234375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1">
+        <text x="103.5234375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1" aria-hidden="true">
             x
         </text>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
@@ -3,40 +3,40 @@
     <g transform="translate(0,95.71875)" id="16">
         <g transform="translate(0,0)" id="5">
             <g transform="translate(11.84326171875,-62.8037109375)" id="7">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                     ∞
                 </text>
             </g>
             <g transform="translate(0,37.7060546875)" id="6">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     i
                 </text>
-                <text x="11.771484375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1">
+                <text x="11.771484375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                     =
                 </text>
-                <text x="33.2021484375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="3" style="opacity:1">
+                <text x="33.2021484375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="3" style="opacity:1" aria-hidden="true">
                     0
                 </text>
             </g>
             <g transform="translate(0,0)" id="undefined">
-                <text x="7.00634765625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+                <text x="7.00634765625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
                     Σ
                 </text>
             </g>
         </g>
         <g transform="translate(58.8369140625,-22)" id="13">
             <g transform="translate(10.6904296875,-7.490234375)" id="14">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="8" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="8" style="opacity:1" aria-hidden="true">
                     1
                 </text>
             </g>
             <g transform="translate(0,76.158203125)" id="15">
-                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1" aria-hidden="true">
                     2
                 </text>
                 <g transform="translate(36.62109375,-10)" id="11">
                     <g transform="translate(0,-22.2431640625)" id="12">
-                        <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="10" style="opacity:1">
+                        <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="10" style="opacity:1" aria-hidden="true">
                             i
                         </text>
                     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
@@ -5,29 +5,29 @@
         <rect type="rect" x="130.869140625" y="-54.4" width="36.62109375" height="64" fill="rgba(0,64,255,0.3)"></rect>
         <rect type="rect" x="72.041015625" y="-54.4" width="58.828125" height="64" fill="rgba(0,64,255,0.3)"></rect>
         <rect type="rect" x="36.62109375" y="-54.4" width="35.419921875" height="64" fill="rgba(0,64,255,0.3)"></rect>
-        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             2
         </text>
-        <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+        <text x="36.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
             x
         </text>
         <g transform="translate(72.041015625,0)" id="2">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                 +
             </text>
         </g>
-        <text x="130.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1">
+        <text x="130.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="3" style="opacity:1" aria-hidden="true">
             5
         </text>
         <g transform="translate(167.490234375,0)" id="4">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                 =
             </text>
         </g>
-        <text x="228.10546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+        <text x="228.10546875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
             1
         </text>
-        <text x="255.1171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1">
+        <text x="255.1171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
             0
         </text>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-subtracting-from-both-sides.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-subtracting-from-both-sides.svg
@@ -2,47 +2,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 412.56640625 120" width="412.56640625" height="120">
     <g transform="translate(0,51)" id="undefined">
         <g transform="translate(0,0)" id="14">
-            <text x="30" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1">
+            <text x="30" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                 2
             </text>
-            <text x="66.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1">
+            <text x="66.62109375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                 x
             </text>
             <g transform="translate(102.041015625,0)" id="4">
-                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                     +
                 </text>
             </g>
-            <text x="160.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1">
+            <text x="160.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                 5
             </text>
             <g transform="translate(197.490234375,0)" id="8">
-                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="8" style="opacity:1">
+                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="8" style="opacity:1" aria-hidden="true">
                     =
                 </text>
             </g>
-            <text x="316.93359375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1">
+            <text x="316.93359375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1" aria-hidden="true">
                 1
             </text>
-            <text x="343.9453125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1">
+            <text x="343.9453125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1" aria-hidden="true">
                 0
             </text>
         </g>
         <g transform="translate(0,60)" id="26">
             <g transform="translate(102.041015625,0)" id="17">
-                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="17" style="opacity:1">
+                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="17" style="opacity:1" aria-hidden="true">
                     −
                 </text>
             </g>
-            <text x="160.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="19" style="opacity:1">
+            <text x="160.869140625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="19" style="opacity:1" aria-hidden="true">
                 5
             </text>
             <g transform="translate(258.10546875,0)" id="22">
-                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="22" style="opacity:1">
+                <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="22" style="opacity:1" aria-hidden="true">
                     −
                 </text>
             </g>
-            <text x="343.9453125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="24" style="opacity:1">
+            <text x="343.9453125" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="24" style="opacity:1" aria-hidden="true">
                 5
             </text>
         </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 67.091796875" width="295.466796875" height="67.091796875">
     <g transform="translate(0,65.158203125)" id="14">
-        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             a
         </text>
         <g transform="translate(30.703125,-10)" id="2">
             <g transform="translate(0,-22.2431640625)" id="3">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     2
                 </text>
             </g>
         </g>
         <g transform="translate(56.337890625,0)" id="4">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                 +
             </text>
         </g>
-        <text x="115.166015625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+        <text x="115.166015625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
             b
         </text>
         <g transform="translate(150.76171875,-10)" id="7">
             <g transform="translate(0,-22.2431640625)" id="8">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                     2
                 </text>
             </g>
         </g>
         <g transform="translate(176.396484375,0)" id="9">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1" aria-hidden="true">
                 =
             </text>
         </g>
-        <text x="237.01171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1">
+        <text x="237.01171875" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="10" style="opacity:1" aria-hidden="true">
             c
         </text>
         <g transform="translate(267.83203125,-10)" id="12">
             <g transform="translate(0,-22.2431640625)" id="13">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="11" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="11" style="opacity:1" aria-hidden="true">
                     2
                 </text>
             </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 364.408203125 100.31640625" width="364.408203125" height="100.31640625">
     <g transform="translate(0,65.158203125)" id="18">
-        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1">
+        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             a
         </text>
         <g transform="translate(30.703125,-10)" id="2">
             <g transform="translate(0,-22.2431640625)" id="3">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     n
                 </text>
             </g>
         </g>
         <g transform="translate(52.6875,0)" id="4">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                 =
             </text>
         </g>
-        <text x="113.302734375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1">
+        <text x="113.302734375" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
             a
         </text>
         <g transform="translate(144.005859375,-10)" id="9">
             <g transform="translate(0,32.9150390625)" id="10">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                     n
                 </text>
-                <text x="21.984375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="7" style="opacity:1">
+                <text x="21.984375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="7" style="opacity:1" aria-hidden="true">
                     −
                 </text>
-                <text x="42.1640625" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="8" style="opacity:1">
+                <text x="42.1640625" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="8" style="opacity:1" aria-hidden="true">
                     1
                 </text>
             </g>
         </g>
         <g transform="translate(205.078125,0)" id="11">
-            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1">
+            <text x="15" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="11" style="opacity:1" aria-hidden="true">
                 +
             </text>
         </g>
-        <text x="263.90625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1">
+        <text x="263.90625" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="12" style="opacity:1" aria-hidden="true">
             a
         </text>
         <g transform="translate(294.609375,-10)" id="16">
             <g transform="translate(0,32.9150390625)" id="17">
-                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="13" style="opacity:1">
+                <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="13" style="opacity:1" aria-hidden="true">
                     n
                 </text>
-                <text x="21.984375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="14" style="opacity:1">
+                <text x="21.984375" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="14" style="opacity:1" aria-hidden="true">
                     −
                 </text>
-                <text x="42.1640625" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="15" style="opacity:1">
+                <text x="42.1640625" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="15" style="opacity:1" aria-hidden="true">
                     2
                 </text>
             </g>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,7 @@
 import MathEditor from "./math-editor";
 import MathKeypad from "./math-keypad";
 import MathRenderer from "./math-renderer";
+import MathmlRenderer from "./mathml-renderer";
 import ZipperEditor from "./zipper-editor";
 
-export {MathEditor, MathKeypad, MathRenderer, ZipperEditor};
+export {MathEditor, MathKeypad, MathRenderer, MathmlRenderer, ZipperEditor};

--- a/packages/react/src/math-renderer.tsx
+++ b/packages/react/src/math-renderer.tsx
@@ -38,6 +38,7 @@ const Glyph: React.FunctionComponent<SceneGraph.Glyph> = ({x, y, glyph}) => {
             fill={glyph.color || "currentcolor"}
             id={id}
             style={{opacity: glyph.pending ? 0.5 : 1.0}}
+            aria-hidden="true"
         >
             {glyph.char}
         </text>
@@ -87,7 +88,7 @@ type Props = {
     style?: React.CSSProperties;
 };
 
-const MathRenderer: React.FunctionComponent<Props> = (props) => {
+const MathRenderer = React.forwardRef<SVGSVGElement, Props>((props, ref) => {
     const {scene, style} = props;
     const {width, height} = scene;
     const padding = CURSOR_WIDTH / 2;
@@ -100,10 +101,13 @@ const MathRenderer: React.FunctionComponent<Props> = (props) => {
             width={width + CURSOR_WIDTH}
             height={height}
             style={style}
+            ref={ref}
         >
             <Group {...scene} />
         </svg>
     );
-};
+});
+
+MathRenderer.displayName = "MathRenderer";
 
 export default MathRenderer;

--- a/packages/react/src/mathml-renderer.tsx
+++ b/packages/react/src/mathml-renderer.tsx
@@ -1,0 +1,163 @@
+import * as React from "react";
+
+import * as Semantic from "@math-blocks/semantic";
+
+// pipelines:
+// Semantic -> HAST(MathML) -> React/Vue/etc.
+// Editor -> HAST(SVG) -> React/Vue/etc.
+
+const print = (math: Semantic.types.Node): React.ReactElement | null => {
+    switch (math.type) {
+        case "add": {
+            // TODO: handle adding parens when necessary (this is kind of link printers we have)
+            const children: React.ReactNode[] = [];
+            // TODO: give each child a key
+            for (const arg of math.args) {
+                if (arg.type === "neg" && arg.subtraction) {
+                    children.push(<mo>-</mo>);
+                } else if (arg.type === "plusminus" && arg.arity === "binary") {
+                    children.push(<mo>±</mo>);
+                } else {
+                    children.push(<mo>+</mo>);
+                }
+                children.push(print(arg));
+            }
+            children.shift(); // removes the leading operator
+            return <mrow>{children}</mrow>;
+        }
+        case "mul": {
+            const children: React.ReactNode[] = [];
+            // TODO: give each child a key
+            for (const arg of math.args) {
+                const child = print(arg);
+                if (arg.type === "add") {
+                    children.push(
+                        <mrow>
+                            <mo>(</mo>
+                            {child}
+                            <mo>)</mo>
+                        </mrow>,
+                    );
+                } else {
+                    children.push(child);
+                }
+                if (math.implicit) {
+                    children.push(<mo>&#x2062;</mo>); // invisible times
+                } else {
+                    children.push(<mo>&times;</mo>);
+                }
+            }
+            children.pop(); // removes the trailing operator
+            return <mrow>{children}</mrow>;
+        }
+        case "number": {
+            return <mn>{math.value}</mn>;
+        }
+        case "identifier": {
+            if (math.subscript) {
+                return (
+                    <msub>
+                        <mi>{math.name}</mi>
+                        {print(math.subscript)}
+                    </msub>
+                );
+            } else {
+                return <mi>{math.name}</mi>;
+            }
+        }
+        case "neg": {
+            const arg = print(math.arg);
+            return math.subtraction ? (
+                arg
+            ) : (
+                <mrow>
+                    <mo>-</mo>
+                    {arg}
+                </mrow>
+            );
+        }
+        case "plusminus": {
+            const arg = print(math.arg);
+            return math.arity === "binary" ? (
+                arg
+            ) : (
+                <mrow>
+                    <mo>±</mo>
+                    {arg}
+                </mrow>
+            );
+        }
+        case "eq": {
+            const children: React.ReactNode[] = [];
+            // TODO: give each child a key
+            for (const arg of math.args) {
+                children.push(print(arg));
+                children.push(<mo>=</mo>);
+            }
+            children.pop(); // removes the trailing &equals;
+            return <mrow>{children}</mrow>;
+        }
+        case "div": {
+            // TODO: fraction from division using the division operator
+            // TODO: remove <mrow> wrapper on children
+            return (
+                <mfrac>
+                    {print(math.args[0])}
+                    {print(math.args[1])}
+                </mfrac>
+            );
+        }
+        case "pow": {
+            // TODO: check if math.base is an identifier with a subscript and
+            // use msubsup in that situation
+            return (
+                <msup>
+                    {print(math.base)}
+                    {print(math.exp)}
+                </msup>
+            );
+        }
+        case "root": {
+            if (math.sqrt) {
+                // TODO: remove extra <mrow>
+                return <msqrt>{print(math.radicand)}</msqrt>;
+            } else {
+                return (
+                    <mroot>
+                        {print(math.radicand)}
+                        {print(math.index)}
+                    </mroot>
+                );
+            }
+        }
+        default: {
+            return null;
+        }
+    }
+};
+
+type Props = {
+    math: Semantic.types.Node | null;
+    style?: React.CSSProperties;
+};
+
+const MathmlRenderer = React.forwardRef<HTMLElement, Props>((props, ref) => {
+    const {math, style} = props;
+
+    if (!math) {
+        return null;
+    }
+    return (
+        <math
+            xmlns="http://www.w3.org/1998/Math/MathML"
+            ref={ref}
+            style={style}
+        >
+            {print(math)}
+        </math>
+    );
+});
+
+MathmlRenderer.displayName = "MathmlRenderer";
+
+export default MathmlRenderer;

--- a/packages/react/src/mathml.d.ts
+++ b/packages/react/src/mathml.d.ts
@@ -1,0 +1,24 @@
+declare namespace JSX {
+    type MathmlProps = {
+        class?: string;
+        id?: string;
+        style?: React.CSSProperties;
+        children?: React.ReactNode;
+    };
+
+    interface IntrinsicElements {
+        mrow: MathmlProps;
+        mn: MathmlProps;
+        mi: MathmlProps;
+        mo: MathmlProps;
+        mfrac: MathmlProps; // TODO: restrict to two children
+        msup: MathmlProps;
+        msub: MathmlProps;
+        mroot: MathmlProps; // TODO: restrict to two children
+        msqrt: MathmlProps;
+        math: MathmlProps & {
+            xmlns: "http://www.w3.org/1998/Math/MathML";
+            ref?: React.Ref<HTMLElement>;
+        };
+    }
+}

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -18,6 +18,8 @@ export type NumericNode =
     | Pow
     | Log
     | Neg
+    | PlusMinus
+    | MinusPlus
     | Abs
     | Parens
     | Sum
@@ -72,7 +74,19 @@ export type Mul = Common & {
 export type Neg = Common & {
     type: "neg";
     arg: NumericNode;
-    subtraction: boolean;
+    subtraction: boolean; // TODO: change this to `arity: "unary" | "binary";`
+};
+
+export type PlusMinus = Common & {
+    type: "plusminus";
+    arg: NumericNode;
+    arity: "unary" | "binary";
+};
+
+export type MinusPlus = Common & {
+    type: "minusplus";
+    arg: NumericNode;
+    arity: "unary" | "binary";
 };
 
 /**


### PR DESCRIPTION
I've added a `MathmlRenderer` to `@math-blocks/react` and use it as part of a `AccessibilityRenderer` in a new MathML demo page.  The `AccessibilityRenderer` uses `Renderer` to display a visual representation of the math with a `MathmlRenderer` above it with opacity set to zero.  VoiceOver can be used to navigate the MathML that's rendered including drilling down into sub-expressions.