### PR TITLE
Dedupe code in typeset.ts

### DIFF
--- a/demo/src/editor/editor-page.tsx
+++ b/demo/src/editor/editor-page.tsx
@@ -14,26 +14,58 @@ const allNodeTypes = Editor.builders.row([
     Editor.builders.frac(
         [Editor.builders.glyph("1")],
         [
-            Editor.builders.root(null, [
-                Editor.builders.glyph("x"),
-                Editor.builders.subsup(undefined, [Editor.builders.glyph("2")]),
-                Editor.builders.glyph("+"),
-                Editor.builders.frac(
-                    [Editor.builders.glyph("1")],
-                    [
-                        Editor.builders.glyph("a"),
-                        Editor.builders.subsup(
-                            [Editor.builders.glyph("n")],
-                            undefined,
-                        ),
-                    ],
-                ),
-            ]),
+            Editor.builders.root(
+                [
+                    Editor.builders.glyph("1"),
+                    Editor.builders.glyph("2"),
+                    Editor.builders.glyph("3"),
+                ],
+                [
+                    Editor.builders.glyph("x"),
+                    Editor.builders.subsup(undefined, [
+                        Editor.builders.glyph("2"),
+                    ]),
+                    Editor.builders.glyph("+"),
+                    Editor.builders.frac(
+                        [Editor.builders.glyph("1")],
+                        [
+                            Editor.builders.glyph("a"),
+                            Editor.builders.subsup(
+                                [Editor.builders.glyph("n")],
+                                undefined,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
         ],
     ),
     Editor.builders.glyph("\u2212"),
     Editor.builders.glyph("\u2212"),
     Editor.builders.glyph("y"),
+    Editor.builders.glyph("+"),
+    Editor.builders.limits(
+        Editor.builders.row([
+            Editor.builders.glyph("l"),
+            Editor.builders.glyph("i"),
+            Editor.builders.glyph("m"),
+        ]),
+        [
+            Editor.builders.glyph("x"),
+            Editor.builders.glyph("\u2192"), // \rightarrow
+            Editor.builders.glyph("0"),
+        ],
+    ),
+    Editor.builders.glyph("+"),
+    Editor.builders.limits(
+        Editor.builders.glyph("\u2211"), // \sum
+        [
+            Editor.builders.glyph("i"),
+            Editor.builders.glyph("="),
+            Editor.builders.glyph("0"),
+        ],
+        [Editor.builders.glyph("\u221E")], // \infty
+    ),
 ]);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const nestedFractions = Editor.builders.row([
@@ -64,11 +96,11 @@ const nestedFractions = Editor.builders.row([
 const zipper: Editor.Zipper = {
     breadcrumbs: [],
     row: {
-        id: nestedFractions.id,
+        id: allNodeTypes.id,
         type: "zrow",
         left: [],
         selection: null,
-        right: nestedFractions.children,
+        right: allNodeTypes.children,
     },
 };
 

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 465.935546875 181.74015625" width="465.935546875" height="181.74015625">
-    <g transform="translate(0,121.66843750000001)" id="20">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 475.935546875 179.32015625000003" width="475.935546875" height="179.32015625000003">
+    <g transform="translate(0,119.24843750000001)" id="20">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             x
         </text>
@@ -23,13 +23,15 @@
                     </text>
                 </g>
                 <g transform="translate(123.251953125,0)" id="13">
-                    <g transform="translate(0,-29.904296875)" id="undefined">
-                        <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true">
-                            √
-                        </text>
+                    <g transform="translate(0,-27.484296875)" id="undefined">
+                        <g transform="translate(0,0)" id="undefined">
+                            <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true">
+                                √
+                            </text>
+                        </g>
                     </g>
-                    <g transform="translate(26.4453125,0)" id="undefined">
-                        <g transform="translate(0,0)" id="14">
+                    <g transform="translate(36.4453125,0)" id="undefined">
+                        <g transform="translate(0,1.4210854715202004e-14)" id="14">
                             <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
                                 b
                             </text>
@@ -55,11 +57,11 @@
                                 c
                             </text>
                         </g>
-                        <line type="line" x1="0" y1="-74.408203125" x2="218.203125" y2="-74.408203125" stroke="currentColor" stroke-width="6.5" stroke-linecap="butt"></line>
+                        <line type="line" x1="0" y1="-73.19820312499999" x2="218.203125" y2="-73.19820312499999" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                     </g>
                 </g>
             </g>
-            <g transform="translate(150.2880859375,58.06148437499999)" id="19">
+            <g transform="translate(155.2880859375,58.06148437499999)" id="19">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="15" style="opacity:1" aria-hidden="true">
                     2
                 </text>
@@ -68,7 +70,7 @@
                 </text>
             </g>
             <g transform="translate(0,-6.217248937900877e-15)" id="undefined">
-                <line type="line" x1="0" y1="0" x2="363.820390625" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="0" x2="373.820390625" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
     </g>

--- a/packages/typesetter/src/scene-graph.ts
+++ b/packages/typesetter/src/scene-graph.ts
@@ -102,7 +102,6 @@ const processHBox = (
     options: Options,
 ): Group => {
     const pen = {x: 0, y: 0};
-    const {multiplier} = box;
 
     const selectionBoxes: Rect[] = [];
     const editorLayer: Node[] = [];
@@ -116,9 +115,7 @@ const processHBox = (
         box.content[1].length > 0;
 
     const {fontMetrics} = fontData;
-    const ascent =
-        (FONT_SIZE * multiplier * fontMetrics.ascender) /
-        fontMetrics.unitsPerEm;
+    const ascent = (FONT_SIZE * fontMetrics.ascender) / fontMetrics.unitsPerEm;
 
     box.content.forEach((section, index) => {
         const isSelection = hasSelection && index === 1;
@@ -137,7 +134,7 @@ const processHBox = (
                 x: pen.x - CURSOR_WIDTH / 2,
                 y: pen.y - ascent,
                 width: CURSOR_WIDTH,
-                height: FONT_SIZE * multiplier,
+                height: FONT_SIZE,
             });
         }
 
@@ -152,7 +149,7 @@ const processHBox = (
 
                 const height = Math.max(
                     Layout.getHeight(node) + Layout.getDepth(node),
-                    FONT_SIZE * multiplier,
+                    FONT_SIZE,
                 );
 
                 selectionBoxes.push({


### PR DESCRIPTION
This PR also adds preliminary support for roots with an index.  There are some issues with tall indices that I'm going to punt on for now since it makes more sense to address those at the same time that we implement tall delimiters (surd in particular).  I've also updated the `allNodeTypes` example in editor-page.tsx to include "limits" nodes.