### PR TITLE
Add a renderMode option to tweak typesetting for static vs dynamic (editing) use cases

### DIFF
--- a/demo/src/mathml/accessible-math.tsx
+++ b/demo/src/mathml/accessible-math.tsx
@@ -19,6 +19,7 @@ const AccessibleMath: React.FC<Props> = (props) => {
         fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         colorMap: undefined,
     };

--- a/demo/src/solver/solver-page.tsx
+++ b/demo/src/solver/solver-page.tsx
@@ -71,6 +71,7 @@ const SolverPage: React.FunctionComponent = () => {
         },
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         // colorMap: props.colorMap,
     };

--- a/demo/src/solver/substeps.tsx
+++ b/demo/src/solver/substeps.tsx
@@ -27,6 +27,7 @@ const Substeps: React.FunctionComponent<Props> = ({prefix, start, step}) => {
         fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         // colorMap: props.colorMap,
     };

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64.51171875" width="293.73828125" height="64.51171875">
     <g transform="translate(0,54.40625)" id="7">
         <rect type="rect" x="35.62109375" y="-54.40625" width="2" height="64" fill="currentcolor"></rect>
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 50.392578125 169.24015625" width="50.392578125" height="169.24015625">
-    <g transform="translate(0,91.03171875000001)" id="8">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 50.392578125 118.6942578125" width="50.392578125" height="118.6942578125">
+    <g transform="translate(0,72.223125)" id="8">
         <g transform="translate(0,-15.48)" style="color:darkcyan" id="5">
-            <g transform="translate(10.6904296875,-28.530234375000006)" id="6">
+            <g transform="translate(10.6904296875,-11.069296875)" id="6">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
                     1
                 </text>
             </g>
-            <g transform="translate(0,76.19820312499999)" style="color:orange" id="7">
+            <g transform="translate(0,61.8632421875)" style="color:orange" id="7">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     2
                 </text>
                 <g transform="translate(36.62109375,-10)" id="3">
-                    <g transform="translate(0,-22.2431640625)" style="color:pink" id="4">
+                    <g transform="translate(0,-10.1025390625)" style="color:pink" id="4">
                         <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                             i
                         </text>
                     </g>
                 </g>
             </g>
-            <g transform="translate(0,-6.217248937900877e-15)" id="undefined">
+            <g transform="translate(0,8.881784197001252e-16)" id="undefined">
                 <line type="line" x1="0" y1="0" x2="44.312578125" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 475.935546875 179.32015625000003" width="475.935546875" height="179.32015625000003">
-    <g transform="translate(0,119.24843750000001)" id="20">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 475.935546875 134.40511718750003" width="475.935546875" height="134.40511718750003">
+    <g transform="translate(0,91.91152343750001)" id="20">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             x
         </text>
@@ -10,7 +10,7 @@
             </text>
         </g>
         <g transform="translate(96.03515625,-15.48)" id="17">
-            <g transform="translate(0,-28.530234375000006)" id="18">
+            <g transform="translate(0,-14.790000000000006)" id="18">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="2" style="opacity:1" aria-hidden="true">
                     −
                 </text>
@@ -23,7 +23,7 @@
                     </text>
                 </g>
                 <g transform="translate(123.251953125,0)" id="13">
-                    <g transform="translate(0,-27.484296875)" id="undefined">
+                    <g transform="translate(0,-13.887617187499998)" id="undefined">
                         <g transform="translate(0,0)" id="undefined">
                             <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true">
                                 √
@@ -31,12 +31,12 @@
                         </g>
                     </g>
                     <g transform="translate(36.4453125,0)" id="undefined">
-                        <g transform="translate(0,1.4210854715202004e-14)" id="14">
+                        <g transform="translate(0,0)" id="14">
                             <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="5" style="opacity:1" aria-hidden="true">
                                 b
                             </text>
                             <g transform="translate(35.595703125,-10)" id="7">
-                                <g transform="translate(0,-22.2431640625)" id="8">
+                                <g transform="translate(0,-10.0615234375)" id="8">
                                     <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                                         2
                                     </text>
@@ -57,11 +57,11 @@
                                 c
                             </text>
                         </g>
-                        <line type="line" x1="0" y1="-73.19820312499999" x2="218.203125" y2="-73.19820312499999" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                        <line type="line" x1="0" y1="-59.6015234375" x2="218.203125" y2="-59.6015234375" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                     </g>
                 </g>
             </g>
-            <g transform="translate(155.2880859375,58.06148437499999)" id="19">
+            <g transform="translate(155.2880859375,56.03999999999999)" id="19">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="15" style="opacity:1" aria-hidden="true">
                     2
                 </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 140.943359375 99.9296875" width="140.943359375" height="99.9296875">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 140.943359375 87.5634765625" width="140.943359375" height="87.5634765625">
     <g transform="translate(0,54.40625)" id="11">
         <g transform="translate(0,0)" id="8">
-            <g transform="translate(0,40.5478515625)" id="9">
+            <g transform="translate(0,39.5224609375)" id="9">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                     x
                 </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 109.2294921875 173.9271875" width="109.2294921875" height="173.9271875">
-    <g transform="translate(0,95.71875)" id="16">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 109.2294921875 118.6942578125" width="109.2294921875" height="118.6942578125">
+    <g transform="translate(0,72.223125)" id="16">
         <g transform="translate(0,0)" id="5">
-            <g transform="translate(11.84326171875,-62.8037109375)" id="7">
+            <g transform="translate(11.84326171875,-44.28515625)" id="7">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="4" style="opacity:1" aria-hidden="true">
                     ∞
                 </text>
             </g>
-            <g transform="translate(0,37.7060546875)" id="6">
+            <g transform="translate(0,36.6806640625)" id="6">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     i
                 </text>
@@ -25,24 +25,24 @@
             </g>
         </g>
         <g transform="translate(58.8369140625,-15.48)" id="13">
-            <g transform="translate(10.6904296875,-28.530234375000006)" id="14">
+            <g transform="translate(10.6904296875,-11.069296875)" id="14">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="8" style="opacity:1" aria-hidden="true">
                     1
                 </text>
             </g>
-            <g transform="translate(0,76.19820312499999)" id="15">
+            <g transform="translate(0,61.8632421875)" id="15">
                 <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="9" style="opacity:1" aria-hidden="true">
                     2
                 </text>
                 <g transform="translate(36.62109375,-10)" id="11">
-                    <g transform="translate(0,-22.2431640625)" id="12">
+                    <g transform="translate(0,-10.1025390625)" id="12">
                         <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="10" style="opacity:1" aria-hidden="true">
                             i
                         </text>
                     </g>
                 </g>
             </g>
-            <g transform="translate(0,-6.217248937900877e-15)" id="undefined">
+            <g transform="translate(0,8.881784197001252e-16)" id="undefined">
                 <line type="line" x1="0" y1="0" x2="44.312578125" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64" width="293.73828125" height="64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 293.73828125 64.51171875" width="293.73828125" height="64.51171875">
     <g transform="translate(0,54.40625)" id="7">
         <rect type="rect" x="167.490234375" y="-54.40625" width="60.615234375" height="64" fill="rgba(0,144,255,0.5)"></rect>
         <rect type="rect" x="130.869140625" y="-54.40625" width="36.62109375" height="64" fill="rgba(0,144,255,0.5)"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 67.091796875" width="295.466796875" height="67.091796875">
-    <g transform="translate(0,65.158203125)" id="14">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 295.466796875 64" width="295.466796875" height="64">
+    <g transform="translate(0,54.40625)" id="14">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             a
         </text>
         <g transform="translate(30.703125,-10)" id="2">
-            <g transform="translate(0,-22.2431640625)" id="3">
+            <g transform="translate(0,-10.0615234375)" id="3">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     2
                 </text>
@@ -20,7 +20,7 @@
             b
         </text>
         <g transform="translate(150.76171875,-10)" id="7">
-            <g transform="translate(0,-22.2431640625)" id="8">
+            <g transform="translate(0,-10.0615234375)" id="8">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                     2
                 </text>
@@ -35,7 +35,7 @@
             c
         </text>
         <g transform="translate(267.83203125,-10)" id="12">
-            <g transform="translate(0,-22.2431640625)" id="13">
+            <g transform="translate(0,-10.0615234375)" id="13">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="11" style="opacity:1" aria-hidden="true">
                     2
                 </text>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 364.408203125 100.31640625" width="364.408203125" height="100.31640625">
-    <g transform="translate(0,65.158203125)" id="18">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 364.408203125 67.2783203125" width="364.408203125" height="67.2783203125">
+    <g transform="translate(0,54.40625)" id="18">
         <text x="0" y="0" font-family="comic sans ms" font-size="60" fill="currentcolor" id="0" style="opacity:1" aria-hidden="true">
             a
         </text>
         <g transform="translate(30.703125,-10)" id="2">
-            <g transform="translate(0,-22.2431640625)" id="3">
+            <g transform="translate(0,-11.4560546875)" id="3">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="1" style="opacity:1" aria-hidden="true">
                     n
                 </text>
@@ -20,7 +20,7 @@
             a
         </text>
         <g transform="translate(144.005859375,-10)" id="9">
-            <g transform="translate(0,32.9150390625)" id="10">
+            <g transform="translate(0,31.9716796875)" id="10">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="6" style="opacity:1" aria-hidden="true">
                     n
                 </text>
@@ -41,7 +41,7 @@
             a
         </text>
         <g transform="translate(294.609375,-10)" id="16">
-            <g transform="translate(0,32.9150390625)" id="17">
+            <g transform="translate(0,31.5)" id="17">
                 <text x="0" y="0" font-family="comic sans ms" font-size="42" fill="currentcolor" id="13" style="opacity:1" aria-hidden="true">
                     n
                 </text>

--- a/packages/react/src/__tests__/renderer.test.tsx
+++ b/packages/react/src/__tests__/renderer.test.tsx
@@ -32,6 +32,7 @@ const context: Typesetter.Context = {
     fontData: fontData,
     baseFontSize: fontSize,
     mathStyle: Typesetter.MathStyle.Display,
+    renderMode: Typesetter.RenderMode.Static,
     cramped: false,
 };
 

--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -89,6 +89,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
         mathStyle: Typesetter.MathStyle.Display,
         cramped: false,
         colorMap: props.colorMap,
+        renderMode: Typesetter.RenderMode.Dynamic,
     };
 
     const options = {showCursor: active};

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -37,6 +37,7 @@ export const Small: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
     };
     const scene = Typesetter.typeset(math, context);
@@ -60,6 +61,7 @@ export const Equation: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
     };
     const scene = Typesetter.typeset(math, context);
@@ -93,6 +95,7 @@ export const Cursor: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Dynamic,
         cramped: false,
     };
     const options = {
@@ -133,6 +136,7 @@ export const Selection: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Dynamic,
         cramped: false,
     };
 
@@ -147,6 +151,7 @@ export const Pythagoras: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
     };
 
@@ -173,6 +178,7 @@ export const QuadraticEquation: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
     };
 
@@ -210,6 +216,7 @@ export const Limit: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
     };
 
@@ -235,6 +242,7 @@ export const Summation: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
     };
 
@@ -260,6 +268,7 @@ export const ColorizedFraction: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         colorMap: colorMap,
     };
@@ -305,6 +314,7 @@ export const ColorizedSum: React.FunctionComponent<EmptyProps> = () => {
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         colorMap: colorMap,
     };
@@ -340,6 +350,7 @@ export const SimpleSemanticColoring: React.FunctionComponent<EmptyProps> = () =>
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         colorMap: colorMap,
     };
@@ -381,6 +392,7 @@ export const NestedSemanticColoring: React.FunctionComponent<EmptyProps> = () =>
         fontData: fontData,
         baseFontSize: fontSize,
         mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Static,
         cramped: false,
         colorMap: colorMap,
     };

--- a/packages/typesetter/src/enums.ts
+++ b/packages/typesetter/src/enums.ts
@@ -4,3 +4,8 @@ export enum MathStyle {
     Script = "S",
     ScriptScript = "SS",
 }
+
+export enum RenderMode {
+    Static = "static",
+    Dynamic = "dynamic",
+}

--- a/packages/typesetter/src/layout.ts
+++ b/packages/typesetter/src/layout.ts
@@ -293,6 +293,7 @@ export const makeFract = (
     // TODO: fix this code once we have debugging outlines in place, right now
     // gap between the fraction bar and the numerator/denominator is too big
     // when the font has been scaled.
+    // Check context.renderMode === RenderMode.Static when doing so.
 
     // const numeratorShift = useDisplayStyle
     //     ? (fontSize * constants.fractionNumeratorDisplayStyleShiftUp) / 1000

--- a/packages/typesetter/src/types.ts
+++ b/packages/typesetter/src/types.ts
@@ -1,4 +1,4 @@
-import {MathStyle} from "./enums";
+import {MathStyle, RenderMode} from "./enums";
 
 import type {FontData} from "@math-blocks/metrics";
 import type {LayoutCursor, Point} from "./scene-graph";
@@ -9,6 +9,7 @@ export type Context = {
     mathStyle: MathStyle;
     cramped: boolean;
     colorMap?: Map<number, string>;
+    renderMode: RenderMode;
 };
 
 export type Options = {


### PR DESCRIPTION
The editing use case ensures that each row has a minimum depth and height.  This PR deduplicates the code that was doing that before and only runs it if `renderMode: RenderMode.Dynamic` is set in the typesetting context.