### PR TITLE
Prevent StoryBook from stealing focus from MathEditor

### DIFF
--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -77,6 +77,10 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
                     props.onChange(Editor.zipperToRow(value));
                 }
             }
+
+            // Prevent StoryBook from capturing '/' and shifting focus to its
+            // search field.
+            e.stopPropagation();
         }
     });
 

--- a/packages/react/src/use-event-listener.ts
+++ b/packages/react/src/use-event-listener.ts
@@ -27,12 +27,16 @@ export default function useEventListener(
             const eventListener = (event: KeyboardEvent): void =>
                 savedHandler.current(event);
 
+            // This allows us to call e.stopPropagation() before StoryBook
+            // steals the focus when '/' is pressed.
+            const options = {capture: true};
+
             // Add event listener
-            element.addEventListener(eventName, eventListener);
+            element.addEventListener(eventName, eventListener, options);
 
             // Remove event listener on cleanup
             return () => {
-                element.removeEventListener(eventName, eventListener);
+                element.removeEventListener(eventName, eventListener, options);
             };
         },
         [eventName, element], // Re-run if eventName or element changes


### PR DESCRIPTION
StoryBook will shift the focus to the "Find Component" search field when `/` is pressed on non-input components.  `MathEditor` uses `/` to create fractions so it was hard to test this behavior inside of StoryBook.  This PR fixes that.