### PR TITLE
Fix tutor: don't reset cursor position after every edit

### DIFF
--- a/demo/src/solver/solver-page.tsx
+++ b/demo/src/solver/solver-page.tsx
@@ -13,6 +13,16 @@ import Substeps from "./substeps";
 const {parse} = Editor;
 
 const question: Editor.types.Row = Editor.util.row("2x+5=10");
+const questionZipper: Editor.Zipper = {
+    breadcrumbs: [],
+    row: {
+        id: question.id,
+        type: "zrow",
+        left: [],
+        selection: null,
+        right: question.children,
+    },
+};
 
 // TODO:
 // - show error messages in the UI
@@ -23,7 +33,7 @@ const question: Editor.types.Row = Editor.util.row("2x+5=10");
 
 const SolverPage: React.FunctionComponent = () => {
     const fontMetrics = comicSans;
-    const [input, setInput] = React.useState(question);
+    const [input, setInput] = React.useState<Editor.Zipper>(questionZipper);
     const [solution, setSolution] = React.useState<Editor.types.Row | null>(
         null,
     );
@@ -31,7 +41,7 @@ const SolverPage: React.FunctionComponent = () => {
 
     const handleSimplify = (): void => {
         console.log("SIMPLIFY");
-        const ast = parse(input);
+        const ast = parse(Editor.zipperToRow(input));
         const result = simplify(ast, []);
         if (result) {
             console.log(result);
@@ -46,7 +56,7 @@ const SolverPage: React.FunctionComponent = () => {
 
     const handleSolve = (): void => {
         console.log("SOLVE");
-        const ast = parse(input);
+        const ast = parse(Editor.zipperToRow(input));
         if (ast.type === "eq") {
             const result = solve(ast, builders.identifier("x"));
             if (result) {
@@ -86,17 +96,6 @@ const SolverPage: React.FunctionComponent = () => {
 
     const showSolution = solution != null;
 
-    const zipper: Editor.Zipper = {
-        breadcrumbs: [],
-        row: {
-            id: input.id,
-            type: "zrow",
-            left: [],
-            selection: null,
-            right: input.children,
-        },
-    };
-
     return (
         <FontDataContext.Provider value={context.fontData}>
             <div style={styles.container}>
@@ -108,10 +107,10 @@ const SolverPage: React.FunctionComponent = () => {
                 <div>
                     <MathEditor
                         readonly={false}
-                        zipper={zipper}
+                        zipper={input}
                         stepChecker={true}
                         focus={true}
-                        onChange={(value: Editor.types.Row) => setInput(value)}
+                        onChange={(value: Editor.Zipper) => setInput(value)}
                     />
                 </div>
                 <div style={styles.gap}></div>

--- a/demo/src/tutor/reducer.ts
+++ b/demo/src/tutor/reducer.ts
@@ -12,20 +12,20 @@ export enum StepStatus {
 export type Step =
     | {
           status: StepStatus.Correct;
-          value: Editor.types.Row;
+          value: Editor.Zipper;
           hint: "none" | "text" | "showme";
       }
     | {
           status: StepStatus.Duplicate;
-          value: Editor.types.Row;
+          value: Editor.Zipper;
       }
     | {
           status: StepStatus.Pending;
-          value: Editor.types.Row;
+          value: Editor.Zipper;
       }
     | {
           status: StepStatus.Incorrect;
-          value: Editor.types.Row;
+          value: Editor.Zipper;
           mistakes: readonly Mistake[];
       };
 
@@ -53,7 +53,7 @@ export type Action =
       }
     | {
           type: "update";
-          value: Editor.types.Row;
+          value: Editor.Zipper;
       }
     | {
           type: "set";

--- a/demo/src/tutor/store.ts
+++ b/demo/src/tutor/store.ts
@@ -4,18 +4,32 @@ import * as Editor from "@math-blocks/editor-core";
 
 import {reducer, State, StepStatus, ProblemStatus} from "./reducer";
 
+const clone = <T>(obj: T): T => {
+    return JSON.parse(JSON.stringify(obj));
+};
+
 const question: Editor.types.Row = Editor.util.row("2x+5=10");
+const zipper: Editor.Zipper = {
+    breadcrumbs: [],
+    row: {
+        id: question.id,
+        type: "zrow",
+        left: [],
+        selection: null,
+        right: question.children,
+    },
+};
 
 const initialState: State = {
     steps: [
         {
             status: StepStatus.Correct,
-            value: question,
+            value: zipper,
             hint: "none",
         },
         {
             status: StepStatus.Duplicate,
-            value: JSON.parse(JSON.stringify(question)),
+            value: clone(zipper),
         },
     ],
     status: ProblemStatus.Incomplete,

--- a/demo/src/tutor/tutor.tsx
+++ b/demo/src/tutor/tutor.tsx
@@ -29,16 +29,7 @@ const Tutor: React.FunctionComponent = () => {
     const isComplete = state.status === ProblemStatus.Complete;
     const pairs = getPairs(state.steps);
 
-    const zipper: Editor.Zipper = {
-        breadcrumbs: [],
-        row: {
-            id: state.steps[0].value.id,
-            type: "zrow",
-            left: [],
-            selection: null,
-            right: state.steps[0].value.children,
-        },
-    };
+    const zipper: Editor.Zipper = state.steps[0].value;
 
     return (
         <div style={{margin: "auto"}}>
@@ -51,13 +42,13 @@ const Tutor: React.FunctionComponent = () => {
                         stepChecker={true}
                         focus={mode === "edit"}
                         style={{marginTop: 8, flexGrow: 1}}
-                        onChange={(value: Editor.types.Row) => {
+                        onChange={(zipper: Editor.Zipper) => {
                             dispatch({
                                 type: "set",
                                 steps: [
                                     {
                                         status: StepStatus.Correct,
-                                        value: value,
+                                        value: zipper,
                                         hint: "none",
                                     },
                                 ],
@@ -76,8 +67,8 @@ const Tutor: React.FunctionComponent = () => {
                             readonly={!isLast || isComplete}
                             prevStep={prevStep}
                             step={step}
-                            onChange={(value: Editor.types.Row) => {
-                                dispatch({type: "update", value});
+                            onChange={(zipper: Editor.Zipper) => {
+                                dispatch({type: "update", value: zipper});
                             }}
                         />
                     );

--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -18,8 +18,8 @@ type Props = {
     // TODO: figure out a better way of handling focus
     focus?: boolean;
 
-    onSubmit?: (value: Editor.types.Row) => unknown;
-    onChange?: (value: Editor.types.Row) => unknown;
+    onSubmit?: (zipper: Editor.Zipper) => unknown;
+    onChange?: (zipper: Editor.Zipper) => unknown;
 
     /**
      * Style
@@ -57,7 +57,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
                 };
                 if (e.key === "Enter" && props.onSubmit) {
                     // TODO: submit all rows
-                    const success = props.onSubmit(Editor.zipperToRow(zipper));
+                    const success = props.onSubmit(zipper);
                     if (success) {
                         setActive(false);
                     }
@@ -75,7 +75,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
                         e.keyCode !== 40
                     ) {
                         // TODO: communicate all rows when sending this event
-                        props.onChange(Editor.zipperToRow(value));
+                        props.onChange(value);
                     }
                 }
 


### PR DESCRIPTION
In #326, `MathEditor` was changed so that it re-renders when its `zipper` prop change.  This cause an issue with the tutor demo which was creating a new `zipper` object whenever a step's value changed.  This PR fixes the issue by storing zippers in the store instead of steps.  It also means we don't have to convert from `Editor.zipper` to `Editor.types.Row` on every edit.