### PR TITLE
Fix the width the of the fraction bar

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 43.208 108.728" width="43.208" height="108.728" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 51.367999999999995 108.728" width="51.367999999999995" height="108.728" style="background:white">
     <g transform="translate(0,64.86)" id="8">
         <g transform="translate(0,-15.48)" style="color:darkcyan" id="5">
-            <g transform="translate(5.754,-11.04)" id="6">
+            <g transform="translate(9.833999999999998,-11.04)" id="6">
                 <path fill="currentcolor" id="0" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
             </g>
-            <g transform="translate(0,59.348)" style="color:orange" id="7">
+            <g transform="translate(4.079999999999998,59.348)" style="color:orange" id="7">
                 <path fill="currentcolor" id="1" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                 <g transform="translate(29.7,-10)" id="3">
                     <g transform="translate(0,-10.378)" style="color:pink" id="4">
@@ -14,7 +14,7 @@
                 </g>
             </g>
             <g transform="translate(0,8.881784197001252e-16)" id="undefined">
-                <line type="line" x1="0" y1="0" x2="37.128" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="0" x2="49.367999999999995" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 516.77 132.66000000000003" width="516.77" height="132.66000000000003" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 529.01 132.66000000000003" width="529.01" height="132.66000000000003" style="background:white">
     <g transform="translate(0,97.74000000000001)" id="20">
         <path fill="currentcolor" id="0" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
         <g transform="translate(106.74000000000001,-15.48)" id="17">
-            <g transform="translate(0,-25.132000000000005)" id="18">
+            <g transform="translate(4.0800000000000125,-25.132000000000005)" id="18">
                 <path fill="currentcolor" id="2" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                 <path fill="currentcolor" id="3" style="opacity:1" aria-hidden="true" d="M 198,402 L 257,705 L 235,705 L 97,694 L 97,668 C 97,668 116,670 127,670C 147,670 163,663 163,641C 163,629 160,610 159,606L 46,25 C 95,0 146,-12 204,-12C 382,-12 483,140 483,304C 483,424 421,479 342,479C 289,479 246,450 203,402ZM 184,316 C 205,363 249,423 313,423C 358,423 395,390 395,300C 395,148 338,30 219,30C 177,30 148,54 135,66Z" transform="translate(43.2, 0) scale(0.06, -0.06)"></path>
                 <g transform="translate(147.48000000000002,0)" id="13">
@@ -27,19 +27,19 @@
                                 <path fill="currentcolor" id="9" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                             </g>
                         </g>
-                        <line type="line" x1="0" y1="-55.088" x2="212.91" y2="-55.088" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                        <line type="line" x1="0" y1="-55.088" x2="216.99" y2="-55.088" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                     </g>
                 </g>
                 <g transform="translate(74.28,0)" id="undefined">
                     <path fill="currentcolor" id="4" style="opacity:1" aria-hidden="true" d="M 658,306 L 658,373 L 394,373 L 394,576 L 326,576 L 326,373 L 62,373 L 62,306 L 326,306 L 326,92 L 394,92 L 394,306 ZM 658,-31 L 658,36 L 62,36 L 62,-31 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                 </g>
             </g>
-            <g transform="translate(172.51500000000001,49.67999999999999)" id="19">
+            <g transform="translate(178.63500000000002,49.67999999999999)" id="19">
                 <path fill="currentcolor" id="15" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                 <path fill="currentcolor" id="16" style="opacity:1" aria-hidden="true" d="M 502,472 L 449,472 L 413,426 L 409,426 C 388,456 358,479 305,479C 174,479 49,341 49,159C 49,43 100,-12 172,-12C 229,-12 288,22 339,85L 346,85 C 343,67 339,53 339,38C 339,5 359,-10 395,-10C 455,-10 497,33 539,97L 519,112 C 506,95 477,60 445,60C 429,60 425,68 425,81C 425,96 430,118 430,118ZM 389,344 C 389,313 378,240 358,181C 329,96 285,54 218,54C 168,54 138,77 138,169C 138,303 202,441 302,441C 358,441 389,397 389,344Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
             </g>
             <g transform="translate(0,-4.440892098500626e-15)" id="undefined">
-                <line type="line" x1="0" y1="0" x2="403.95000000000005" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="0" x2="420.27000000000004" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
         <g transform="translate(33.54,0)" id="undefined">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 105.746 108.728" width="105.746" height="108.728" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 113.90599999999999 108.728" width="113.90599999999999" height="108.728" style="background:white">
     <g transform="translate(0,64.86)" id="16">
         <g transform="translate(0,0)" id="5">
             <g transform="translate(11.255999999999997,-45.42)" id="7">
@@ -15,10 +15,10 @@
             </g>
         </g>
         <g transform="translate(62.538,-15.48)" id="13">
-            <g transform="translate(5.754,-11.04)" id="14">
+            <g transform="translate(9.833999999999998,-11.04)" id="14">
                 <path fill="currentcolor" id="8" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
             </g>
-            <g transform="translate(0,59.348)" id="15">
+            <g transform="translate(4.079999999999998,59.348)" id="15">
                 <path fill="currentcolor" id="9" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                 <g transform="translate(29.7,-10)" id="11">
                     <g transform="translate(0,-10.378)" id="12">
@@ -27,7 +27,7 @@
                 </g>
             </g>
             <g transform="translate(0,8.881784197001252e-16)" id="undefined">
-                <line type="line" x1="0" y1="0" x2="37.128" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="0" x2="49.367999999999995" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-no-cursor,-no-selection.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-no-cursor,-no-selection.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 464.53999999999996 115.91999999999999" width="464.53999999999996" height="115.91999999999999" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 484.94000000000005 115.91999999999999" width="484.94000000000005" height="115.91999999999999" style="background:white">
     <g transform="translate(0,74.94)" id="21">
-        <g transform="translate(263.64,0)" id="19">
+        <g transform="translate(271.8,0)" id="19">
             <g transform="translate(0,20.400000000000006)" id="undefined">
                 <g transform="translate(0,0)" id="undefined">
                     <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 926,1589 L 484,-88 L 480,-88 L 216,603 L 196,603 L 30,494 L 49,465 L 153,505 L 451,-265 L 496,-265 L 976,1521 L 1076,1521 L 1076,1589 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
@@ -10,10 +10,10 @@
             <g transform="translate(62.46,0)" id="undefined">
                 <g transform="translate(0,1.4210854715202004e-14)" id="20">
                     <g transform="translate(0,-15.48)" id="16">
-                        <g transform="translate(53.37,-11.04)" id="17">
+                        <g transform="translate(57.449999999999996,-11.04)" id="17">
                             <path fill="currentcolor" id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(0,49.38)" id="18">
+                        <g transform="translate(4.079999999999998,49.38)" id="18">
                             <path fill="currentcolor" id="13" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                             <path fill="currentcolor" id="15" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(102.9, 0) scale(0.06, -0.06)"></path>
                             <g transform="translate(29.7,0)" id="undefined">
@@ -21,20 +21,20 @@
                             </g>
                         </g>
                         <g transform="translate(0,8.881784197001252e-16)" id="undefined">
-                            <line type="line" x1="0" y1="0" x2="132.35999999999999" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                            <line type="line" x1="0" y1="0" x2="144.6" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                         </g>
                     </g>
                 </g>
-                <line type="line" x1="0" y1="-72.89999999999999" x2="136.44" y2="-72.89999999999999" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="-72.89999999999999" x2="148.68" y2="-72.89999999999999" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
         <g transform="translate(0,0)" id="undefined">
             <g transform="translate(27,0)" id="9">
                 <g transform="translate(0,-15.48)" id="4">
-                    <g transform="translate(53.37,-11.04)" id="5">
+                    <g transform="translate(57.449999999999996,-11.04)" id="5">
                         <path fill="currentcolor" id="0" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(0,49.38)" id="6">
+                    <g transform="translate(4.079999999999998,49.38)" id="6">
                         <path fill="currentcolor" id="1" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         <path fill="currentcolor" id="3" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(102.9, 0) scale(0.06, -0.06)"></path>
                         <g transform="translate(29.7,0)" id="undefined">
@@ -42,14 +42,14 @@
                         </g>
                     </g>
                     <g transform="translate(0,8.881784197001252e-16)" id="undefined">
-                        <line type="line" x1="0" y1="0" x2="132.35999999999999" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                        <line type="line" x1="0" y1="0" x2="144.6" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                     </g>
                 </g>
             </g>
             <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 64,270 C 64,-159 206,-511 395,-683L 418,-659 C 242,-450 159,-113 159,270C 159,653 242,990 418,1199L 395,1223 C 206,1051 64,699 64,270Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-            <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 386,270 C 386,699 244,1051 55,1223L 32,1199 C 208,990 291,653 291,270C 291,-113 208,-450 32,-659L 55,-683 C 244,-511 386,-159 386,270Z" transform="translate(163.44, 0) scale(0.06, -0.06)"></path>
+            <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 386,270 C 386,699 244,1051 55,1223L 32,1199 C 208,990 291,653 291,270C 291,-113 208,-450 32,-659L 55,-683 C 244,-511 386,-159 386,270Z" transform="translate(171.6, 0) scale(0.06, -0.06)"></path>
         </g>
-        <g transform="translate(190.44,0)" id="undefined">
+        <g transform="translate(198.6,0)" id="undefined">
             <path fill="currentcolor" id="11" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-cursor.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-cursor.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 480.97999999999996 159.12" width="480.97999999999996" height="159.12" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 501.38 159.12" width="501.38" height="159.12" style="background:white">
     <g transform="translate(0,96.60000000000001)" id="21">
-        <g transform="translate(271.91999999999996,0)" id="19">
+        <g transform="translate(280.08,0)" id="19">
             <g transform="translate(0,29.69999999999999)" id="undefined">
                 <g transform="translate(0,0)" id="undefined">
                     <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 1062,2105 L 532,-81 L 528,-81 L 216,807 L 196,807 L 30,698 L 49,669 L 153,709 L 502,-265 L 547,-265 L 1112,2037 L 1212,2037 L 1212,2105 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
@@ -10,10 +10,10 @@
             <g transform="translate(70.62,0)" id="undefined">
                 <g transform="translate(0,1.4210854715202004e-14)" id="20">
                     <g transform="translate(0,-15.48)" id="16">
-                        <g transform="translate(53.37,-24.840000000000003)" id="17">
+                        <g transform="translate(57.449999999999996,-24.840000000000003)" id="17">
                             <path fill="currentcolor" id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(0,57.24)" id="18">
+                        <g transform="translate(4.079999999999998,57.24)" id="18">
                             <path fill="currentcolor" id="13" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                             <path fill="currentcolor" id="15" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(102.9, 0) scale(0.06, -0.06)"></path>
                             <g transform="translate(29.7,0)" id="undefined">
@@ -21,21 +21,21 @@
                             </g>
                         </g>
                         <g transform="translate(0,-2.6645352591003757e-15)" id="undefined">
-                            <line type="line" x1="0" y1="0" x2="132.35999999999999" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                            <line type="line" x1="0" y1="0" x2="144.6" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                         </g>
                     </g>
                 </g>
-                <line type="line" x1="0" y1="-94.56" x2="136.44" y2="-94.56" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="-94.56" x2="148.68" y2="-94.56" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
         <g transform="translate(0,0)" id="undefined">
             <g transform="translate(31.14,0)" id="9">
                 <g transform="translate(0,-15.48)" id="4">
-                    <g transform="translate(53.37,-24.840000000000003)" id="5">
+                    <g transform="translate(57.449999999999996,-24.840000000000003)" id="5">
                         <rect type="rect" x="-1" y="-46.2" width="2" height="60" fill="currentcolor"></rect>
                         <path fill="currentcolor" id="0" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(0,57.24)" id="6">
+                    <g transform="translate(4.079999999999998,57.24)" id="6">
                         <path fill="currentcolor" id="1" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         <path fill="currentcolor" id="3" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(102.9, 0) scale(0.06, -0.06)"></path>
                         <g transform="translate(29.7,0)" id="undefined">
@@ -43,14 +43,14 @@
                         </g>
                     </g>
                     <g transform="translate(0,-2.6645352591003757e-15)" id="undefined">
-                        <line type="line" x1="0" y1="0" x2="132.35999999999999" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                        <line type="line" x1="0" y1="0" x2="144.6" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                     </g>
                 </g>
             </g>
             <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 77,270 C 77,-310 247,-806 457,-1042L 486,-1020 C 288,-730 182,-246 182,270C 182,786 288,1270 486,1560L 457,1582 C 247,1346 77,850 77,270Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-            <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 442,270 C 442,850 272,1346 62,1582L 33,1560 C 231,1270 337,786 337,270C 337,-246 231,-730 33,-1020L 62,-1042 C 272,-806 442,-310 442,270Z" transform="translate(167.57999999999998, 0) scale(0.06, -0.06)"></path>
+            <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 442,270 C 442,850 272,1346 62,1582L 33,1560 C 231,1270 337,786 337,270C 337,-246 231,-730 33,-1020L 62,-1042 C 272,-806 442,-310 442,270Z" transform="translate(175.74, 0) scale(0.06, -0.06)"></path>
         </g>
-        <g transform="translate(198.71999999999997,0)" id="undefined">
+        <g transform="translate(206.88,0)" id="undefined">
             <path fill="currentcolor" id="11" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-selection.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-selection.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 480.97999999999996 159.12" width="480.97999999999996" height="159.12" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 501.38 159.12" width="501.38" height="159.12" style="background:white">
     <g transform="translate(0,96.60000000000001)" id="21">
-        <rect type="rect" x="198.71999999999997" y="-46.2" width="73.2" height="60" fill="rgba(0,144,255,0.5)"></rect>
-        <rect type="rect" x="0" y="-94.92" width="198.71999999999997" height="157.44" fill="rgba(0,144,255,0.5)"></rect>
-        <g transform="translate(271.91999999999996,0)" id="19">
+        <rect type="rect" x="206.88" y="-46.2" width="73.2" height="60" fill="rgba(0,144,255,0.5)"></rect>
+        <rect type="rect" x="0" y="-94.92" width="206.88" height="157.44" fill="rgba(0,144,255,0.5)"></rect>
+        <g transform="translate(280.08,0)" id="19">
             <g transform="translate(0,29.69999999999999)" id="undefined">
                 <g transform="translate(0,0)" id="undefined">
                     <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 1062,2105 L 532,-81 L 528,-81 L 216,807 L 196,807 L 30,698 L 49,669 L 153,709 L 502,-265 L 547,-265 L 1112,2037 L 1212,2037 L 1212,2105 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
@@ -12,10 +12,10 @@
             <g transform="translate(70.62,0)" id="undefined">
                 <g transform="translate(0,1.4210854715202004e-14)" id="20">
                     <g transform="translate(0,-15.48)" id="16">
-                        <g transform="translate(53.37,-24.840000000000003)" id="17">
+                        <g transform="translate(57.449999999999996,-24.840000000000003)" id="17">
                             <path fill="currentcolor" id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(0,57.24)" id="18">
+                        <g transform="translate(4.079999999999998,57.24)" id="18">
                             <path fill="currentcolor" id="13" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                             <path fill="currentcolor" id="15" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(102.9, 0) scale(0.06, -0.06)"></path>
                             <g transform="translate(29.7,0)" id="undefined">
@@ -23,20 +23,20 @@
                             </g>
                         </g>
                         <g transform="translate(0,-2.6645352591003757e-15)" id="undefined">
-                            <line type="line" x1="0" y1="0" x2="132.35999999999999" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                            <line type="line" x1="0" y1="0" x2="144.6" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                         </g>
                     </g>
                 </g>
-                <line type="line" x1="0" y1="-94.56" x2="136.44" y2="-94.56" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                <line type="line" x1="0" y1="-94.56" x2="148.68" y2="-94.56" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
             </g>
         </g>
         <g transform="translate(0,0)" id="undefined">
             <g transform="translate(31.14,0)" id="9">
                 <g transform="translate(0,-15.48)" id="4">
-                    <g transform="translate(53.37,-24.840000000000003)" id="5">
+                    <g transform="translate(57.449999999999996,-24.840000000000003)" id="5">
                         <path fill="currentcolor" id="0" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(0,57.24)" id="6">
+                    <g transform="translate(4.079999999999998,57.24)" id="6">
                         <path fill="currentcolor" id="1" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         <path fill="currentcolor" id="3" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(102.9, 0) scale(0.06, -0.06)"></path>
                         <g transform="translate(29.7,0)" id="undefined">
@@ -44,14 +44,14 @@
                         </g>
                     </g>
                     <g transform="translate(0,-2.6645352591003757e-15)" id="undefined">
-                        <line type="line" x1="0" y1="0" x2="132.35999999999999" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
+                        <line type="line" x1="0" y1="0" x2="144.6" y2="0" stroke="currentColor" stroke-width="4.08" stroke-linecap="butt"></line>
                     </g>
                 </g>
             </g>
             <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 77,270 C 77,-310 247,-806 457,-1042L 486,-1020 C 288,-730 182,-246 182,270C 182,786 288,1270 486,1560L 457,1582 C 247,1346 77,850 77,270Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-            <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 442,270 C 442,850 272,1346 62,1582L 33,1560 C 231,1270 337,786 337,270C 337,-246 231,-730 33,-1020L 62,-1042 C 272,-806 442,-310 442,270Z" transform="translate(167.57999999999998, 0) scale(0.06, -0.06)"></path>
+            <path fill="currentcolor" id="undefined" style="opacity:1" aria-hidden="true" d="M 442,270 C 442,850 272,1346 62,1582L 33,1560 C 231,1270 337,786 337,270C 337,-246 231,-730 33,-1020L 62,-1042 C 272,-806 442,-310 442,270Z" transform="translate(175.74, 0) scale(0.06, -0.06)"></path>
         </g>
-        <g transform="translate(198.71999999999997,0)" id="undefined">
+        <g transform="translate(206.88,0)" id="undefined">
             <path fill="currentcolor" id="11" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
         </g>
     </g>

--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -124,6 +124,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
                     height: 0,
                     margin: 0,
                     padding: 0,
+                    border: "none",
                 }}
                 onBlur={() => setActive(false)}
                 autoCapitalize="off"

--- a/packages/typesetter/src/layout.ts
+++ b/packages/typesetter/src/layout.ts
@@ -316,14 +316,14 @@ export const makeFract = (
     // );
 
     const multiplier = multiplierForMathStyle(mathStyle);
-    const width = Math.max(
-        Math.max(getWidth(numBox), getWidth(denBox)), // TODO: calculate this based on current font size
-        30 * multiplier, // empty numerator/denominator width
-    );
-    const stroke = hpackNat(
-        [[makeHRule(thickness, width - thickness)]],
-        context,
-    );
+    const endPadding = thickness; // add extra space around the numerator and denominator
+    const width =
+        Math.max(
+            Math.max(getWidth(numBox), getWidth(denBox)), // TODO: calculate this based on current font size
+            30 * multiplier, // empty numerator/denominator width
+        ) +
+        2 * endPadding;
+    const stroke = hpackNat([[makeHRule(thickness, width)]], context);
 
     const upList = makeList(minNumGap, numBox);
     const dnList = makeList(minDenGap, denBox);

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -148,7 +148,8 @@ const typesetRoot = (
 
     const fontSize = fontSizeForContext(context);
     const thickness = (fontSize * constants.fractionRuleThickness.value) / 1000;
-    const stroke = Layout.makeHRule(thickness, radicand.width);
+    const endPadding = thickness; // Add extra space at the end of the radicand
+    const stroke = Layout.makeHRule(thickness, radicand.width + endPadding);
 
     const vbox = Layout.makeVBox(
         radicand.width,
@@ -160,6 +161,7 @@ const typesetRoot = (
     surdVBox.shift = surdVBox.height - vbox.height;
 
     const root = Layout.hpackNat([[surdVBox, vbox]], context);
+    root.width += endPadding;
 
     return root;
 };


### PR DESCRIPTION
This PR also adds padding around numerators, denominators, and to the end of radicands.  This makes it easier to differentiate which node the cursor is inside of since it was hard to tell some times, especially with radicals.