### PR TITLE
Change Focus' .dir property to a number

### DIFF
--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -9,5 +9,5 @@ export {parse} from "./parser/parser";
 
 export {zipperReducer} from "./reducer/reducer";
 export {zipperToRow, rowToZipper} from "./reducer/convert";
-export {Dir} from "./reducer/enums";
+export {SelectionDir as Dir} from "./reducer/enums";
 export type {Breadcrumb, Focus, Zipper, ZRow, ZFrac} from "./reducer/types";

--- a/packages/editor-core/src/reducer/__tests__/backspace.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/backspace.test.ts
@@ -9,7 +9,7 @@ import {
     delimited,
     toEqualEditorNodes,
 } from "../test-util";
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import * as builders from "../../builders";
 import * as types from "../../types";
 
@@ -94,7 +94,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zfrac",
-                            dir: Dir.Left, // the numerator is focused
+                            dir: 0, // the numerator is focused
                             other: row("3"), // denominator
                         },
                     },
@@ -128,7 +128,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zfrac",
-                            dir: Dir.Right, // the denominator is focused
+                            dir: 1, // the denominator is focused
                             other: row("2"), // numerator
                         },
                     },
@@ -160,7 +160,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: Dir.Right,
+                dir: 1,
                 other: f.children[0],
             });
             expect(result.row.left).toHaveLength(1);
@@ -191,7 +191,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: Dir.Left, // the subscript is focused
+                            dir: 0, // the subscript is focused
                             other: null, // no superscript
                         },
                     },
@@ -225,7 +225,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: Dir.Left, // the subscript is focused
+                            dir: 0, // the subscript is focused
                             other: row("2"), // superscript
                         },
                     },
@@ -259,7 +259,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: Dir.Right, // the superscript is focused
+                            dir: 1, // the superscript is focused
                             other: null, // no subscript
                         },
                     },
@@ -293,7 +293,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: Dir.Right, // the superscript is focused
+                            dir: 1, // the superscript is focused
                             other: row("n"), // subscript
                         },
                     },
@@ -330,7 +330,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Left,
+                dir: 0,
                 other: null,
             });
             expect(result.row.left).toHaveLength(1);
@@ -357,7 +357,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Right,
+                dir: 1,
                 other: null,
             });
             expect(result.row.left).toHaveLength(1);
@@ -388,7 +388,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zroot",
-                            dir: Dir.Right, // the radicand is focused
+                            dir: 1, // the radicand is focused
                             other: null, // no index
                         },
                     },
@@ -422,7 +422,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zroot",
-                            dir: Dir.Right, // the radicand is focused
+                            dir: 1, // the radicand is focused
                             other: row("3"), // index
                         },
                     },
@@ -456,7 +456,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zroot",
-                            dir: Dir.Left, // the index is focused
+                            dir: 0, // the index is focused
                             other: row("27"), // radicand
                         },
                     },
@@ -488,7 +488,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Right,
+                dir: 1,
                 other: null,
             });
             expect(result.row.left).toHaveLength(1);
@@ -515,7 +515,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Right,
+                dir: 1,
                 other: r.children[0],
             });
             expect(result.row.left).toHaveLength(1);
@@ -546,7 +546,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zlimits",
-                            dir: Dir.Left, // the lower bound is focused
+                            dir: 0, // the lower bound is focused
                             other: null, // no upper bound
                             inner: row("lim"),
                         },
@@ -581,7 +581,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zlimits",
-                            dir: Dir.Left, // the lower bound is focused
+                            dir: 0, // the lower bound is focused
                             other: row("n"), // upper bound
                             inner: row("sum"),
                         },
@@ -616,7 +616,7 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zlimits",
-                            dir: Dir.Right, // the upper bound is focused
+                            dir: 1, // the upper bound is focused
                             other: row("i=0"), // lower bound
                             inner: row("sum"),
                         },
@@ -663,7 +663,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: lim.id,
                 type: "zlimits",
-                dir: Dir.Left,
+                dir: 0,
                 other: null,
                 inner: inner,
             });
@@ -706,7 +706,7 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: Dir.Right,
+                dir: 1,
                 other: lower,
                 inner: inner,
             });
@@ -924,7 +924,7 @@ describe("backspace", () => {
                     type: "zrow",
                     left: row("2x").children,
                     selection: {
-                        dir: Dir.Left,
+                        dir: SelectionDir.Left,
                         nodes: row("+5").children,
                     },
                     right: row("=10").children,

--- a/packages/editor-core/src/reducer/__tests__/convert.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/convert.test.ts
@@ -1,7 +1,7 @@
 import * as builders from "../../builders";
 
 import {zipperToRow} from "../convert";
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import {row, toEqualEditorNodes} from "../test-util";
 
 import type {Zipper} from "../types";
@@ -51,7 +51,7 @@ describe("zipperToRow", () => {
                     type: "zrow",
                     left: row("1").children,
                     selection: {
-                        dir: Dir.Right,
+                        dir: SelectionDir.Right,
                         nodes: row("+").children,
                     },
                     right: row("2").children,
@@ -90,7 +90,7 @@ describe("zipperToRow", () => {
                         focus: {
                             id: 2,
                             type: "zfrac",
-                            dir: Dir.Left,
+                            dir: 0,
                             other: row("3"),
                         },
                     },
@@ -128,7 +128,7 @@ describe("zipperToRow", () => {
                             type: "zrow",
                             left: row("1+").children,
                             selection: {
-                                dir: Dir.Left,
+                                dir: SelectionDir.Left,
                                 nodes: row("5+").children,
                             },
                             right: row("+4").children,
@@ -137,7 +137,7 @@ describe("zipperToRow", () => {
                         focus: {
                             id: 2,
                             type: "zfrac",
-                            dir: Dir.Left,
+                            dir: 0,
                             other: row("3"),
                         },
                     },
@@ -177,7 +177,7 @@ describe("zipperToRow", () => {
                             type: "zrow",
                             left: row("1+").children,
                             selection: {
-                                dir: Dir.Right,
+                                dir: SelectionDir.Right,
                                 nodes: row("+5").children,
                             },
                             right: row("+4").children,
@@ -186,7 +186,7 @@ describe("zipperToRow", () => {
                         focus: {
                             id: 2,
                             type: "zfrac",
-                            dir: Dir.Left,
+                            dir: 0,
                             other: row("3"),
                         },
                     },

--- a/packages/editor-core/src/reducer/__tests__/insert-char.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/insert-char.test.ts
@@ -2,7 +2,7 @@ import * as builders from "../../builders";
 
 import {insertChar} from "../insert-char";
 import {row, toEqualEditorNodes} from "../test-util";
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import type {Zipper} from "../types";
 
 expect.extend({toEqualEditorNodes});
@@ -94,7 +94,7 @@ describe("insertChar", () => {
                     type: "zrow",
                     left: [builders.glyph("1")],
                     selection: {
-                        dir: Dir.Right,
+                        dir: SelectionDir.Right,
                         nodes: [builders.glyph("+")],
                     },
                     right: [builders.glyph("2")],
@@ -115,7 +115,7 @@ describe("insertChar", () => {
                     type: "zrow",
                     left: [],
                     selection: {
-                        dir: Dir.Left,
+                        dir: SelectionDir.Left,
                         nodes: [builders.glyph("2")],
                     },
                     right: [],
@@ -125,7 +125,7 @@ describe("insertChar", () => {
                         focus: {
                             id: 0,
                             type: "zfrac",
-                            dir: Dir.Right,
+                            dir: 1,
                             other: builders.row([builders.glyph("3")]),
                         },
                         row: {
@@ -133,7 +133,7 @@ describe("insertChar", () => {
                             type: "zrow",
                             left: [builders.glyph("1"), builders.glyph("+")],
                             selection: {
-                                dir: Dir.Left,
+                                dir: SelectionDir.Left,
                                 nodes: [],
                             },
                             right: [],
@@ -156,7 +156,7 @@ describe("insertChar", () => {
                     type: "zrow",
                     left: [builders.glyph("1")],
                     selection: {
-                        dir: Dir.Right,
+                        dir: SelectionDir.Right,
                         nodes: [builders.glyph("+")],
                     },
                     right: [builders.glyph("2")],

--- a/packages/editor-core/src/reducer/__tests__/move-cursor.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/move-cursor.test.ts
@@ -4,7 +4,6 @@ import * as builders from "../../builders";
 import {moveLeft} from "../move-left";
 import {moveRight} from "../move-right";
 import {row, frac, root, subsup} from "../test-util";
-import {Dir} from "../enums";
 import type {Zipper} from "../types";
 
 describe("moveRight", () => {
@@ -66,7 +65,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: Dir.Left,
+                dir: 0,
                 other: f.children[1],
             });
             expect(result.row.left).toHaveLength(0);
@@ -93,7 +92,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: Dir.Right,
+                dir: 1,
                 other: f.children[0],
             });
             expect(result.row.left).toHaveLength(0);
@@ -145,7 +144,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Left,
+                dir: 0,
                 other: ss.children[1],
             });
             expect(result.row.left).toHaveLength(0);
@@ -172,7 +171,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Right,
+                dir: 1,
                 other: ss.children[0],
             });
             expect(result.row.left).toHaveLength(0);
@@ -224,7 +223,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Left,
+                dir: 0,
                 other: null,
             });
             expect(result.row.left).toHaveLength(0);
@@ -274,7 +273,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Right,
+                dir: 1,
                 other: null,
             });
             expect(result.row.left).toHaveLength(0);
@@ -324,7 +323,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Left,
+                dir: 0,
                 other: r.children[1],
             });
             expect(result.row.left).toHaveLength(0);
@@ -351,7 +350,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Right,
+                dir: 1,
                 other: r.children[0],
             });
             expect(result.row.left).toHaveLength(0);
@@ -403,7 +402,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Right,
+                dir: 1,
                 other: null,
             });
             expect(result.row.left).toHaveLength(0);
@@ -467,7 +466,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: lim.id,
                 type: "zlimits",
-                dir: Dir.Left,
+                dir: 0,
                 other: null,
                 inner: inner,
             });
@@ -547,7 +546,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: Dir.Left,
+                dir: 0,
                 other: upper,
                 inner: inner,
             });
@@ -590,7 +589,7 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: Dir.Right,
+                dir: 1,
                 other: lower,
                 inner: inner,
             });
@@ -698,7 +697,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: Dir.Right,
+                dir: 1,
                 other: f.children[0],
             });
             expect(result.row.left).toHaveLength(1);
@@ -725,7 +724,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: Dir.Left,
+                dir: 0,
                 other: f.children[1],
             });
             expect(result.row.left).toHaveLength(1);
@@ -777,7 +776,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Right,
+                dir: 1,
                 other: ss.children[0],
             });
             expect(result.row.left).toHaveLength(1);
@@ -804,7 +803,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Left,
+                dir: 0,
                 other: ss.children[1],
             });
             expect(result.row.left).toHaveLength(1);
@@ -856,7 +855,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Right,
+                dir: 1,
                 other: null,
             });
             expect(result.row.left).toHaveLength(1);
@@ -906,7 +905,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: Dir.Left,
+                dir: 0,
                 other: null,
             });
             expect(result.row.left).toHaveLength(1);
@@ -956,7 +955,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Right,
+                dir: 1,
                 other: r.children[0],
             });
             expect(result.row.left).toHaveLength(1);
@@ -983,7 +982,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Left,
+                dir: 0,
                 other: r.children[1],
             });
             expect(result.row.left).toHaveLength(1);
@@ -1035,7 +1034,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: Dir.Right,
+                dir: 1,
                 other: null,
             });
             expect(result.row.left).toHaveLength(1);
@@ -1099,7 +1098,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: lim.id,
                 type: "zlimits",
-                dir: Dir.Left,
+                dir: 0,
                 other: null,
                 inner: inner,
             });
@@ -1179,7 +1178,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: Dir.Right,
+                dir: 1,
                 other: lower,
                 inner: inner,
             });
@@ -1222,7 +1221,7 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: Dir.Left,
+                dir: 0,
                 other: upper,
                 inner: inner,
             });

--- a/packages/editor-core/src/reducer/__tests__/move-selection.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/move-selection.test.ts
@@ -3,7 +3,7 @@ import * as builders from "../../builders";
 import {moveLeft} from "../move-left";
 import {moveRight} from "../move-right";
 import {row, frac} from "../test-util";
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import type {Zipper} from "../types";
 
 // TODO: add a serializer or custom matcher to help with assertions
@@ -25,7 +25,7 @@ describe("moveRight w/ selecting = true", () => {
             const result = moveRight(zipper, true);
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.row.right).toHaveLength(2);
         });
@@ -45,7 +45,7 @@ describe("moveRight w/ selecting = true", () => {
             const result = moveRight(moveRight(zipper, true), true);
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(2);
             expect(result.row.right).toHaveLength(1);
         });
@@ -68,7 +68,7 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.row.right).toHaveLength(2);
         });
@@ -88,7 +88,7 @@ describe("moveRight w/ selecting = true", () => {
             const result = moveLeft(moveLeft(moveRight(zipper), true), true);
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.row.right).toHaveLength(2);
         });
@@ -108,7 +108,7 @@ describe("moveRight w/ selecting = true", () => {
             const result = moveRight(moveRight(moveLeft(zipper), true), true);
 
             expect(result.row.left).toHaveLength(2);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
         });
@@ -134,10 +134,12 @@ describe("moveRight w/ selecting = true", () => {
             const result = moveRight(moveRight(moveRight(zipper), true), true);
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[0].row.right).toHaveLength(2);
         });
@@ -161,10 +163,12 @@ describe("moveRight w/ selecting = true", () => {
             const result = moveRight(moveRight(moveRight(zipper)), true);
 
             expect(result.row.left).toHaveLength(1);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(0);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[0].row.right).toHaveLength(2);
         });
@@ -191,10 +195,12 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(1); // focus is selected
             expect(result.breadcrumbs[0].row.right).toHaveLength(1);
         });
@@ -227,10 +233,12 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(2); // focus is selected
             expect(result.breadcrumbs[0].row.right).toHaveLength(0);
         });
@@ -260,10 +268,12 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[0].row.right).toHaveLength(2);
         });
@@ -296,7 +306,7 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
             expect(result.breadcrumbs[0].row.selection).toBeNull();
@@ -368,10 +378,12 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(2);
-            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[1].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[1].row.right).toHaveLength(2);
             expect(result.breadcrumbs[0].row.selection).toBeNull();
@@ -415,13 +427,17 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(2);
-            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[1].row.selection?.nodes).toHaveLength(2); // focus is selected
             expect(result.breadcrumbs[1].row.right).toHaveLength(0);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
         });
 
@@ -466,10 +482,12 @@ describe("moveRight w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Right);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Right);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(2);
-            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(Dir.Right);
+            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(
+                SelectionDir.Right,
+            );
             expect(result.breadcrumbs[1].row.selection?.nodes).toHaveLength(2); // focus is selected
             expect(result.breadcrumbs[1].row.right).toHaveLength(0);
             expect(result.breadcrumbs[0].row.selection).toBeNull();
@@ -494,7 +512,7 @@ describe("moveLeft w/ selecting = true", () => {
             const result = moveLeft(zipper, true);
 
             expect(result.row.left).toHaveLength(2);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
         });
@@ -514,7 +532,7 @@ describe("moveLeft w/ selecting = true", () => {
             const result = moveLeft(moveLeft(zipper, true), true);
 
             expect(result.row.left).toHaveLength(1);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(2);
             expect(result.row.right).toHaveLength(0);
         });
@@ -537,7 +555,7 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(2);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
         });
@@ -563,10 +581,12 @@ describe("moveLeft w/ selecting = true", () => {
             const result = moveLeft(moveLeft(moveLeft(zipper), true), true);
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[0].row.left).toHaveLength(2);
         });
@@ -590,10 +610,12 @@ describe("moveLeft w/ selecting = true", () => {
             const result = moveLeft(moveLeft(moveLeft(zipper)), true);
 
             expect(result.row.right).toHaveLength(1);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(0);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[0].row.left).toHaveLength(2);
         });
@@ -620,10 +642,12 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(1); // focus is selected
             expect(result.breadcrumbs[0].row.left).toHaveLength(1);
         });
@@ -653,10 +677,12 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.right).toHaveLength(1);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(0);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(2); // focus is selected
             expect(result.breadcrumbs[0].row.left).toHaveLength(0);
         });
@@ -686,10 +712,12 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[0].row.left).toHaveLength(2);
         });
@@ -722,7 +750,7 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(1);
             expect(result.breadcrumbs[0].row.selection).toBeNull();
@@ -794,10 +822,12 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(2);
-            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[1].row.selection?.nodes).toHaveLength(0); // focus is selected
             expect(result.breadcrumbs[1].row.left).toHaveLength(2);
             expect(result.breadcrumbs[0].row.selection).toBeNull();
@@ -841,13 +871,17 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(2);
-            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[1].row.selection?.nodes).toHaveLength(2); // focus is selected
             expect(result.breadcrumbs[1].row.left).toHaveLength(0);
-            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[0].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[0].row.selection?.nodes).toHaveLength(0); // focus is selected
         });
 
@@ -892,10 +926,12 @@ describe("moveLeft w/ selecting = true", () => {
             );
 
             expect(result.row.left).toHaveLength(0);
-            expect(result.row.selection?.dir).toEqual(Dir.Left);
+            expect(result.row.selection?.dir).toEqual(SelectionDir.Left);
             expect(result.row.selection?.nodes).toHaveLength(1);
             expect(result.breadcrumbs).toHaveLength(2);
-            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(Dir.Left);
+            expect(result.breadcrumbs[1].row.selection?.dir).toEqual(
+                SelectionDir.Left,
+            );
             expect(result.breadcrumbs[1].row.selection?.nodes).toHaveLength(2); // focus is selected
             expect(result.breadcrumbs[1].row.left).toHaveLength(0);
             expect(result.breadcrumbs[0].row.selection).toBeNull();

--- a/packages/editor-core/src/reducer/__tests__/parens.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/parens.test.ts
@@ -2,7 +2,7 @@ import {toEqualEditorNodes, row, delimited} from "../test-util";
 import {parens} from "../parens";
 import {moveLeft} from "../move-left";
 import {moveRight} from "../move-right";
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import * as builders from "../../builders";
 
 import type {Zipper} from "../types";
@@ -18,7 +18,7 @@ describe("parens", () => {
                     type: "zrow",
                     left: row("2").children,
                     selection: {
-                        dir: Dir.Left,
+                        dir: SelectionDir.Left,
                         nodes: row("x+5").children,
                     },
                     right: row("=10").children,
@@ -47,7 +47,7 @@ describe("parens", () => {
                     type: "zrow",
                     left: row("2").children,
                     selection: {
-                        dir: Dir.Right,
+                        dir: SelectionDir.Right,
                         nodes: row("x+5").children,
                     },
                     right: row("=10").children,

--- a/packages/editor-core/src/reducer/__tests__/root.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/root.test.ts
@@ -2,7 +2,7 @@ import * as core from "@math-blocks/core";
 
 import * as builders from "../../builders";
 
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import {moveLeft} from "../move-left";
 import {root} from "../root";
 import {row, toEqualEditorNodes} from "../test-util";
@@ -39,7 +39,7 @@ describe("root", () => {
             expect(result.breadcrumbs).toHaveLength(1);
             expect(result.breadcrumbs[0].focus).toMatchInlineSnapshot(`
                 Object {
-                  "dir": "right",
+                  "dir": 1,
                   "id": 3,
                   "other": null,
                   "type": "zroot",
@@ -72,7 +72,7 @@ describe("root", () => {
             expect(result.breadcrumbs).toHaveLength(1);
             expect(result.breadcrumbs[0].focus).toMatchInlineSnapshot(`
                 Object {
-                  "dir": "left",
+                  "dir": 0,
                   "id": 3,
                   "other": Object {
                     "children": Array [],
@@ -100,7 +100,7 @@ describe("root", () => {
                         type: "zrow",
                         left: row("1+").children,
                         selection: {
-                            dir: Dir.Right,
+                            dir: SelectionDir.Right,
                             nodes: row("2+3").children,
                         },
                         right: [],
@@ -114,7 +114,7 @@ describe("root", () => {
                 expect(result.row.left).toEqualEditorNodes(row("2+3").children);
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+                expect(result.breadcrumbs[0].focus.dir).toEqual(1);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
                 expect(result.breadcrumbs[0].focus.other).toBeNull();
                 expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -156,7 +156,7 @@ describe("root", () => {
                 );
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+                expect(result.breadcrumbs[0].focus.dir).toEqual(1);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
                 expect(result.breadcrumbs[0].focus.other).toBeNull();
                 expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -176,7 +176,7 @@ describe("root", () => {
                         type: "zrow",
                         left: row("1+").children,
                         selection: {
-                            dir: Dir.Right,
+                            dir: SelectionDir.Right,
                             nodes: row("2+3").children,
                         },
                         right: [],
@@ -190,7 +190,7 @@ describe("root", () => {
                 expect(result.row.left).toEqualEditorNodes(row("2+3").children);
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual("left");
+                expect(result.breadcrumbs[0].focus.dir).toEqual(0);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
                 expect(result.breadcrumbs[0].focus.other)
                     .toMatchInlineSnapshot(`
@@ -239,7 +239,7 @@ describe("root", () => {
                 );
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual("left");
+                expect(result.breadcrumbs[0].focus.dir).toEqual(0);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
                 expect(result.breadcrumbs[0].focus.other)
                     .toMatchInlineSnapshot(`

--- a/packages/editor-core/src/reducer/__tests__/slash.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/slash.test.ts
@@ -1,6 +1,6 @@
 import * as builders from "../../builders";
 
-import {Dir} from "../enums";
+import {SelectionDir} from "../enums";
 import {slash} from "../slash";
 import {moveLeft} from "../move-left";
 import {row, toEqualEditorNodes} from "../test-util";
@@ -28,7 +28,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -58,7 +58,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -89,7 +89,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -120,7 +120,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -151,7 +151,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -182,7 +182,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -222,7 +222,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -253,7 +253,7 @@ describe("slash", () => {
                     type: "zrow",
                     left: row("1+").children,
                     selection: {
-                        dir: Dir.Right,
+                        dir: SelectionDir.Right,
                         nodes: row("2+3").children,
                     },
                     right: [],
@@ -266,7 +266,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,
@@ -303,7 +303,7 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual("right");
+            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
                 result.breadcrumbs[0].focus.other?.children,

--- a/packages/editor-core/src/reducer/backspace.ts
+++ b/packages/editor-core/src/reducer/backspace.ts
@@ -1,4 +1,3 @@
-import {Dir} from "./enums";
 import {rezipSelection, zdelimited, zrow} from "./util";
 import {moveLeft} from "./move-left";
 
@@ -88,7 +87,7 @@ export const backspace = (zipper: Zipper): Zipper => {
 
     const children = focus.other ? focus.other.children : [];
 
-    if (focus.dir === Dir.Left) {
+    if (focus.dir === 0) {
         return {
             breadcrumbs: breadcrumbs.slice(0, -1),
             row: {

--- a/packages/editor-core/src/reducer/convert.ts
+++ b/packages/editor-core/src/reducer/convert.ts
@@ -11,7 +11,7 @@ import {
     zroot,
     zdelimited,
 } from "./util";
-import {Dir} from "./enums";
+import {SelectionDir} from "./enums";
 
 export const zipperToRow = (zipper: Zipper): Row => {
     if (zipper.breadcrumbs.length === 0) {
@@ -25,7 +25,7 @@ export const zipperToRow = (zipper: Zipper): Row => {
     const focusedNode = focusToNode(crumb.focus, zrowToRow(zipper.row));
 
     const newRight =
-        crumb.row.selection?.dir === Dir.Right
+        crumb.row.selection?.dir === SelectionDir.Right
             ? [...crumb.row.left, focusedNode, ...selection, ...crumb.row.right]
             : [
                   ...crumb.row.left,
@@ -76,7 +76,6 @@ export const rowToZipper = (
         (child) => int.type === "content" && int.id === child.id,
     );
     if (rowIndex === -1) {
-        // debugger;
         return;
     }
 
@@ -115,34 +114,47 @@ export const rowToZipper = (
     }
 
     if (focusIndex === -1) {
-        // debugger;
         return;
     }
-
-    // TODO: replace Dir.Left, Dir.Right, Dir.None with an simple integer index
 
     let focus: Focus;
     let focusRow: Row;
     switch (child.type) {
         case "frac": {
-            focus = zfrac(child, focusIndex === 0 ? Dir.Left : Dir.Right);
+            if (focusIndex !== 0 && focusIndex !== 1) {
+                throw new Error(`Invalid focusIndex: ${focusIndex} for "frac"`);
+            }
+            focus = zfrac(child, focusIndex);
             focusRow = child.children[focusIndex];
             break;
         }
         case "limits": {
-            focus = zlimits(child, focusIndex === 0 ? Dir.Left : Dir.Right);
+            if (focusIndex !== 0 && focusIndex !== 1) {
+                throw new Error(
+                    `Invalid focusIndex: ${focusIndex} for "limits"`,
+                );
+            }
+            focus = zlimits(child, focusIndex);
             // @ts-expect-error: this should never happen since focusIndex !== -1
             focusRow = child.children[focusIndex];
             break;
         }
         case "subsup": {
-            focus = zsubsup(child, focusIndex === 0 ? Dir.Left : Dir.Right);
+            if (focusIndex !== 0 && focusIndex !== 1) {
+                throw new Error(
+                    `Invalid focusIndex: ${focusIndex} for "subsup"`,
+                );
+            }
+            focus = zsubsup(child, focusIndex);
             // @ts-expect-error: this should never happen since focusIndex !== -1
             focusRow = child.children[focusIndex];
             break;
         }
         case "root": {
-            focus = zroot(child, focusIndex === 0 ? Dir.Left : Dir.Right);
+            if (focusIndex !== 0 && focusIndex !== 1) {
+                throw new Error(`Invalid focusIndex: ${focusIndex} for "root"`);
+            }
+            focus = zroot(child, focusIndex);
             // @ts-expect-error: this should never happen since focusIndex !== -1
             focusRow = child.children[focusIndex];
             break;

--- a/packages/editor-core/src/reducer/enums.ts
+++ b/packages/editor-core/src/reducer/enums.ts
@@ -1,5 +1,4 @@
-export enum Dir {
+export enum SelectionDir {
     Left = "left",
     Right = "right",
-    None = "none",
 }

--- a/packages/editor-core/src/reducer/move-left.ts
+++ b/packages/editor-core/src/reducer/move-left.ts
@@ -2,7 +2,7 @@ import {UnreachableCaseError} from "@math-blocks/core";
 
 import * as types from "../types";
 
-import {Dir} from "./enums";
+import {SelectionDir} from "./enums";
 import type {Breadcrumb, Focus, Zipper, ZRow, ZRowWithSelection} from "./types";
 import * as util from "./util";
 import {crumbMoveLeft, startSelection, stopSelection} from "./selection-util";
@@ -48,20 +48,20 @@ const cursorLeft = (zipper: Zipper): Zipper => {
             let focus: Focus;
             switch (prev.type) {
                 case "frac": {
-                    focus = util.zfrac(prev, Dir.Right);
+                    focus = util.zfrac(prev, 1);
                     break;
                 }
                 case "subsup": {
-                    const dir = prev.children[1] ? Dir.Right : Dir.Left;
+                    const dir = prev.children[1] ? 1 : 0;
                     focus = util.zsubsup(prev, dir);
                     break;
                 }
                 case "root": {
-                    focus = util.zroot(prev, Dir.Right);
+                    focus = util.zroot(prev, 1);
                     break;
                 }
                 case "limits": {
-                    const dir = prev.children[1] ? Dir.Right : Dir.Left;
+                    const dir = prev.children[1] ? 1 : 0;
                     focus = util.zlimits(prev, dir);
                     break;
                 }
@@ -119,7 +119,7 @@ const cursorLeft = (zipper: Zipper): Zipper => {
                     row: parentRow,
                     focus: {
                         ...focus,
-                        dir: Dir.Left,
+                        dir: 0,
                         other: exitedRow,
                     },
                 },
@@ -129,22 +129,22 @@ const cursorLeft = (zipper: Zipper): Zipper => {
 
         switch (focus.type) {
             case "zsubsup": {
-                return focus.dir === Dir.Right && focus.other
+                return focus.dir === 1 && focus.other
                     ? focusLeft(focus.other)
                     : exitNode(util.subsup(focus, exitedRow));
             }
             case "zfrac": {
-                return focus.dir === Dir.Right
+                return focus.dir === 1
                     ? focusLeft(focus.other)
                     : exitNode(util.frac(focus, exitedRow));
             }
             case "zroot": {
-                return focus.dir === Dir.Right && focus.other
+                return focus.dir === 1 && focus.other
                     ? focusLeft(focus.other)
                     : exitNode(util.root(focus, exitedRow));
             }
             case "zlimits":
-                return focus.dir === Dir.Right && focus.other
+                return focus.dir === 1 && focus.other
                     ? focusLeft(focus.other)
                     : exitNode(util.limits(focus, exitedRow));
             default:
@@ -181,15 +181,15 @@ const selectionLeft = (zipper: Zipper): Zipper => {
         // We haven't started selecting anything yet.
         if (row.left.length > 0) {
             // Create a new selection to the left and move left.
-            return crumbMoveLeft(startSelection(zipper, Dir.Left));
+            return crumbMoveLeft(startSelection(zipper, SelectionDir.Left));
         } else {
             // Create an empty selection and them move outward.
             const index = zipper.breadcrumbs.length - 1;
             const crumb = zipper.breadcrumbs[index];
-            const updatedCrumb = startSelection(crumb, Dir.Left);
+            const updatedCrumb = startSelection(crumb, SelectionDir.Left);
 
             return {
-                ...startSelection(zipper, Dir.Left),
+                ...startSelection(zipper, SelectionDir.Left),
                 breadcrumbs: replaceItem(
                     zipper.breadcrumbs,
                     updatedCrumb,
@@ -202,13 +202,13 @@ const selectionLeft = (zipper: Zipper): Zipper => {
 
         const row = rowsWithSelections[0]; // same as zipper.row
 
-        if (row.selection.dir === Dir.Left) {
+        if (row.selection.dir === SelectionDir.Left) {
             if (row.left.length > 0) {
                 return crumbMoveLeft(zipper);
             } else if (zipper.breadcrumbs.length > 0) {
                 const index = zipper.breadcrumbs.length - 1;
                 const crumb = zipper.breadcrumbs[index];
-                const updatedCrumb = startSelection(crumb, Dir.Left);
+                const updatedCrumb = startSelection(crumb, SelectionDir.Left);
 
                 // move out to start a selection in the parent crumb
                 return {
@@ -248,7 +248,7 @@ const selectionLeft = (zipper: Zipper): Zipper => {
         const crumb = zipper.breadcrumbs[index];
         const row = rowsWithSelections[0]; // same as crumb.row
 
-        if (row.selection.dir === Dir.Left) {
+        if (row.selection.dir === SelectionDir.Left) {
             if (row.left.length > 0) {
                 const updatedCrumb = crumbMoveLeft(crumb);
                 return {
@@ -270,7 +270,7 @@ const selectionLeft = (zipper: Zipper): Zipper => {
                 }
 
                 const crumb = zipper.breadcrumbs[index];
-                const updatedCrumb = startSelection(crumb, Dir.Left);
+                const updatedCrumb = startSelection(crumb, SelectionDir.Left);
                 return {
                     ...zipper,
                     breadcrumbs: replaceItem(

--- a/packages/editor-core/src/reducer/move-right.ts
+++ b/packages/editor-core/src/reducer/move-right.ts
@@ -2,7 +2,7 @@ import {UnreachableCaseError} from "@math-blocks/core";
 
 import * as types from "../types";
 
-import {Dir} from "./enums";
+import {SelectionDir} from "./enums";
 import type {Breadcrumb, Focus, Zipper, ZRow, ZRowWithSelection} from "./types";
 import * as util from "./util";
 import {crumbMoveRight, startSelection, stopSelection} from "./selection-util";
@@ -48,21 +48,21 @@ const cursorRight = (zipper: Zipper): Zipper => {
             let focus: Focus;
             switch (next.type) {
                 case "frac": {
-                    focus = util.zfrac(next, Dir.Left);
+                    focus = util.zfrac(next, 0);
                     break;
                 }
                 case "subsup": {
-                    const dir = next.children[0] ? Dir.Left : Dir.Right;
+                    const dir = next.children[0] ? 0 : 1;
                     focus = util.zsubsup(next, dir);
                     break;
                 }
                 case "root": {
-                    const dir = next.children[0] ? Dir.Left : Dir.Right;
+                    const dir = next.children[0] ? 0 : 1;
                     focus = util.zroot(next, dir);
                     break;
                 }
                 case "limits":
-                    focus = util.zlimits(next, Dir.Left);
+                    focus = util.zlimits(next, 0);
                     break;
                 case "delimited": {
                     focus = util.zdelimited(next);
@@ -117,7 +117,7 @@ const cursorRight = (zipper: Zipper): Zipper => {
                     row: parentRow,
                     focus: {
                         ...focus,
-                        dir: Dir.Right,
+                        dir: 1,
                         other: exitedRow,
                     },
                 },
@@ -127,19 +127,19 @@ const cursorRight = (zipper: Zipper): Zipper => {
 
         switch (focus.type) {
             case "zsubsup":
-                return focus.dir === Dir.Left && focus.other
+                return focus.dir === 0 && focus.other
                     ? focusRight(focus.other)
                     : exitNode(util.subsup(focus, exitedRow));
             case "zfrac":
-                return focus.dir === Dir.Left
+                return focus.dir === 0
                     ? focusRight(focus.other)
                     : exitNode(util.frac(focus, exitedRow));
             case "zroot":
-                return focus.dir === Dir.Left
+                return focus.dir === 0
                     ? focusRight(focus.other)
                     : exitNode(util.root(focus, exitedRow));
             case "zlimits":
-                return focus.dir === Dir.Left && focus.other
+                return focus.dir === 0 && focus.other
                     ? focusRight(focus.other)
                     : exitNode(util.limits(focus, exitedRow));
             default:
@@ -176,15 +176,15 @@ const selectionRight = (zipper: Zipper): Zipper => {
         // We haven't started selecting anything yet.
         if (row.right.length > 0) {
             // Create a new selection to the left and move left.
-            return crumbMoveRight(startSelection(zipper, Dir.Right));
+            return crumbMoveRight(startSelection(zipper, SelectionDir.Right));
         } else {
             // Create an empty selection and them move outward.
             const index = zipper.breadcrumbs.length - 1;
             const crumb = zipper.breadcrumbs[index];
-            const updatedCrumb = startSelection(crumb, Dir.Right);
+            const updatedCrumb = startSelection(crumb, SelectionDir.Right);
 
             return {
-                ...startSelection(zipper, Dir.Right),
+                ...startSelection(zipper, SelectionDir.Right),
                 breadcrumbs: replaceItem(
                     zipper.breadcrumbs,
                     updatedCrumb,
@@ -197,13 +197,13 @@ const selectionRight = (zipper: Zipper): Zipper => {
 
         const row = rowsWithSelections[0]; // same as zipper.row
 
-        if (row.selection.dir === Dir.Right) {
+        if (row.selection.dir === SelectionDir.Right) {
             if (zipper.row.right.length > 0) {
                 return crumbMoveRight(zipper);
             } else if (zipper.breadcrumbs.length > 0) {
                 const index = zipper.breadcrumbs.length - 1;
                 const crumb = zipper.breadcrumbs[index];
-                const updatedCrumb = startSelection(crumb, Dir.Right);
+                const updatedCrumb = startSelection(crumb, SelectionDir.Right);
 
                 // Move out to start a selection in the parent crumb.
                 return {
@@ -243,7 +243,7 @@ const selectionRight = (zipper: Zipper): Zipper => {
         const crumb = zipper.breadcrumbs[index];
         const row = rowsWithSelections[0]; // same as crumb.row
 
-        if (row.selection.dir === Dir.Right) {
+        if (row.selection.dir === SelectionDir.Right) {
             if (row.right.length > 0) {
                 const updatedCrumb = crumbMoveRight(crumb);
                 return {
@@ -265,7 +265,7 @@ const selectionRight = (zipper: Zipper): Zipper => {
                 }
 
                 const crumb = zipper.breadcrumbs[index];
-                const updatedCrumb = startSelection(crumb, Dir.Right);
+                const updatedCrumb = startSelection(crumb, SelectionDir.Right);
                 return {
                     ...zipper,
                     breadcrumbs: replaceItem(

--- a/packages/editor-core/src/reducer/reducer.ts
+++ b/packages/editor-core/src/reducer/reducer.ts
@@ -8,7 +8,6 @@ import {parens} from "./parens";
 import {root} from "./root";
 import {slash} from "./slash";
 import {subsup} from "./subsup";
-import {Dir} from "./enums";
 import {zrow} from "./util";
 import type {Zipper} from "./types";
 
@@ -38,10 +37,10 @@ export const zipperReducer = (
             return backspace(state);
         }
         case "_": {
-            return subsup(state, Dir.Left);
+            return subsup(state, 0);
         }
         case "^": {
-            return subsup(state, Dir.Right);
+            return subsup(state, 1);
         }
         case "(":
         case ")":

--- a/packages/editor-core/src/reducer/root.ts
+++ b/packages/editor-core/src/reducer/root.ts
@@ -3,7 +3,6 @@ import {getId} from "@math-blocks/core";
 import * as builders from "../builders";
 
 import * as util from "./util";
-import {Dir} from "./enums";
 import type {Zipper, Focus} from "./types";
 
 export const root = (zipper: Zipper, withIndex: boolean): Zipper => {
@@ -14,13 +13,13 @@ export const root = (zipper: Zipper, withIndex: boolean): Zipper => {
         ? {
               id: getId(),
               type: "zroot",
-              dir: Dir.Left,
+              dir: 0,
               other: builders.row([]),
           }
         : {
               id: getId(),
               type: "zroot",
-              dir: Dir.Right,
+              dir: 1,
               other: null,
           };
 

--- a/packages/editor-core/src/reducer/selection-util.ts
+++ b/packages/editor-core/src/reducer/selection-util.ts
@@ -1,9 +1,9 @@
-import {Dir} from "./enums";
+import {SelectionDir} from "./enums";
 import type {ZRow} from "./types";
 
 export const startSelection = <T extends {row: ZRow}>(
     crumb: T,
-    dir: Dir,
+    dir: SelectionDir,
 ): T => {
     return {
         ...crumb,
@@ -37,7 +37,7 @@ export const crumbMoveLeft = <T extends {row: ZRow}>(crumb: T): T => {
         return crumb;
     }
 
-    if (selection.dir === Dir.Left) {
+    if (selection.dir === SelectionDir.Left) {
         return {
             ...crumb,
             row: {
@@ -77,7 +77,7 @@ export const crumbMoveRight = <T extends {row: ZRow}>(crumb: T): T => {
         return crumb;
     }
 
-    if (selection.dir === Dir.Right) {
+    if (selection.dir === SelectionDir.Right) {
         return {
             ...crumb,
             row: {

--- a/packages/editor-core/src/reducer/slash.ts
+++ b/packages/editor-core/src/reducer/slash.ts
@@ -1,6 +1,5 @@
 import {getId} from "@math-blocks/core";
 
-import {Dir} from "./enums";
 import {rezipSelection, zrow} from "./util";
 import type {Zipper, Focus} from "./types";
 
@@ -43,7 +42,7 @@ export const slash = (zipper: Zipper): Zipper => {
         const focus: Focus = {
             type: "zfrac",
             id: getId(),
-            dir: Dir.Right,
+            dir: 1,
             other: {
                 id: getId(),
                 type: "row",
@@ -99,7 +98,7 @@ export const slash = (zipper: Zipper): Zipper => {
     const focus: Focus = {
         type: "zfrac",
         id: getId(),
-        dir: Dir.Right,
+        dir: 1,
         other: {
             id: getId(),
             type: "row",

--- a/packages/editor-core/src/reducer/subsup.ts
+++ b/packages/editor-core/src/reducer/subsup.ts
@@ -1,10 +1,9 @@
 import {getId} from "@math-blocks/core";
 
 import * as util from "./util";
-import {Dir} from "./enums";
 import type {Zipper} from "./types";
 
-export const subsup = (zipper: Zipper, dir: Dir): Zipper => {
+export const subsup = (zipper: Zipper, dir: 0 | 1): Zipper => {
     const {row, breadcrumbs} = zipper;
 
     if (row.right.length > 0) {
@@ -26,12 +25,12 @@ export const subsup = (zipper: Zipper, dir: Dir): Zipper => {
                             id: next.id, // reuse the id of the subsup we're updating
                             type: "zsubsup",
                             dir: dir,
-                            other: dir === Dir.Left ? sup : sub,
+                            other: dir === 0 ? sup : sub,
                         },
                     },
                 ],
                 row:
-                    dir === Dir.Left
+                    dir === 0
                         ? sub
                             ? util.zrow(sub.id, [], sub.children)
                             : util.zrow(getId(), [], [])

--- a/packages/editor-core/src/reducer/types.ts
+++ b/packages/editor-core/src/reducer/types.ts
@@ -1,8 +1,8 @@
 import * as types from "../types";
-import {Dir} from "./enums";
+import {SelectionDir} from "./enums";
 
 type Selection = {
-    dir: Dir;
+    dir: SelectionDir;
     nodes: readonly types.Node[];
 };
 
@@ -27,7 +27,7 @@ export type ZRow = ZRowWithoutSelection | ZRowWithSelection;
 export type ZFrac = {
     id: number;
     type: "zfrac";
-    dir: Dir; // what is focused, left = 0, right = 1
+    dir: 0 | 1; // index of focused child
     other: types.Row; // what isn't being focused
 };
 
@@ -36,7 +36,7 @@ export type ZFrac = {
 export type ZSubSup = {
     id: number;
     type: "zsubsup";
-    dir: Dir;
+    dir: 0 | 1; // index of focused child
     other: types.Row | null; // what isn't being focused
 };
 
@@ -44,14 +44,14 @@ export type ZLimits =
     | {
           id: number;
           type: "zlimits";
-          dir: Dir.Left;
+          dir: 0; // index of focused child
           other: types.Row | null;
           inner: types.Node;
       }
     | {
           id: number;
           type: "zlimits";
-          dir: Dir.Right;
+          dir: 1; // index of focused child
           other: types.Row;
           inner: types.Node;
       };
@@ -60,20 +60,20 @@ export type ZRoot =
     | {
           id: number;
           type: "zroot";
-          dir: Dir.Left;
+          dir: 0; // index of focused child
           other: types.Row;
       }
     | {
           id: number;
           type: "zroot";
-          dir: Dir.Right;
+          dir: 1; // index of focused child
           other: types.Row | null;
       };
 
 export type ZDelimited = {
     id: number;
     type: "zdelimited";
-    dir: Dir.None;
+    dir: 0; // index of focused child
     other: null;
     leftDelim: types.Atom;
     rightDelim: types.Atom;

--- a/packages/editor-core/src/reducer/util.ts
+++ b/packages/editor-core/src/reducer/util.ts
@@ -2,7 +2,7 @@ import {UnreachableCaseError} from "@math-blocks/core";
 
 import * as types from "../types";
 
-import {Dir} from "./enums";
+import {SelectionDir} from "./enums";
 import type {
     ZRow,
     ZFrac,
@@ -15,7 +15,7 @@ import type {
 } from "./types";
 
 export const frac = (focus: ZFrac, replacement: types.Row): types.Frac => {
-    if (focus.dir === Dir.Left) {
+    if (focus.dir === 0) {
         return {
             id: focus.id,
             type: "frac",
@@ -30,12 +30,12 @@ export const frac = (focus: ZFrac, replacement: types.Row): types.Frac => {
     }
 };
 
-export const zfrac = (node: types.Frac, dir: Dir): ZFrac => {
+export const zfrac = (node: types.Frac, dir: 0 | 1): ZFrac => {
     return {
         id: node.id,
         type: "zfrac",
         dir,
-        other: dir === Dir.Left ? node.children[1] : node.children[0],
+        other: node.children[1 - dir],
     };
 };
 
@@ -43,7 +43,7 @@ export const subsup = (
     focus: ZSubSup,
     replacement: types.Row,
 ): types.SubSup => {
-    if (focus.dir === Dir.Left) {
+    if (focus.dir === 0) {
         return {
             id: focus.id,
             type: "subsup",
@@ -58,17 +58,17 @@ export const subsup = (
     }
 };
 
-export const zsubsup = (node: types.SubSup, dir: Dir): ZSubSup => {
+export const zsubsup = (node: types.SubSup, dir: 0 | 1): ZSubSup => {
     return {
         id: node.id,
         type: "zsubsup",
         dir,
-        other: dir === Dir.Left ? node.children[1] : node.children[0],
+        other: node.children[1 - dir],
     };
 };
 
 export const root = (focus: ZRoot, replacement: types.Row): types.Root => {
-    if (focus.dir === Dir.Left) {
+    if (focus.dir === 0) {
         return {
             id: focus.id,
             type: "root",
@@ -83,15 +83,15 @@ export const root = (focus: ZRoot, replacement: types.Row): types.Root => {
     }
 };
 
-export const zroot = (node: types.Root, dir: Dir): ZRoot => {
-    if (dir === Dir.Left) {
+export const zroot = (node: types.Root, dir: 0 | 1): ZRoot => {
+    if (dir === 0) {
         return {
             id: node.id,
             type: "zroot",
             dir,
             other: node.children[1],
         };
-    } else if (dir === Dir.Right) {
+    } else if (dir === 1) {
         return {
             id: node.id,
             type: "zroot",
@@ -107,7 +107,7 @@ export const limits = (
     focus: ZLimits,
     replacement: types.Row,
 ): types.Limits => {
-    if (focus.dir === Dir.Left) {
+    if (focus.dir === 0) {
         return {
             id: focus.id,
             type: "limits",
@@ -124,8 +124,8 @@ export const limits = (
     }
 };
 
-export const zlimits = (node: types.Limits, dir: Dir): ZLimits => {
-    if (dir === Dir.Left) {
+export const zlimits = (node: types.Limits, dir: 0 | 1): ZLimits => {
+    if (dir === 0) {
         return {
             id: node.id,
             type: "zlimits",
@@ -133,7 +133,7 @@ export const zlimits = (node: types.Limits, dir: Dir): ZLimits => {
             other: node.children[1],
             inner: node.inner,
         };
-    } else if (dir === Dir.Right) {
+    } else if (dir === 1) {
         return {
             id: node.id,
             type: "zlimits",
@@ -163,7 +163,7 @@ export const zdelimited = (node: types.Delimited): ZDelimited => {
     return {
         id: node.id,
         type: "zdelimited",
-        dir: Dir.None,
+        dir: 0,
         other: null,
         leftDelim: node.leftDelim,
         rightDelim: node.rightDelim,
@@ -290,7 +290,7 @@ export const rezipSelection = (zipper: Zipper): Zipper => {
 
     if (lastCrumb.row.selection) {
         const newSelectionNodes =
-            lastCrumb.row.selection.dir === Dir.Left
+            lastCrumb.row.selection.dir === SelectionDir.Left
                 ? [...lastCrumb.row.selection.nodes, node]
                 : [node, ...lastCrumb.row.selection.nodes];
 

--- a/packages/react/src/__tests__/mouse-cursor.test.tsx
+++ b/packages/react/src/__tests__/mouse-cursor.test.tsx
@@ -168,7 +168,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([
                 glyph("1"),
@@ -190,7 +190,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([glyph("1")]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("2")]);
         });
@@ -209,7 +209,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("1"),
                 glyph("2"),
@@ -231,7 +231,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Right);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("x"),
                 glyph("+"),
@@ -278,7 +278,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Right);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("2")]);
         });
@@ -297,7 +297,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Right);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
             expect(zipper.row.left).toEqualEditorNodes([glyph("2")]);
             expect(zipper.row.right).toEqualEditorNodes([]);
         });
@@ -316,7 +316,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("n")]);
         });
@@ -335,7 +335,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([glyph("n")]);
             expect(zipper.row.right).toEqualEditorNodes([]);
         });
@@ -376,7 +376,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("3")]);
         });
@@ -395,7 +395,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Right);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("x"),
                 glyph("+"),
@@ -443,7 +443,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.None);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("x"),
                 glyph("+"),
@@ -492,7 +492,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Right);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
             expect(zipper.row.left).toEqualEditorNodes([glyph("\u221e")]);
             expect(zipper.row.right).toEqualEditorNodes([]);
         });
@@ -511,7 +511,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(Editor.Dir.Left);
+            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("i"),
                 glyph("="),

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -326,12 +326,12 @@ const typesetFocus = (
             const childContext = childContextForFrac(context);
 
             const numerator =
-                focus.dir === "left"
+                focus.dir === 0
                     ? _typesetZipper(zipper, childContext)
                     : typesetRow(focus.other, childContext);
 
             const denominator =
-                focus.dir === "left"
+                focus.dir === 0
                     ? typesetRow(focus.other, childContext)
                     : _typesetZipper(zipper, childContext);
 
@@ -346,7 +346,7 @@ const typesetFocus = (
             const childContext = childContextForSubsup(context);
 
             const [sub, sup] =
-                focus.dir === "left"
+                focus.dir === 0
                     ? [zipper.row, focus.other]
                     : [focus.other, zipper.row];
 
@@ -377,7 +377,7 @@ const typesetFocus = (
         }
         case "zroot": {
             const [ind, rad] =
-                focus.dir === "left"
+                focus.dir === 0
                     ? [zipper.row, focus.other]
                     : [focus.other, zipper.row];
 
@@ -410,7 +410,7 @@ const typesetFocus = (
             const childContext = childContextForLimits(context);
 
             const [lower, upper] =
-                focus.dir === "left"
+                focus.dir === 0
                     ? [zipper.row, focus.other]
                     : [focus.other, zipper.row];
 


### PR DESCRIPTION
This property represents the index of the focused child.  We should probably change the name of this property while we're at it.