### PR TITLE
Switch to left/right arrays for Focus types

### DIFF
--- a/packages/editor-core/src/reducer/__tests__/backspace.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/backspace.test.ts
@@ -94,8 +94,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zfrac",
-                            dir: 0, // the numerator is focused
-                            other: row("3"), // denominator
+                            left: [],
+                            right: [row("3")],
                         },
                     },
                 ],
@@ -128,8 +128,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zfrac",
-                            dir: 1, // the denominator is focused
-                            other: row("2"), // numerator
+                            left: [row("2")],
+                            right: [],
                         },
                     },
                 ],
@@ -160,8 +160,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: 1,
-                other: f.children[0],
+                left: [f.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -191,8 +191,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: 0, // the subscript is focused
-                            other: null, // no superscript
+                            left: [], // the subscript is focused
+                            right: [null], // no superscript
                         },
                     },
                 ],
@@ -225,8 +225,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: 0, // the subscript is focused
-                            other: row("2"), // superscript
+                            left: [], // the subscript is focused
+                            right: [row("2")], // superscript
                         },
                     },
                 ],
@@ -259,8 +259,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: 1, // the superscript is focused
-                            other: null, // no subscript
+                            left: [null], // no subscript
+                            right: [], // the superscript is focused
                         },
                     },
                 ],
@@ -293,8 +293,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zsubsup",
-                            dir: 1, // the superscript is focused
-                            other: row("n"), // subscript
+                            left: [row("n")], // subscript
+                            right: [], // the superscript is focused
                         },
                     },
                 ],
@@ -330,8 +330,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 0,
-                other: null,
+                left: [],
+                right: [null],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -357,8 +357,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 1,
-                other: null,
+                left: [null],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -388,8 +388,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zroot",
-                            dir: 1, // the radicand is focused
-                            other: null, // no index
+                            left: [null], // no index
+                            right: [], // the radicand is focused
                         },
                     },
                 ],
@@ -422,8 +422,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zroot",
-                            dir: 1, // the radicand is focused
-                            other: row("3"), // index
+                            left: [row("3")], // index
+                            right: [], // the radicand is focused
                         },
                     },
                 ],
@@ -456,8 +456,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zroot",
-                            dir: 0, // the index is focused
-                            other: row("27"), // radicand
+                            left: [], // the index is focused
+                            right: [row("27")], // radicand
                         },
                     },
                 ],
@@ -488,8 +488,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 1,
-                other: null,
+                left: [null],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -515,8 +515,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 1,
-                other: r.children[0],
+                left: [r.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -546,8 +546,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zlimits",
-                            dir: 0, // the lower bound is focused
-                            other: null, // no upper bound
+                            left: [], // the lower bound is focused
+                            right: [null], // no upper bound
                             inner: row("lim"),
                         },
                     },
@@ -581,8 +581,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zlimits",
-                            dir: 0, // the lower bound is focused
-                            other: row("n"), // upper bound
+                            left: [], // the lower bound is focused
+                            right: [row("n")], // upper bound
                             inner: row("sum"),
                         },
                     },
@@ -616,8 +616,8 @@ describe("backspace", () => {
                         focus: {
                             id: 0,
                             type: "zlimits",
-                            dir: 1, // the upper bound is focused
-                            other: row("i=0"), // lower bound
+                            left: [row("i=0")], // lower bound
+                            right: [], // the upper bound is focused
                             inner: row("sum"),
                         },
                     },
@@ -663,8 +663,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: lim.id,
                 type: "zlimits",
-                dir: 0,
-                other: null,
+                left: [],
+                right: [null],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(1);
@@ -706,8 +706,8 @@ describe("backspace", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: 1,
-                other: lower,
+                left: [lower],
+                right: [],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(1);

--- a/packages/editor-core/src/reducer/__tests__/convert.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/convert.test.ts
@@ -90,8 +90,8 @@ describe("zipperToRow", () => {
                         focus: {
                             id: 2,
                             type: "zfrac",
-                            dir: 0,
-                            other: row("3"),
+                            left: [],
+                            right: [row("3")],
                         },
                     },
                 ],
@@ -137,8 +137,8 @@ describe("zipperToRow", () => {
                         focus: {
                             id: 2,
                             type: "zfrac",
-                            dir: 0,
-                            other: row("3"),
+                            left: [],
+                            right: [row("3")],
                         },
                     },
                 ],
@@ -186,8 +186,8 @@ describe("zipperToRow", () => {
                         focus: {
                             id: 2,
                             type: "zfrac",
-                            dir: 0,
-                            other: row("3"),
+                            left: [],
+                            right: [row("3")],
                         },
                     },
                 ],

--- a/packages/editor-core/src/reducer/__tests__/insert-char.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/insert-char.test.ts
@@ -125,8 +125,8 @@ describe("insertChar", () => {
                         focus: {
                             id: 0,
                             type: "zfrac",
-                            dir: 1,
-                            other: builders.row([builders.glyph("3")]),
+                            left: [builders.row([builders.glyph("3")])],
+                            right: [],
                         },
                         row: {
                             id: 0,

--- a/packages/editor-core/src/reducer/__tests__/move-cursor.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/move-cursor.test.ts
@@ -65,8 +65,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: 0,
-                other: f.children[1],
+                left: [],
+                right: [f.children[1]],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -92,8 +92,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: 1,
-                other: f.children[0],
+                left: [f.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -144,8 +144,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 0,
-                other: ss.children[1],
+                left: [],
+                right: [ss.children[1]],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -171,8 +171,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 1,
-                other: ss.children[0],
+                left: [ss.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -223,8 +223,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 0,
-                other: null,
+                left: [],
+                right: [null],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -273,8 +273,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 1,
-                other: null,
+                left: [null],
+                right: [],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -323,8 +323,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 0,
-                other: r.children[1],
+                left: [],
+                right: [r.children[1]],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -350,8 +350,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 1,
-                other: r.children[0],
+                left: [r.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -402,8 +402,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 1,
-                other: null,
+                left: [null],
+                right: [],
             });
             expect(result.row.left).toHaveLength(0);
             expect(result.row.right).toHaveLength(1);
@@ -466,8 +466,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: lim.id,
                 type: "zlimits",
-                dir: 0,
-                other: null,
+                left: [],
+                right: [null],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(0);
@@ -546,8 +546,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: 0,
-                other: upper,
+                left: [],
+                right: [upper],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(0);
@@ -589,8 +589,8 @@ describe("moveRight", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: 1,
-                other: lower,
+                left: [lower],
+                right: [],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(0);
@@ -697,8 +697,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: 1,
-                other: f.children[0],
+                left: [f.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -724,8 +724,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: f.id,
                 type: "zfrac",
-                dir: 0,
-                other: f.children[1],
+                left: [],
+                right: [f.children[1]],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -776,8 +776,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 1,
-                other: ss.children[0],
+                left: [ss.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -803,8 +803,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 0,
-                other: ss.children[1],
+                left: [],
+                right: [ss.children[1]],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -855,8 +855,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 1,
-                other: null,
+                left: [null],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -905,8 +905,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: ss.id,
                 type: "zsubsup",
-                dir: 0,
-                other: null,
+                left: [],
+                right: [null],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -955,8 +955,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 1,
-                other: r.children[0],
+                left: [r.children[0]],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -982,8 +982,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 0,
-                other: r.children[1],
+                left: [],
+                right: [r.children[1]],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -1034,8 +1034,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: r.id,
                 type: "zroot",
-                dir: 1,
-                other: null,
+                left: [null],
+                right: [],
             });
             expect(result.row.left).toHaveLength(1);
             expect(result.row.right).toHaveLength(0);
@@ -1098,8 +1098,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: lim.id,
                 type: "zlimits",
-                dir: 0,
-                other: null,
+                left: [],
+                right: [null],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(1);
@@ -1178,8 +1178,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: 1,
-                other: lower,
+                left: [lower],
+                right: [],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(1);
@@ -1221,8 +1221,8 @@ describe("moveLeft", () => {
             expect(result.breadcrumbs[0].focus).toEqual({
                 id: sum.id,
                 type: "zlimits",
-                dir: 0,
-                other: upper,
+                left: [],
+                right: [upper],
                 inner: inner,
             });
             expect(result.row.left).toHaveLength(1);

--- a/packages/editor-core/src/reducer/__tests__/root.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/root.test.ts
@@ -39,9 +39,11 @@ describe("root", () => {
             expect(result.breadcrumbs).toHaveLength(1);
             expect(result.breadcrumbs[0].focus).toMatchInlineSnapshot(`
                 Object {
-                  "dir": 1,
                   "id": 3,
-                  "other": null,
+                  "left": Array [
+                    null,
+                  ],
+                  "right": Array [],
                   "type": "zroot",
                 }
             `);
@@ -72,13 +74,15 @@ describe("root", () => {
             expect(result.breadcrumbs).toHaveLength(1);
             expect(result.breadcrumbs[0].focus).toMatchInlineSnapshot(`
                 Object {
-                  "dir": 0,
                   "id": 3,
-                  "other": Object {
-                    "children": Array [],
-                    "id": 4,
-                    "type": "row",
-                  },
+                  "left": Array [],
+                  "right": Array [
+                    Object {
+                      "children": Array [],
+                      "id": 4,
+                      "type": "row",
+                    },
+                  ],
                   "type": "zroot",
                 }
             `);
@@ -114,9 +118,9 @@ describe("root", () => {
                 expect(result.row.left).toEqualEditorNodes(row("2+3").children);
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual(1);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
-                expect(result.breadcrumbs[0].focus.other).toBeNull();
+                expect(result.breadcrumbs[0].focus.left).toEqual([null]);
+                expect(result.breadcrumbs[0].focus.right).toEqual([]);
                 expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
                     row("").children,
                 );
@@ -156,9 +160,9 @@ describe("root", () => {
                 );
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual(1);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
-                expect(result.breadcrumbs[0].focus.other).toBeNull();
+                expect(result.breadcrumbs[0].focus.left).toEqual([null]);
+                expect(result.breadcrumbs[0].focus.right).toEqual([]);
                 expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
                     row("").children,
                 );
@@ -190,15 +194,17 @@ describe("root", () => {
                 expect(result.row.left).toEqualEditorNodes(row("2+3").children);
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual(0);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
-                expect(result.breadcrumbs[0].focus.other)
+                expect(result.breadcrumbs[0].focus.left).toEqual([]);
+                expect(result.breadcrumbs[0].focus.right)
                     .toMatchInlineSnapshot(`
-                    Object {
-                      "children": Array [],
-                      "id": 8,
-                      "type": "row",
-                    }
+                    Array [
+                      Object {
+                        "children": Array [],
+                        "id": 8,
+                        "type": "row",
+                      },
+                    ]
                 `);
                 expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
                     row("").children,
@@ -239,15 +245,17 @@ describe("root", () => {
                 );
                 expect(result.row.right).toEqualEditorNodes(row("").children);
                 expect(result.breadcrumbs).toHaveLength(1);
-                expect(result.breadcrumbs[0].focus.dir).toEqual(0);
                 expect(result.breadcrumbs[0].focus.type).toEqual("zroot");
-                expect(result.breadcrumbs[0].focus.other)
+                expect(result.breadcrumbs[0].focus.left).toEqual([]);
+                expect(result.breadcrumbs[0].focus.right)
                     .toMatchInlineSnapshot(`
-                    Object {
-                      "children": Array [],
-                      "id": 7,
-                      "type": "row",
-                    }
+                    Array [
+                      Object {
+                        "children": Array [],
+                        "id": 7,
+                        "type": "row",
+                      },
+                    ]
                 `);
                 expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
                     row("").children,

--- a/packages/editor-core/src/reducer/__tests__/slash.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/slash.test.ts
@@ -28,10 +28,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("2").children);
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
                 row("").children,
@@ -58,10 +58,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("ab").children);
 
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -89,10 +89,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("(1+2)").children);
 
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -120,10 +120,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("(a)(b)").children);
 
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -151,10 +151,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("1").children);
 
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -182,10 +182,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("1").children);
 
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -222,10 +222,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("2").children);
 
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
@@ -266,10 +266,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(row("2+3").children);
             expect(result.breadcrumbs[0].row.right).toEqualEditorNodes(
                 row("").children,
@@ -303,10 +303,10 @@ describe("slash", () => {
             expect(result.row.left).toEqualEditorNodes(row("").children);
             expect(result.row.right).toEqualEditorNodes(row("").children);
             expect(result.breadcrumbs).toHaveLength(1);
-            expect(result.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(result.breadcrumbs[0].focus.right).toEqual([]);
             expect(result.breadcrumbs[0].focus.type).toEqual("zfrac");
             expect(
-                result.breadcrumbs[0].focus.other?.children,
+                result.breadcrumbs[0].focus.left[0]?.children,
             ).toEqualEditorNodes(
                 builders.row([
                     builders.glyph("x"),

--- a/packages/editor-core/src/reducer/backspace.ts
+++ b/packages/editor-core/src/reducer/backspace.ts
@@ -85,9 +85,8 @@ export const backspace = (zipper: Zipper): Zipper => {
 
     const {focus, row} = parent;
 
-    const children = focus.other ? focus.other.children : [];
-
-    if (focus.dir === 0) {
+    if (focus.left.length === 0) {
+        const children = focus.right[0] ? focus.right[0].children : [];
         return {
             breadcrumbs: breadcrumbs.slice(0, -1),
             row: {
@@ -96,7 +95,7 @@ export const backspace = (zipper: Zipper): Zipper => {
             },
         };
     } else {
-        if (focus.type === "zsubsup" && focus.other) {
+        if (focus.type === "zsubsup" && focus.left[0]) {
             return {
                 breadcrumbs: breadcrumbs.slice(0, -1),
                 row: {
@@ -106,7 +105,7 @@ export const backspace = (zipper: Zipper): Zipper => {
                         {
                             id: focus.id,
                             type: "subsup",
-                            children: [focus.other, null],
+                            children: [focus.left[0], null],
                         },
                     ],
                     right: [...zipper.row.right, ...row.right],
@@ -114,6 +113,7 @@ export const backspace = (zipper: Zipper): Zipper => {
             };
         }
 
+        const children = focus.left[0] ? focus.left[0].children : [];
         return {
             breadcrumbs: breadcrumbs.slice(0, -1),
             row: {

--- a/packages/editor-core/src/reducer/backspace.ts
+++ b/packages/editor-core/src/reducer/backspace.ts
@@ -82,45 +82,39 @@ export const backspace = (zipper: Zipper): Zipper => {
     }
 
     const parent = breadcrumbs[breadcrumbs.length - 1];
-
     const {focus, row} = parent;
 
-    if (focus.left.length === 0) {
-        const children = focus.right[0] ? focus.right[0].children : [];
+    // Special deleting from the start of a superscript when there's both a
+    // superscript and subscript.
+    // - before: a_n^|2
+    // - after: a_n|2
+    if (focus.type === "zsubsup" && focus.left[0]) {
         return {
             breadcrumbs: breadcrumbs.slice(0, -1),
             row: {
                 ...row,
-                right: [...zipper.row.right, ...children, ...row.right],
-            },
-        };
-    } else {
-        if (focus.type === "zsubsup" && focus.left[0]) {
-            return {
-                breadcrumbs: breadcrumbs.slice(0, -1),
-                row: {
-                    ...row,
-                    left: [
-                        ...row.left,
-                        {
-                            id: focus.id,
-                            type: "subsup",
-                            children: [focus.left[0], null],
-                        },
-                    ],
-                    right: [...zipper.row.right, ...row.right],
-                },
-            };
-        }
-
-        const children = focus.left[0] ? focus.left[0].children : [];
-        return {
-            breadcrumbs: breadcrumbs.slice(0, -1),
-            row: {
-                ...row,
-                left: [...row.left, ...children],
+                left: [
+                    ...row.left,
+                    {
+                        id: focus.id,
+                        type: "subsup",
+                        children: [focus.left[0], null],
+                    },
+                ],
                 right: [...zipper.row.right, ...row.right],
             },
         };
     }
+
+    const leftChildren = focus.left[0] ? focus.left[0].children : [];
+    const rightChildren = focus.right[0] ? focus.right[0].children : [];
+
+    return {
+        breadcrumbs: breadcrumbs.slice(0, -1),
+        row: {
+            ...row,
+            left: [...row.left, ...leftChildren],
+            right: [...zipper.row.right, ...rightChildren, ...row.right],
+        },
+    };
 };

--- a/packages/editor-core/src/reducer/move-left.ts
+++ b/packages/editor-core/src/reducer/move-left.ts
@@ -119,8 +119,8 @@ const cursorLeft = (zipper: Zipper): Zipper => {
                     row: parentRow,
                     focus: {
                         ...focus,
-                        dir: 0,
-                        other: exitedRow,
+                        left: [],
+                        right: [exitedRow],
                     },
                 },
             ],
@@ -129,23 +129,23 @@ const cursorLeft = (zipper: Zipper): Zipper => {
 
         switch (focus.type) {
             case "zsubsup": {
-                return focus.dir === 1 && focus.other
-                    ? focusLeft(focus.other)
+                return focus.left[0]
+                    ? focusLeft(focus.left[0])
                     : exitNode(util.subsup(focus, exitedRow));
             }
             case "zfrac": {
-                return focus.dir === 1
-                    ? focusLeft(focus.other)
+                return focus.left[0]
+                    ? focusLeft(focus.left[0])
                     : exitNode(util.frac(focus, exitedRow));
             }
             case "zroot": {
-                return focus.dir === 1 && focus.other
-                    ? focusLeft(focus.other)
+                return focus.left[0]
+                    ? focusLeft(focus.left[0])
                     : exitNode(util.root(focus, exitedRow));
             }
             case "zlimits":
-                return focus.dir === 1 && focus.other
-                    ? focusLeft(focus.other)
+                return focus.left[0]
+                    ? focusLeft(focus.left[0])
                     : exitNode(util.limits(focus, exitedRow));
             default:
                 throw new UnreachableCaseError(focus);

--- a/packages/editor-core/src/reducer/move-left.ts
+++ b/packages/editor-core/src/reducer/move-left.ts
@@ -52,8 +52,8 @@ const cursorLeft = (zipper: Zipper): Zipper => {
                     break;
                 }
                 case "subsup": {
-                    const dir = prev.children[1] ? 1 : 0;
-                    focus = util.zsubsup(prev, dir);
+                    const index = prev.children[1] ? 1 : 0;
+                    focus = util.zsubsup(prev, index);
                     break;
                 }
                 case "root": {
@@ -61,8 +61,8 @@ const cursorLeft = (zipper: Zipper): Zipper => {
                     break;
                 }
                 case "limits": {
-                    const dir = prev.children[1] ? 1 : 0;
-                    focus = util.zlimits(prev, dir);
+                    const index = prev.children[1] ? 1 : 0;
+                    focus = util.zlimits(prev, index);
                     break;
                 }
                 case "delimited": {
@@ -127,29 +127,9 @@ const cursorLeft = (zipper: Zipper): Zipper => {
             row: util.zrow(row.id, row.children, []),
         });
 
-        switch (focus.type) {
-            case "zsubsup": {
-                return focus.left[0]
-                    ? focusLeft(focus.left[0])
-                    : exitNode(util.subsup(focus, exitedRow));
-            }
-            case "zfrac": {
-                return focus.left[0]
-                    ? focusLeft(focus.left[0])
-                    : exitNode(util.frac(focus, exitedRow));
-            }
-            case "zroot": {
-                return focus.left[0]
-                    ? focusLeft(focus.left[0])
-                    : exitNode(util.root(focus, exitedRow));
-            }
-            case "zlimits":
-                return focus.left[0]
-                    ? focusLeft(focus.left[0])
-                    : exitNode(util.limits(focus, exitedRow));
-            default:
-                throw new UnreachableCaseError(focus);
-        }
+        return focus.left[0]
+            ? focusLeft(focus.left[0])
+            : exitNode(util.focusToNode(focus, exitedRow));
     }
 
     return zipper;

--- a/packages/editor-core/src/reducer/move-right.ts
+++ b/packages/editor-core/src/reducer/move-right.ts
@@ -117,8 +117,8 @@ const cursorRight = (zipper: Zipper): Zipper => {
                     row: parentRow,
                     focus: {
                         ...focus,
-                        dir: 1,
-                        other: exitedRow,
+                        left: [exitedRow],
+                        right: [],
                     },
                 },
             ],
@@ -127,20 +127,20 @@ const cursorRight = (zipper: Zipper): Zipper => {
 
         switch (focus.type) {
             case "zsubsup":
-                return focus.dir === 0 && focus.other
-                    ? focusRight(focus.other)
+                return focus.right[0]
+                    ? focusRight(focus.right[0])
                     : exitNode(util.subsup(focus, exitedRow));
             case "zfrac":
-                return focus.dir === 0
-                    ? focusRight(focus.other)
+                return focus.right[0]
+                    ? focusRight(focus.right[0])
                     : exitNode(util.frac(focus, exitedRow));
             case "zroot":
-                return focus.dir === 0
-                    ? focusRight(focus.other)
+                return focus.right[0]
+                    ? focusRight(focus.right[0])
                     : exitNode(util.root(focus, exitedRow));
             case "zlimits":
-                return focus.dir === 0 && focus.other
-                    ? focusRight(focus.other)
+                return focus.right[0]
+                    ? focusRight(focus.right[0])
                     : exitNode(util.limits(focus, exitedRow));
             default:
                 throw new UnreachableCaseError(focus);

--- a/packages/editor-core/src/reducer/move-right.ts
+++ b/packages/editor-core/src/reducer/move-right.ts
@@ -52,13 +52,13 @@ const cursorRight = (zipper: Zipper): Zipper => {
                     break;
                 }
                 case "subsup": {
-                    const dir = next.children[0] ? 0 : 1;
-                    focus = util.zsubsup(next, dir);
+                    const index = next.children[0] ? 0 : 1;
+                    focus = util.zsubsup(next, index);
                     break;
                 }
                 case "root": {
-                    const dir = next.children[0] ? 0 : 1;
-                    focus = util.zroot(next, dir);
+                    const index = next.children[0] ? 0 : 1;
+                    focus = util.zroot(next, index);
                     break;
                 }
                 case "limits":
@@ -125,26 +125,9 @@ const cursorRight = (zipper: Zipper): Zipper => {
             row: util.zrow(row.id, [], row.children),
         });
 
-        switch (focus.type) {
-            case "zsubsup":
-                return focus.right[0]
-                    ? focusRight(focus.right[0])
-                    : exitNode(util.subsup(focus, exitedRow));
-            case "zfrac":
-                return focus.right[0]
-                    ? focusRight(focus.right[0])
-                    : exitNode(util.frac(focus, exitedRow));
-            case "zroot":
-                return focus.right[0]
-                    ? focusRight(focus.right[0])
-                    : exitNode(util.root(focus, exitedRow));
-            case "zlimits":
-                return focus.right[0]
-                    ? focusRight(focus.right[0])
-                    : exitNode(util.limits(focus, exitedRow));
-            default:
-                throw new UnreachableCaseError(focus);
-        }
+        return focus.right[0]
+            ? focusRight(focus.right[0])
+            : exitNode(util.focusToNode(focus, exitedRow));
     }
 
     return zipper;

--- a/packages/editor-core/src/reducer/root.ts
+++ b/packages/editor-core/src/reducer/root.ts
@@ -13,14 +13,14 @@ export const root = (zipper: Zipper, withIndex: boolean): Zipper => {
         ? {
               id: getId(),
               type: "zroot",
-              dir: 0,
-              other: builders.row([]),
+              left: [],
+              right: [builders.row([])],
           }
         : {
               id: getId(),
               type: "zroot",
-              dir: 1,
-              other: null,
+              left: [null],
+              right: [],
           };
 
     if (selection) {

--- a/packages/editor-core/src/reducer/slash.ts
+++ b/packages/editor-core/src/reducer/slash.ts
@@ -42,12 +42,14 @@ export const slash = (zipper: Zipper): Zipper => {
         const focus: Focus = {
             type: "zfrac",
             id: getId(),
-            dir: 1,
-            other: {
-                id: getId(),
-                type: "row",
-                children: selection.nodes,
-            },
+            left: [
+                {
+                    id: getId(),
+                    type: "row",
+                    children: selection.nodes,
+                },
+            ],
+            right: [],
         };
 
         return {
@@ -98,12 +100,14 @@ export const slash = (zipper: Zipper): Zipper => {
     const focus: Focus = {
         type: "zfrac",
         id: getId(),
-        dir: 1,
-        other: {
-            id: getId(),
-            type: "row",
-            children: left.slice(index + 1),
-        },
+        left: [
+            {
+                id: getId(),
+                type: "row",
+                children: left.slice(index + 1),
+            },
+        ],
+        right: [],
     };
 
     return {

--- a/packages/editor-core/src/reducer/subsup.ts
+++ b/packages/editor-core/src/reducer/subsup.ts
@@ -21,12 +21,7 @@ export const subsup = (zipper: Zipper, dir: 0 | 1): Zipper => {
                             ...row,
                             right: rest,
                         },
-                        focus: {
-                            id: next.id, // reuse the id of the subsup we're updating
-                            type: "zsubsup",
-                            dir: dir,
-                            other: dir === 0 ? sup : sub,
-                        },
+                        focus: util.zsubsup(next, dir),
                     },
                 ],
                 row:
@@ -47,12 +42,20 @@ export const subsup = (zipper: Zipper, dir: 0 | 1): Zipper => {
             ...zipper.breadcrumbs,
             {
                 row: zipper.row,
-                focus: {
-                    id: getId(),
-                    type: "zsubsup",
-                    dir: dir,
-                    other: null, // this is a new subsup so don't give it a sub
-                },
+                focus:
+                    dir === 0
+                        ? {
+                              id: getId(),
+                              type: "zsubsup",
+                              left: [],
+                              right: [null],
+                          }
+                        : {
+                              id: getId(),
+                              type: "zsubsup",
+                              left: [null],
+                              right: [],
+                          },
             },
         ],
         row: util.zrow(getId(), [], []),

--- a/packages/editor-core/src/reducer/types.ts
+++ b/packages/editor-core/src/reducer/types.ts
@@ -24,35 +24,49 @@ export type ZRowWithSelection = {
 
 export type ZRow = ZRowWithoutSelection | ZRowWithSelection;
 
-export type ZFrac = {
-    id: number;
-    type: "zfrac";
-    dir: 0 | 1; // index of focused child
-    other: types.Row; // what isn't being focused
-};
+export type ZFrac =
+    | {
+          id: number;
+          type: "zfrac";
+          left: [];
+          right: [types.Row];
+      }
+    | {
+          id: number;
+          type: "zfrac";
+          left: [types.Row];
+          right: [];
+      };
 
 // TODO: consider splitting up SubSup into three different types.
 // If both `sub` and `sup` are `null` then the node is invalid.
-export type ZSubSup = {
-    id: number;
-    type: "zsubsup";
-    dir: 0 | 1; // index of focused child
-    other: types.Row | null; // what isn't being focused
-};
+export type ZSubSup =
+    | {
+          id: number;
+          type: "zsubsup";
+          left: [];
+          right: [types.Row | null];
+      }
+    | {
+          id: number;
+          type: "zsubsup";
+          left: [types.Row | null];
+          right: [];
+      };
 
 export type ZLimits =
     | {
           id: number;
           type: "zlimits";
-          dir: 0; // index of focused child
-          other: types.Row | null;
+          left: [];
+          right: [types.Row | null];
           inner: types.Node;
       }
     | {
           id: number;
           type: "zlimits";
-          dir: 1; // index of focused child
-          other: types.Row;
+          left: [types.Row];
+          right: [];
           inner: types.Node;
       };
 
@@ -60,21 +74,21 @@ export type ZRoot =
     | {
           id: number;
           type: "zroot";
-          dir: 0; // index of focused child
-          other: types.Row;
+          left: [];
+          right: [types.Row];
       }
     | {
           id: number;
           type: "zroot";
-          dir: 1; // index of focused child
-          other: types.Row | null;
+          left: [types.Row | null];
+          right: [];
       };
 
 export type ZDelimited = {
     id: number;
     type: "zdelimited";
-    dir: 0; // index of focused child
-    other: null;
+    left: [];
+    right: [];
     leftDelim: types.Atom;
     rightDelim: types.Atom;
 };

--- a/packages/editor-core/src/reducer/util.ts
+++ b/packages/editor-core/src/reducer/util.ts
@@ -15,135 +15,120 @@ import type {
 } from "./types";
 
 export const frac = (focus: ZFrac, replacement: types.Row): types.Frac => {
-    if (focus.dir === 0) {
-        return {
-            id: focus.id,
-            type: "frac",
-            children: [replacement, focus.other],
-        };
-    } else {
-        return {
-            id: focus.id,
-            type: "frac",
-            children: [focus.other, replacement],
-        };
-    }
+    return {
+        id: focus.id,
+        type: "frac",
+        children: [...focus.left, replacement, ...focus.right] as [
+            types.Row,
+            types.Row,
+        ],
+    };
 };
 
-export const zfrac = (node: types.Frac, dir: 0 | 1): ZFrac => {
-    return {
-        id: node.id,
-        type: "zfrac",
-        dir,
-        other: node.children[1 - dir],
-    };
+export const zfrac = (node: types.Frac, index: 0 | 1): ZFrac => {
+    return index === 0
+        ? {
+              id: node.id,
+              type: "zfrac",
+              left: [],
+              right: [node.children[1]],
+          }
+        : {
+              id: node.id,
+              type: "zfrac",
+              left: [node.children[0]],
+              right: [],
+          };
 };
 
 export const subsup = (
     focus: ZSubSup,
     replacement: types.Row,
 ): types.SubSup => {
-    if (focus.dir === 0) {
-        return {
-            id: focus.id,
-            type: "subsup",
-            children: [replacement, focus.other],
-        };
-    } else {
-        return {
-            id: focus.id,
-            type: "subsup",
-            children: [focus.other, replacement],
-        };
-    }
-};
-
-export const zsubsup = (node: types.SubSup, dir: 0 | 1): ZSubSup => {
     return {
-        id: node.id,
-        type: "zsubsup",
-        dir,
-        other: node.children[1 - dir],
+        id: focus.id,
+        type: "subsup",
+        children: [...focus.left, replacement, ...focus.right] as [
+            types.Row | null,
+            types.Row | null,
+        ],
     };
 };
 
-export const root = (focus: ZRoot, replacement: types.Row): types.Root => {
-    if (focus.dir === 0) {
-        return {
-            id: focus.id,
-            type: "root",
-            children: [replacement, focus.other],
-        };
-    } else {
-        return {
-            id: focus.id,
-            type: "root",
-            children: [focus.other, replacement],
-        };
-    }
+export const zsubsup = (node: types.SubSup, index: 0 | 1): ZSubSup => {
+    return index === 0
+        ? {
+              id: node.id,
+              type: "zsubsup",
+              left: [],
+              right: [node.children[1]],
+          }
+        : {
+              id: node.id,
+              type: "zsubsup",
+              left: [node.children[0]],
+              right: [],
+          };
 };
 
-export const zroot = (node: types.Root, dir: 0 | 1): ZRoot => {
-    if (dir === 0) {
-        return {
-            id: node.id,
-            type: "zroot",
-            dir,
-            other: node.children[1],
-        };
-    } else if (dir === 1) {
-        return {
-            id: node.id,
-            type: "zroot",
-            dir,
-            other: node.children[0],
-        };
-    } else {
-        throw new Error("dir cannot be Dir.None for zlimits");
-    }
+export const root = (focus: ZRoot, replacement: types.Row): types.Root => {
+    return {
+        id: focus.id,
+        type: "root",
+        children: [...focus.left, replacement, ...focus.right] as [
+            types.Row | null,
+            types.Row,
+        ],
+    };
+};
+
+export const zroot = (node: types.Root, index: 0 | 1): ZRoot => {
+    return index === 0
+        ? {
+              id: node.id,
+              type: "zroot",
+              left: [],
+              right: [node.children[1]],
+          }
+        : {
+              id: node.id,
+              type: "zroot",
+              left: [node.children[0]],
+              right: [],
+          };
 };
 
 export const limits = (
     focus: ZLimits,
     replacement: types.Row,
 ): types.Limits => {
-    if (focus.dir === 0) {
-        return {
-            id: focus.id,
-            type: "limits",
-            children: [replacement, focus.other],
-            inner: focus.inner,
-        };
-    } else {
-        return {
-            id: focus.id,
-            type: "limits",
-            children: [focus.other, replacement],
-            inner: focus.inner,
-        };
-    }
+    return {
+        id: focus.id,
+        type: "limits",
+        inner: focus.inner,
+        children: [...focus.left, replacement, ...focus.right] as [
+            types.Row,
+            types.Row | null,
+        ],
+    };
 };
 
-export const zlimits = (node: types.Limits, dir: 0 | 1): ZLimits => {
-    if (dir === 0) {
-        return {
-            id: node.id,
-            type: "zlimits",
-            dir,
-            other: node.children[1],
-            inner: node.inner,
-        };
-    } else if (dir === 1) {
-        return {
-            id: node.id,
-            type: "zlimits",
-            dir,
-            other: node.children[0],
-            inner: node.inner,
-        };
-    } else {
-        throw new Error("dir cannot be Dir.None for zlimits");
-    }
+export const zlimits = (node: types.Limits, index: 0 | 1): ZLimits => {
+    return index === 0
+        ? {
+              id: node.id,
+              type: "zlimits",
+              left: [],
+              right: [node.children[1]],
+              inner: node.inner,
+          }
+        : {
+              id: node.id,
+              type: "zlimits",
+              left: [node.children[0]],
+              right: [],
+              inner: node.inner,
+          };
 };
 
 export const delimited = (
@@ -153,7 +138,7 @@ export const delimited = (
     return {
         id: focus.id,
         type: "delimited",
-        children: [replacement],
+        children: [replacement], // focus.left and focus.right are always empty arrays
         leftDelim: focus.leftDelim,
         rightDelim: focus.rightDelim,
     };
@@ -163,8 +148,8 @@ export const zdelimited = (node: types.Delimited): ZDelimited => {
     return {
         id: node.id,
         type: "zdelimited",
-        dir: 0,
-        other: null,
+        left: [],
+        right: [],
         leftDelim: node.leftDelim,
         rightDelim: node.rightDelim,
     };

--- a/packages/react/src/__tests__/mouse-cursor.test.tsx
+++ b/packages/react/src/__tests__/mouse-cursor.test.tsx
@@ -168,7 +168,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([
                 glyph("1"),
@@ -190,7 +190,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([glyph("1")]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("2")]);
         });
@@ -209,7 +209,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("1"),
                 glyph("2"),
@@ -231,7 +231,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(zipper.breadcrumbs[0].focus.right).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("x"),
                 glyph("+"),
@@ -278,7 +278,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(zipper.breadcrumbs[0].focus.right).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("2")]);
         });
@@ -297,7 +297,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(zipper.breadcrumbs[0].focus.right).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([glyph("2")]);
             expect(zipper.row.right).toEqualEditorNodes([]);
         });
@@ -316,7 +316,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("n")]);
         });
@@ -335,7 +335,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([glyph("n")]);
             expect(zipper.row.right).toEqualEditorNodes([]);
         });
@@ -376,7 +376,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([]);
             expect(zipper.row.right).toEqualEditorNodes([glyph("3")]);
         });
@@ -395,7 +395,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(zipper.breadcrumbs[0].focus.right).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("x"),
                 glyph("+"),
@@ -443,7 +443,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("x"),
                 glyph("+"),
@@ -492,7 +492,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(1);
+            expect(zipper.breadcrumbs[0].focus.right).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([glyph("\u221e")]);
             expect(zipper.row.right).toEqualEditorNodes([]);
         });
@@ -511,7 +511,7 @@ describe("moving cursor with mouse", () => {
             }
 
             expect(zipper.breadcrumbs).toHaveLength(1);
-            expect(zipper.breadcrumbs[0].focus.dir).toEqual(0);
+            expect(zipper.breadcrumbs[0].focus.left).toEqual([]);
             expect(zipper.row.left).toEqualEditorNodes([
                 glyph("i"),
                 glyph("="),

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -325,15 +325,13 @@ const typesetFocus = (
         case "zfrac": {
             const childContext = childContextForFrac(context);
 
-            const numerator =
-                focus.dir === 0
-                    ? _typesetZipper(zipper, childContext)
-                    : typesetRow(focus.other, childContext);
+            const numerator = focus.left[0]
+                ? typesetRow(focus.left[0], childContext)
+                : _typesetZipper(zipper, childContext);
 
-            const denominator =
-                focus.dir === 0
-                    ? typesetRow(focus.other, childContext)
-                    : _typesetZipper(zipper, childContext);
+            const denominator = focus.right[0]
+                ? typesetRow(focus.right[0], childContext)
+                : _typesetZipper(zipper, childContext);
 
             const frac = typesetFrac(numerator, denominator, context);
 
@@ -346,23 +344,23 @@ const typesetFocus = (
             const childContext = childContextForSubsup(context);
 
             const [sub, sup] =
-                focus.dir === 0
-                    ? [zipper.row, focus.other]
-                    : [focus.other, zipper.row];
+                focus.left.length === 0 && focus.right.length === 1
+                    ? [zipper.row, focus.right[0]]
+                    : [focus.left[0], zipper.row];
 
             // TODO: document this better so I know what's going on here.
-            const subBox =
-                sub &&
-                (sub.type === "row"
+            const subBox = sub
+                ? sub.type === "row"
                     ? typesetRow(sub, childContext)
-                    : _typesetZipper(zipper, childContext));
+                    : _typesetZipper(zipper, childContext)
+                : null;
 
             // TODO: document this better so I know what's going on here.
-            const supBox =
-                sup &&
-                (sup.type === "row"
+            const supBox = sup
+                ? sup.type === "row"
                     ? typesetRow(sup, childContext)
-                    : _typesetZipper(zipper, childContext));
+                    : _typesetZipper(zipper, childContext)
+                : null;
 
             const parentBox = typesetSubsup(
                 subBox,
@@ -376,10 +374,9 @@ const typesetFocus = (
             return parentBox;
         }
         case "zroot": {
-            const [ind, rad] =
-                focus.dir === 0
-                    ? [zipper.row, focus.other]
-                    : [focus.other, zipper.row];
+            const [ind, rad] = focus.right[0]
+                ? [zipper.row, focus.right[0]]
+                : [focus.left[0], zipper.row];
 
             const radicand =
                 rad.type === "row"
@@ -409,21 +406,20 @@ const typesetFocus = (
         case "zlimits": {
             const childContext = childContextForLimits(context);
 
-            const [lower, upper] =
-                focus.dir === 0
-                    ? [zipper.row, focus.other]
-                    : [focus.other, zipper.row];
+            const [lower, upper] = focus.left[0]
+                ? [focus.left[0], zipper.row]
+                : [zipper.row, focus.right[0]];
 
             const lowerBox =
                 lower.type === "row"
                     ? typesetRow(lower, childContext)
                     : _typesetZipper(zipper, childContext);
 
-            const upperBox =
-                upper &&
-                (upper.type === "row"
+            const upperBox = upper
+                ? upper.type === "row"
                     ? typesetRow(upper, childContext)
-                    : _typesetZipper(zipper, childContext));
+                    : _typesetZipper(zipper, childContext)
+                : null;
 
             const inner = _typeset(focus.inner, {...context, operator: true});
             inner.id = focus.inner.id;


### PR DESCRIPTION
This change will allow us to handle navigating within structural nodes with more than two children.  In particular we'll be using this to support matrices as well as showing working vertical (we want to align different parts of each line with each other making it very similar to laying out and navigating cells in a matrix).