### PR TITLE
Move formatting logic from math-editor into editor-core reducers

### DIFF
--- a/packages/editor-core/src/reducer/__tests__/cancel.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/cancel.test.ts
@@ -1,0 +1,151 @@
+import {cancel} from "../cancel";
+import {moveRight} from "../move-right";
+
+import {row, frac, stateFromZipper} from "../test-util";
+
+import type {Zipper} from "../types";
+import {getId} from "@math-blocks/core";
+
+describe("cancel", () => {
+    test("single cancel region", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: row("2").children,
+                selection: row("x+5").children,
+                right: row("=10").children,
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        const state = stateFromZipper(zipper);
+        const cancelId = -1;
+
+        const newState = cancel(state, cancelId);
+
+        expect(newState.zipper.row.selection).toHaveLength(3);
+        expect(
+            newState.zipper.row.selection.every(
+                (node) => node.style.cancel === cancelId,
+            ),
+        ).toBeTruthy();
+        expect(
+            newState.startZipper.row.right
+                .slice(0, 3)
+                .every((node) => node.style.cancel === cancelId),
+        ).toBeTruthy();
+        expect(
+            newState.endZipper.row.left
+                .slice(1)
+                .every((node) => node.style.cancel === cancelId),
+        ).toBeTruthy();
+    });
+
+    test("two side-by-side cancel regions", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: [],
+                selection: [],
+                right: row("2x+5=10").children,
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        let state = stateFromZipper(zipper);
+        state = {...state, selecting: true};
+        state = moveRight(state);
+        state = cancel(state, -1);
+        state = {
+            ...state,
+            startZipper: state.endZipper,
+            zipper: state.endZipper,
+        };
+        state = moveRight(state);
+        state = cancel(state, -2);
+
+        expect(state.endZipper.row.left).toHaveLength(2);
+        expect(state.endZipper.row.left[0].style.cancel).toEqual(-1);
+        expect(state.endZipper.row.left[1].style.cancel).toEqual(-2);
+
+        expect(state.zipper.row.left[0].style.cancel).toEqual(-1);
+        expect(state.zipper.row.selection).toHaveLength(1);
+        expect(state.zipper.row.selection[0].style.cancel).toEqual(-2);
+
+        expect(state.startZipper.row.left[0].style.cancel).toEqual(-1);
+        expect(state.startZipper.row.right[0].style.cancel).toEqual(-2);
+    });
+
+    test("clearing a cancel region", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: row("2").children,
+                selection: row("x+5").children,
+                right: row("=10").children,
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        zipper.row.selection.forEach((node) => (node.style.cancel = -1));
+        const state = stateFromZipper(zipper);
+
+        const newState = cancel(state);
+
+        expect(newState.zipper.row.selection).toHaveLength(3);
+        expect(
+            newState.zipper.row.selection.every(
+                (node) => node.style.cancel === undefined,
+            ),
+        ).toBeTruthy();
+        expect(
+            newState.startZipper.row.right
+                .slice(0, 3)
+                .every((node) => node.style.cancel === undefined),
+        ).toBeTruthy();
+        expect(
+            newState.endZipper.row.left
+                .slice(1)
+                .every((node) => node.style.cancel === undefined),
+        ).toBeTruthy();
+    });
+
+    test("nested cancel regions are not allowed", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: [],
+                selection: [frac("1", "2")],
+                right: [],
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        // @ts-expect-error: we know this is a fraction
+        zipper.row.selection[0].children[0].children[0].style.cancel = -1;
+        // @ts-expect-error: we know this is a fraction
+        zipper.row.selection[0].children[1].children[0].style.cancel = -1;
+
+        const state = stateFromZipper(zipper);
+
+        const newState = cancel(state, -2);
+
+        expect(newState.zipper.row.selection[0].style.cancel).toEqual(-2);
+
+        // Nested nodes have their cancel id cleared
+        expect(
+            // @ts-expect-error: we know this is a fraction
+            newState.zipper.row.selection[0].children[0].children[0].style
+                .cancel,
+        ).toBeUndefined();
+        expect(
+            // @ts-expect-error: we know this is a fraction
+            newState.zipper.row.selection[0].children[1].children[0].style
+                .cancel,
+        ).toBeUndefined();
+    });
+});

--- a/packages/editor-core/src/reducer/__tests__/color.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/color.test.ts
@@ -1,0 +1,155 @@
+import {color} from "../color";
+import {moveRight} from "../move-right";
+
+import {row, frac, stateFromZipper} from "../test-util";
+
+import type {Zipper} from "../types";
+import {getId} from "@math-blocks/core";
+
+describe("color", () => {
+    test("single color region", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: row("2").children,
+                selection: row("x+5").children,
+                right: row("=10").children,
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        const state = stateFromZipper(zipper);
+
+        const newState = color(state, "blue");
+
+        expect(newState.zipper.row.selection).toHaveLength(3);
+        expect(
+            newState.zipper.row.selection.every(
+                (node) => node.style.color === "blue",
+            ),
+        ).toBeTruthy();
+        expect(
+            newState.startZipper.row.right
+                .slice(0, 3)
+                .every((node) => node.style.color === "blue"),
+        ).toBeTruthy();
+        expect(
+            newState.endZipper.row.left
+                .slice(1)
+                .every((node) => node.style.color === "blue"),
+        ).toBeTruthy();
+    });
+
+    test("override existing color", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: row("2").children,
+                selection: row("x+5").children,
+                right: row("=10").children,
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        zipper.row.left.forEach((node) => (node.style.color = "orange"));
+        zipper.row.selection.forEach((node) => (node.style.color = "orange"));
+        zipper.row.right.forEach((node) => (node.style.color = "orange"));
+
+        const state = stateFromZipper(zipper);
+
+        const newState = color(state, "blue");
+
+        expect(newState.zipper.row.selection).toHaveLength(3);
+        expect(
+            newState.zipper.row.selection.every(
+                (node) => node.style.color === "blue",
+            ),
+        ).toBeTruthy();
+
+        // Colors on non-selected nodes are left alone
+        expect(
+            newState.zipper.row.right.every(
+                (node) => node.style.color === "orange",
+            ),
+        ).toBeTruthy();
+        expect(
+            newState.zipper.row.left.every(
+                (node) => node.style.color === "orange",
+            ),
+        ).toBeTruthy();
+    });
+
+    test("two side-by-side color regions", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: [],
+                selection: [],
+                right: row("2x+5=10").children,
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        let state = stateFromZipper(zipper);
+        state = {...state, selecting: true};
+        state = moveRight(state);
+        state = color(state, "blue");
+        state = {
+            ...state,
+            startZipper: state.endZipper,
+            zipper: state.endZipper,
+        };
+        state = moveRight(state);
+        state = color(state, "orange");
+
+        expect(state.endZipper.row.left).toHaveLength(2);
+        expect(state.endZipper.row.left[0].style.color).toEqual("blue");
+        expect(state.endZipper.row.left[1].style.color).toEqual("orange");
+
+        expect(state.zipper.row.left[0].style.color).toEqual("blue");
+        expect(state.zipper.row.selection).toHaveLength(1);
+        expect(state.zipper.row.selection[0].style.color).toEqual("orange");
+
+        expect(state.startZipper.row.left[0].style.color).toEqual("blue");
+        expect(state.startZipper.row.right[0].style.color).toEqual("orange");
+    });
+
+    test("all ancestor nodes within the selection get the same color", () => {
+        const zipper: Zipper = {
+            row: {
+                id: getId(),
+                type: "zrow",
+                left: [],
+                selection: [frac("1", "2")],
+                right: [],
+                style: {},
+            },
+            breadcrumbs: [],
+        };
+        // @ts-expect-error: we know this is a fraction
+        zipper.row.selection[0].children[0].children[0].style.cancel = -1;
+        // @ts-expect-error: we know this is a fraction
+        zipper.row.selection[0].children[1].children[0].style.cancel = -1;
+
+        const state = stateFromZipper(zipper);
+
+        const newState = color(state, "blue");
+
+        expect(newState.zipper.row.selection[0].style.color).toEqual("blue");
+
+        // All ancestor nodes get the same color
+        expect(
+            // @ts-expect-error: we know this is a fraction
+            newState.zipper.row.selection[0].children[0].children[0].style
+                .color,
+        ).toEqual("blue");
+        expect(
+            // @ts-expect-error: we know this is a fraction
+            newState.zipper.row.selection[0].children[1].children[0].style
+                .color,
+        ).toEqual("blue");
+    });
+});

--- a/packages/editor-core/src/reducer/cancel.ts
+++ b/packages/editor-core/src/reducer/cancel.ts
@@ -1,0 +1,66 @@
+import * as transforms from "../ast/transforms";
+import {selectionZipperFromZippers} from "./convert";
+
+import type {State} from "./types";
+
+export const cancel = (state: State, cancelId?: number): State => {
+    const {zipper, startZipper, endZipper} = state;
+    const {selection} = zipper.row;
+
+    let inSelection = false;
+
+    if (selection.length > 0) {
+        const selectedNodeIds = selection.map((node) => node.id);
+        const callback: transforms.ZipperCallback = {
+            enter: (node) => {
+                if (node.type !== "atom" && selectedNodeIds.includes(node.id)) {
+                    inSelection = true;
+                }
+            },
+            exit: (node) => {
+                if (node.type !== "atom" && selectedNodeIds.includes(node.id)) {
+                    inSelection = false;
+                }
+                // Clear cancel ids on ancestor nodes so that we don't end up
+                // with cancel operations appearing within other cancel operations.
+                if (inSelection) {
+                    return {
+                        ...node,
+                        style: {
+                            ...node.style,
+                            cancel: undefined,
+                        },
+                    };
+                }
+                if (selectedNodeIds.includes(node.id)) {
+                    return {
+                        ...node,
+                        style: {
+                            ...node.style,
+                            cancel: cancelId,
+                        },
+                    };
+                }
+            },
+        };
+        // We transform both the start and end zipper in order for
+        // things to work with Case 3 in selectionZipperFromZippers.
+        const newStartZipper = transforms.traverseZipper(startZipper, callback);
+        const newEndZipper = transforms.traverseZipper(endZipper, callback);
+        const newSelectionZippper = selectionZipperFromZippers(
+            newStartZipper,
+            newEndZipper,
+        );
+
+        if (newSelectionZippper) {
+            return {
+                startZipper: newStartZipper,
+                endZipper: newEndZipper,
+                zipper: newSelectionZippper,
+                selecting: true,
+            };
+        }
+    }
+
+    return state;
+};

--- a/packages/editor-core/src/reducer/color.ts
+++ b/packages/editor-core/src/reducer/color.ts
@@ -1,0 +1,56 @@
+import * as transforms from "../ast/transforms";
+import {selectionZipperFromZippers} from "./convert";
+
+import type {State} from "./types";
+
+export const color = (state: State, color: string): State => {
+    const {zipper, startZipper, endZipper} = state;
+    const {selection} = zipper.row;
+
+    let inSelection = false;
+
+    if (selection.length > 0) {
+        const selectedNodeIds = selection.map((node) => node.id);
+        const callback: transforms.ZipperCallback = {
+            enter: (node) => {
+                if (node.type !== "atom" && selectedNodeIds.includes(node.id)) {
+                    inSelection = true;
+                }
+            },
+            exit: (node) => {
+                if (node.type !== "atom" && selectedNodeIds.includes(node.id)) {
+                    inSelection = false;
+                }
+                if (inSelection || selectedNodeIds.includes(node.id)) {
+                    return {
+                        ...node,
+                        style: {
+                            ...node.style,
+                            color: color,
+                        },
+                    };
+                }
+            },
+        };
+
+        // We transform both the start and end zipper in order for
+        // things to work with Case 3 in selectionZipperFromZippers.
+        const newStartZipper = transforms.traverseZipper(startZipper, callback);
+        const newEndZipper = transforms.traverseZipper(endZipper, callback);
+        const newSelectionZippper = selectionZipperFromZippers(
+            newStartZipper,
+            newEndZipper,
+        );
+
+        if (newSelectionZippper) {
+            return {
+                startZipper: newStartZipper,
+                endZipper: newEndZipper,
+                zipper: newSelectionZippper,
+                selecting: true,
+            };
+        }
+    }
+
+    return state;
+};

--- a/packages/editor-core/src/reducer/reducer.ts
+++ b/packages/editor-core/src/reducer/reducer.ts
@@ -8,6 +8,9 @@ import {parens} from "./parens";
 import {root} from "./root";
 import {slash} from "./slash";
 import {subsup} from "./subsup";
+import {color} from "./color";
+import {cancel} from "./cancel";
+
 import {zrow} from "./util";
 import type {Zipper, State} from "./types";
 
@@ -23,7 +26,8 @@ const initialState: State = {
     selecting: false,
 };
 
-type Action = {type: string};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Action = {type: string; detail?: any};
 
 export const zipperReducer = (
     state: State = initialState,
@@ -59,6 +63,12 @@ export const zipperReducer = (
         // TODO: use "Sqrt" and "NthRoot" to differentiate the two possibilities
         case "\u221A": {
             return root(state, false);
+        }
+        case "Color": {
+            return color(state, action.detail);
+        }
+        case "Cancel": {
+            return cancel(state, action.detail);
         }
         // We don't handle any other actions yet so ignore them and return the
         // current startZipper.

--- a/packages/editor-core/src/reducer/test-util.ts
+++ b/packages/editor-core/src/reducer/test-util.ts
@@ -3,7 +3,7 @@ import * as Semantic from "@math-blocks/semantic";
 import * as types from "../ast/types";
 import * as builders from "../ast/builders";
 
-import type {ZRow} from "./types";
+import type {ZRow, Zipper, State} from "./types";
 
 export const row = (str: string): types.Row =>
     builders.row(
@@ -87,4 +87,38 @@ export const zrow = (
         right: right,
         style: {},
     };
+};
+
+export const stateFromZipper = (zipper: Zipper): State => {
+    if (zipper.row.selection.length > 0) {
+        const startZipper = {
+            ...zipper,
+            row: {
+                ...zipper.row,
+                selection: [],
+                right: [...zipper.row.selection, ...zipper.row.right],
+            },
+        };
+        const endZipper = {
+            ...zipper,
+            row: {
+                ...zipper.row,
+                left: [...zipper.row.left, ...zipper.row.selection],
+                selection: [],
+            },
+        };
+        return {
+            startZipper,
+            endZipper,
+            zipper,
+            selecting: true,
+        };
+    } else {
+        return {
+            startZipper: zipper,
+            endZipper: zipper,
+            zipper,
+            selecting: false,
+        };
+    }
 };

--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -150,132 +150,40 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
         (e: CustomEvent<FormattingEvent>): void => {
             const {detail} = e;
             if (detail.type === "color") {
-                const color = detail.value;
-                const {selection} = zipper.row;
-
-                let inSelection = false;
-
-                if (selection.length > 0) {
-                    const selectedNodeIds = selection.map((node) => node.id);
-                    const callback: Editor.transforms.ZipperCallback = {
-                        enter: (node) => {
-                            if (
-                                node.type !== "atom" &&
-                                selectedNodeIds.includes(node.id)
-                            ) {
-                                inSelection = true;
-                            }
-                        },
-                        exit: (node) => {
-                            if (
-                                node.type !== "atom" &&
-                                selectedNodeIds.includes(node.id)
-                            ) {
-                                inSelection = false;
-                            }
-                            if (
-                                inSelection ||
-                                selectedNodeIds.includes(node.id)
-                            ) {
-                                return {
-                                    ...node,
-                                    style: {
-                                        ...node.style,
-                                        color: color,
-                                    },
-                                };
-                            }
-                        },
-                    };
-                    // We transform both the start and end zipper in order for
-                    // things to work with Case 3 in selectionZipperFromZippers.
-                    const newStartZipper = Editor.transforms.traverseZipper(
-                        startZipper,
-                        callback,
-                    );
-                    const newEndZipper = Editor.transforms.traverseZipper(
-                        endZipper,
-                        callback,
-                    );
-                    const newSelectionZippper = Editor.selectionZipperFromZippers(
-                        newStartZipper,
-                        newEndZipper,
-                    );
-
-                    if (newSelectionZippper) {
-                        setStartZipper(newStartZipper);
-                        setEndZipper(newEndZipper);
-                        setZipper(newSelectionZippper);
-                    }
+                const state = {
+                    startZipper: startZipper,
+                    endZipper: endZipper,
+                    zipper: zipper,
+                    selecting: selecting,
+                };
+                const newState = Editor.zipperReducer(state, {
+                    type: "Color",
+                    detail: detail.value,
+                });
+                if (newState !== state) {
+                    setStartZipper(newState.startZipper);
+                    setEndZipper(newState.endZipper);
+                    setZipper(newState.zipper);
                 }
             } else if (detail.type === "cancel") {
-                const {selection} = zipper.row;
-
-                let inSelection = false;
-
-                if (selection.length > 0) {
-                    const selectedNodeIds = selection.map((node) => node.id);
-                    console.log(selectedNodeIds);
-                    const callback: Editor.transforms.ZipperCallback = {
-                        enter: (node) => {
-                            if (
-                                node.type !== "atom" &&
-                                selectedNodeIds.includes(node.id)
-                            ) {
-                                inSelection = true;
-                            }
-                        },
-                        exit: (node) => {
-                            if (
-                                node.type !== "atom" &&
-                                selectedNodeIds.includes(node.id)
-                            ) {
-                                inSelection = false;
-                            }
-                            if (inSelection) {
-                                return {
-                                    ...node,
-                                    style: {
-                                        ...node.style,
-                                        cancel: undefined,
-                                    },
-                                };
-                            }
-                            if (selectedNodeIds.includes(node.id)) {
-                                return {
-                                    ...node,
-                                    style: {
-                                        ...node.style,
-                                        cancel: detail.value,
-                                    },
-                                };
-                            }
-                        },
-                    };
-                    // We transform both the start and end zipper in order for
-                    // things to work with Case 3 in selectionZipperFromZippers.
-                    const newStartZipper = Editor.transforms.traverseZipper(
-                        startZipper,
-                        callback,
-                    );
-                    const newEndZipper = Editor.transforms.traverseZipper(
-                        endZipper,
-                        callback,
-                    );
-                    const newSelectionZippper = Editor.selectionZipperFromZippers(
-                        newStartZipper,
-                        newEndZipper,
-                    );
-
-                    if (newSelectionZippper) {
-                        setStartZipper(newStartZipper);
-                        setEndZipper(newEndZipper);
-                        setZipper(newSelectionZippper);
-                    }
+                const state = {
+                    startZipper: startZipper,
+                    endZipper: endZipper,
+                    zipper: zipper,
+                    selecting: selecting,
+                };
+                const newState = Editor.zipperReducer(state, {
+                    type: "Cancel",
+                    detail: detail.value,
+                });
+                if (newState !== state) {
+                    setStartZipper(newState.startZipper);
+                    setEndZipper(newState.endZipper);
+                    setZipper(newState.zipper);
                 }
             }
         },
-        [zipper, startZipper, endZipper],
+        [zipper, startZipper, endZipper, selecting],
     ) as EventListener;
 
     useEffect(


### PR DESCRIPTION
We'd like to be able to reuse more of the logic from the MathEditor react component in other editor implementations in the future.  Having the logic in reducers also makes it easier to test.