### PR TITLE
Differentiate HBox from VBox in typesetter

### DIFF
--- a/packages/typesetter/src/layout.ts
+++ b/packages/typesetter/src/layout.ts
@@ -42,10 +42,6 @@ type Content =
 export type HBox = {
     type: "HBox";
     shift: Dist;
-    // TODO: tighten this up by modeling the possible types of content
-    // - no cursor, no selection
-    // - cursor
-    // - selection
     content: Content;
     fontSize: number;
 } & Common &

--- a/packages/typesetter/src/scene-graph.ts
+++ b/packages/typesetter/src/scene-graph.ts
@@ -99,7 +99,7 @@ export type LayoutCursor = {
 
 const CURSOR_WIDTH = 2;
 
-const processHBox = (box: Layout.Box, loc: Point, context: Context): Group => {
+const processHBox = (box: Layout.HBox, loc: Point, context: Context): Group => {
     const pen = {x: 0, y: 0};
 
     const selectionBoxes: Rect[] = [];
@@ -380,7 +380,7 @@ const processHBox = (box: Layout.Box, loc: Point, context: Context): Group => {
     };
 };
 
-const processVBox = (box: Layout.Box, loc: Point, context: Context): Group => {
+const processVBox = (box: Layout.VBox, loc: Point, context: Context): Group => {
     const pen = {x: 0, y: 0};
 
     pen.y -= box.height;
@@ -393,113 +393,111 @@ const processVBox = (box: Layout.Box, loc: Point, context: Context): Group => {
         stroke: "red",
     };
 
-    box.content.forEach((section) => {
-        section.forEach((node) => {
-            const width = Layout.getWidth(node);
-            const height = Layout.getHeight(node);
-            const depth = Layout.getDepth(node);
+    box.content.forEach((node) => {
+        const width = Layout.getWidth(node);
+        const height = Layout.getHeight(node);
+        const depth = Layout.getDepth(node);
 
-            switch (node.type) {
-                case "Box": {
-                    // TODO: reconsider whether we should be taking the shift into
-                    // account when computing the height, maybe we can drop this
-                    // and simplify things.  The reason why we zero out the shift
-                    // here is that when we render a box inside of a vbox, the shift
-                    // is a horizontal shift as opposed to a vertical one.
-                    // I'm not sure we can do this properly since how the shift is
-                    // used depends on the parent box type.  We could pass that info
-                    // to the getHeight() function... we should probably do an audit
-                    // of all the callsites for getHeight()
-                    const height = Layout.getHeight({...node, shift: 0});
-                    const depth = Layout.getDepth({...node, shift: 0});
+        switch (node.type) {
+            case "Box": {
+                // TODO: reconsider whether we should be taking the shift into
+                // account when computing the height, maybe we can drop this
+                // and simplify things.  The reason why we zero out the shift
+                // here is that when we render a box inside of a vbox, the shift
+                // is a horizontal shift as opposed to a vertical one.
+                // I'm not sure we can do this properly since how the shift is
+                // used depends on the parent box type.  We could pass that info
+                // to the getHeight() function... we should probably do an audit
+                // of all the callsites for getHeight()
+                const height = Layout.getHeight({...node, shift: 0});
+                const depth = Layout.getDepth({...node, shift: 0});
 
-                    pen.y += height;
-                    // TODO: see if we can get rid of this check in the future
-                    if (Number.isNaN(pen.y)) {
-                        // eslint-disable-next-line no-debugger
-                        debugger;
-                    }
-
-                    const child = _processBox(
-                        node,
-                        {x: pen.x + node.shift, y: pen.y},
-                        context,
-                    );
-
-                    // We always have to include child groups regardless of the
-                    // layer.  TODO: drop this once we flatten the scene graph.
-                    children.push(child);
-
-                    if (layer === "debug") {
-                        children.push({
-                            type: "rect",
-                            id: node.id,
-                            x: pen.x + node.shift,
-                            y: pen.y - height,
-                            width: width,
-                            height: depth + height,
-                            style: debugStyle,
-                        });
-                    }
-
-                    pen.y += depth;
-                    break;
+                pen.y += height;
+                // TODO: see if we can get rid of this check in the future
+                if (Number.isNaN(pen.y)) {
+                    // eslint-disable-next-line no-debugger
+                    debugger;
                 }
-                case "HRule": {
-                    pen.y += height;
-                    const child = processHRule(node, pen);
-                    if (layer === "content") {
-                        children.push(child);
-                    }
-                    pen.y += depth;
-                    break;
+
+                const child = _processBox(
+                    node,
+                    {x: pen.x + node.shift, y: pen.y},
+                    context,
+                );
+
+                // We always have to include child groups regardless of the
+                // layer.  TODO: drop this once we flatten the scene graph.
+                children.push(child);
+
+                if (layer === "debug") {
+                    children.push({
+                        type: "rect",
+                        id: node.id,
+                        x: pen.x + node.shift,
+                        y: pen.y - height,
+                        width: width,
+                        height: depth + height,
+                        style: debugStyle,
+                    });
                 }
-                case "Glyph": {
-                    // Although there currently isn't anything that uses a glyph
-                    // in a vbox, we'll likely need it for accents.
-                    pen.y += height;
-                    const child = processGlyph(node, pen);
 
-                    if (layer === "content") {
-                        children.push(child);
-                    }
-
-                    if (layer === "debug") {
-                        children.push({
-                            type: "rect",
-                            id: node.id,
-                            x: pen.x,
-                            y: pen.y,
-                            width: width,
-                            height: depth + height,
-                            style: debugStyle,
-                        });
-                    }
-
-                    if (layer === "hitboxes") {
-                        // TODO: do a second pass on the hitboxes to expand them
-                        // to their full height
-                        children.push({
-                            type: "rect",
-                            id: node.id,
-                            x: pen.x,
-                            y: pen.y,
-                            width: width,
-                            height: depth + height,
-                            style: debugStyle,
-                        });
-                    }
-
-                    pen.y += depth;
-                    break;
-                }
-                case "Kern":
-                    pen.y += node.size;
-                    break;
-                default:
-                    throw new UnreachableCaseError(node);
+                pen.y += depth;
+                break;
             }
-        });
+            case "HRule": {
+                pen.y += height;
+                const child = processHRule(node, pen);
+                if (layer === "content") {
+                    children.push(child);
+                }
+                pen.y += depth;
+                break;
+            }
+            case "Glyph": {
+                // Although there currently isn't anything that uses a glyph
+                // in a vbox, we'll likely need it for accents.
+                pen.y += height;
+                const child = processGlyph(node, pen);
+
+                if (layer === "content") {
+                    children.push(child);
+                }
+
+                if (layer === "debug") {
+                    children.push({
+                        type: "rect",
+                        id: node.id,
+                        x: pen.x,
+                        y: pen.y,
+                        width: width,
+                        height: depth + height,
+                        style: debugStyle,
+                    });
+                }
+
+                if (layer === "hitboxes") {
+                    // TODO: do a second pass on the hitboxes to expand them
+                    // to their full height
+                    children.push({
+                        type: "rect",
+                        id: node.id,
+                        x: pen.x,
+                        y: pen.y,
+                        width: width,
+                        height: depth + height,
+                        style: debugStyle,
+                    });
+                }
+
+                pen.y += depth;
+                break;
+            }
+            case "Kern":
+                pen.y += node.size;
+                break;
+            default:
+                throw new UnreachableCaseError(node);
+        }
     });
 
     return {
@@ -534,7 +532,11 @@ type Context = {
     layer: "content" | "selection" | "debug" | "hitboxes";
 };
 
-const _processBox = (box: Layout.Box, loc: Point, context: Context): Group => {
+const _processBox = (
+    box: Layout.HBox | Layout.VBox,
+    loc: Point,
+    context: Context,
+): Group => {
     switch (box.kind) {
         case "hbox":
             return processHBox(box, loc, context);
@@ -554,7 +556,7 @@ export type Scene = {
 };
 
 export const processBox = (
-    box: Layout.Box,
+    box: Layout.HBox,
     fontData: FontData,
     options: Options = {},
 ): Scene => {

--- a/packages/typesetter/src/scene-graph.ts
+++ b/packages/typesetter/src/scene-graph.ts
@@ -107,9 +107,7 @@ const processHBox = (box: Layout.HBox, loc: Point, context: Context): Group => {
     const children: Node[] = [];
 
     const hasSelection =
-        !context.inSelection &&
-        box.content.length === 3 &&
-        box.content[1].length > 0;
+        !context.inSelection && box.content.type === "selection";
 
     const {
         layer,
@@ -140,7 +138,19 @@ const processHBox = (box: Layout.HBox, loc: Point, context: Context): Group => {
 
     let cancelRegion: CancelRegion | null = null;
 
-    box.content.forEach((section, index) => {
+    const sections = [];
+    if (box.content.type === "static") {
+        sections.push(box.content.nodes);
+    } else if (box.content.type === "cursor") {
+        sections.push(box.content.left);
+        sections.push(box.content.right);
+    } else {
+        sections.push(box.content.left);
+        sections.push(box.content.selection);
+        sections.push(box.content.right);
+    }
+
+    sections.forEach((section, index) => {
         const isSelection = hasSelection && index === 1;
 
         // There should only be two sections max.  If there are two sections

--- a/packages/typesetter/src/scene-graph.ts
+++ b/packages/typesetter/src/scene-graph.ts
@@ -230,7 +230,8 @@ const processHBox = (box: Layout.HBox, loc: Point, context: Context): Group => {
             const depth = Layout.getDepth(node);
 
             switch (node.type) {
-                case "Box": {
+                case "HBox":
+                case "VBox": {
                     const child = _processBox(
                         node,
                         {x: pen.x, y: pen.y + node.shift},
@@ -399,7 +400,8 @@ const processVBox = (box: Layout.VBox, loc: Point, context: Context): Group => {
         const depth = Layout.getDepth(node);
 
         switch (node.type) {
-            case "Box": {
+            case "HBox":
+            case "VBox": {
                 // TODO: reconsider whether we should be taking the shift into
                 // account when computing the height, maybe we can drop this
                 // and simplify things.  The reason why we zero out the shift
@@ -537,10 +539,10 @@ const _processBox = (
     loc: Point,
     context: Context,
 ): Group => {
-    switch (box.kind) {
-        case "hbox":
+    switch (box.type) {
+        case "HBox":
             return processHBox(box, loc, context);
-        case "vbox":
+        case "VBox":
             return processVBox(box, loc, context);
     }
 };

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -16,7 +16,7 @@ import {typesetTable} from "./typesetters/table";
 import type {Context} from "./types";
 import type {Scene} from "./scene-graph";
 
-const typesetRow = (row: Editor.types.Row, context: Context): Layout.Box => {
+const typesetRow = (row: Editor.types.Row, context: Context): Layout.HBox => {
     const box = Layout.hpackNat([typesetNodes(row.children, context)], context);
     box.id = row.id;
     box.style.color = row.style.color;
@@ -139,7 +139,7 @@ const getTypesetChildren = (
     zipper: Editor.Zipper,
     focus: Editor.Focus,
     childContext: Context,
-): (Layout.Box | null)[] => {
+): (Layout.HBox | null)[] => {
     const focusedCell = _typesetZipper(zipper, childContext);
 
     return [
@@ -159,7 +159,7 @@ const typesetFocus = (
     context: Context,
     prevEditNode?: Editor.types.Node,
     prevLayoutNode?: Layout.Node,
-): Layout.Box => {
+): Layout.Node => {
     switch (focus.type) {
         case "zfrac": {
             const childContext = childContextForFrac(context);
@@ -495,7 +495,7 @@ const typesetNodes = (
 const _typesetZipper = (
     zipper: Editor.Zipper,
     context: Context,
-): Layout.Box => {
+): Layout.HBox => {
     // The bottommost crumb is the outermost row
     const [crumb, ...restCrumbs] = zipper.breadcrumbs;
 
@@ -585,7 +585,7 @@ export const typesetZipper = (
     context: Context,
     options: Options = {},
 ): Scene => {
-    const box = _typesetZipper(zipper, context) as Layout.Box;
+    const box = _typesetZipper(zipper, context) as Layout.HBox;
     return processBox(box, context.fontData, options);
 };
 
@@ -594,6 +594,6 @@ export const typeset = (
     context: Context,
     options: Options = {},
 ): Scene => {
-    const box = typesetNode(node, context) as Layout.Box;
+    const box = typesetNode(node, context) as Layout.HBox;
     return processBox(box, context.fontData, options);
 };

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -17,7 +17,10 @@ import type {Context} from "./types";
 import type {Scene} from "./scene-graph";
 
 const typesetRow = (row: Editor.types.Row, context: Context): Layout.HBox => {
-    const box = Layout.hpackNat([typesetNodes(row.children, context)], context);
+    const box = Layout.makeStaticHBox(
+        typesetNodes(row.children, context),
+        context,
+    );
     box.id = row.id;
     box.style.color = row.style.color;
 
@@ -38,8 +41,8 @@ const withOperatorPadding = (
     // We need to tweak this loic so that we only add padding on the right side
     // for binary operators below.  This is so that we don't get extra space
     // when adding/subtracting something just to the right of an "=" in the above
-    return Layout.hpackNat(
-        [[Layout.makeKern(fontSize / 4), node, Layout.makeKern(fontSize / 4)]],
+    return Layout.makeStaticHBox(
+        [Layout.makeKern(fontSize / 4), node, Layout.makeKern(fontSize / 4)],
         context,
     );
 };
@@ -527,7 +530,7 @@ const _typesetZipper = (
             ),
         );
 
-        const box = Layout.hpackNat([nodes], context);
+        const box = Layout.makeStaticHBox(nodes, context);
         box.id = row.id;
         box.style.color = row.style.color;
 
@@ -564,7 +567,11 @@ const _typesetZipper = (
             prevLayoutNode,
         );
 
-        const box = Layout.hpackNat([left, selection, right], context);
+        const box =
+            selection.length > 0
+                ? Layout.makeSelectionHBox(left, selection, right, context)
+                : Layout.makeCursorHBox(left, right, context);
+
         box.id = row.id;
         box.style.color = row.style.color;
 

--- a/packages/typesetter/src/typesetters/delimited.ts
+++ b/packages/typesetter/src/typesetters/delimited.ts
@@ -32,7 +32,7 @@ export const typesetDelimited = (
     open.pending = node.leftDelim.value.pending;
     close.pending = node.rightDelim.value.pending;
 
-    const delimited = Layout.hpackNat([[open, row, close]], context);
+    const delimited = Layout.makeStaticHBox([open, row, close], context);
 
     delimited.id = node.id;
     delimited.style = node.style;

--- a/packages/typesetter/src/typesetters/delimited.ts
+++ b/packages/typesetter/src/typesetters/delimited.ts
@@ -6,10 +6,10 @@ import {makeDelimiter} from "../utils";
 import type {Context} from "../types";
 
 export const typesetDelimited = (
-    row: Layout.Box,
+    row: Layout.HBox,
     node: Editor.types.Delimited | Editor.ZDelimited,
     context: Context,
-): Layout.Box => {
+): Layout.HBox => {
     const thresholdOptions = {
         value: "both" as const,
         strict: true,

--- a/packages/typesetter/src/typesetters/frac.ts
+++ b/packages/typesetter/src/typesetters/frac.ts
@@ -90,8 +90,8 @@ export const typesetFrac = (
 
     const upList = makeList(minNumGap, numBox);
     const dnList = makeList(minDenGap, denBox);
-    const stroke = Layout.hpackNat(
-        [[Layout.makeHRule(thickness, width)]],
+    const stroke = Layout.makeStaticHBox(
+        [Layout.makeHRule(thickness, width)],
         context,
     );
 

--- a/packages/typesetter/src/typesetters/frac.ts
+++ b/packages/typesetter/src/typesetters/frac.ts
@@ -8,14 +8,14 @@ import type {Context} from "../types";
 
 const makeList = (
     size: Layout.Dist,
-    box: Layout.Box,
+    box: Layout.HBox,
 ): readonly Layout.Node[] => [Layout.makeKern(size), box];
 
 export const typesetFrac = (
-    typesetChildren: readonly (Layout.Box | null)[],
+    typesetChildren: readonly (Layout.HBox | null)[],
     node: Editor.types.Frac | Editor.ZFrac,
     context: Context,
-): Layout.Box => {
+): Layout.VBox => {
     let [numBox, denBox] = typesetChildren;
     if (!numBox || !denBox) {
         throw new Error("The numerator and denominator must both be defined");

--- a/packages/typesetter/src/typesetters/limits.ts
+++ b/packages/typesetter/src/typesetters/limits.ts
@@ -26,13 +26,11 @@ export const typesetLimits = (
 
     const newInner =
         innerWidth < width
-            ? Layout.hpackNat(
+            ? Layout.makeStaticHBox(
                   [
-                      [
-                          Layout.makeKern((width - innerWidth) / 2),
-                          inner,
-                          Layout.makeKern((width - innerWidth) / 2),
-                      ],
+                      Layout.makeKern((width - innerWidth) / 2),
+                      inner,
+                      Layout.makeKern((width - innerWidth) / 2),
                   ],
                   context,
               )

--- a/packages/typesetter/src/typesetters/limits.ts
+++ b/packages/typesetter/src/typesetters/limits.ts
@@ -6,11 +6,11 @@ import type {Context} from "../types";
 
 // TODO: render as a subsup if mathStyle isn't MathStyle.Display
 export const typesetLimits = (
-    typesetChildren: readonly (Layout.Box | null)[],
+    typesetChildren: readonly (Layout.HBox | null)[],
     node: Editor.types.Limits | Editor.ZLimits,
     inner: Layout.Node,
     context: Context,
-): Layout.Box => {
+): Layout.VBox => {
     const [lowerBox, upperBox] = typesetChildren;
 
     if (!lowerBox) {

--- a/packages/typesetter/src/typesetters/root.ts
+++ b/packages/typesetter/src/typesetters/root.ts
@@ -25,8 +25,8 @@ export const typesetRoot = (
         strict: true,
     };
 
-    const surd = Layout.hpackNat(
-        [[makeDelimiter("\u221A", radicand, thresholdOptions, context)]],
+    const surd = Layout.makeStaticHBox(
+        [makeDelimiter("\u221A", radicand, thresholdOptions, context)],
         context,
     );
 
@@ -97,20 +97,12 @@ export const typesetRoot = (
                 break;
         }
 
-        root = Layout.hpackNat(
-            [
-                [
-                    beforeDegreeKern,
-                    degree,
-                    afterDegreeKern,
-                    surd,
-                    radicalWithRule,
-                ],
-            ],
+        root = Layout.makeStaticHBox(
+            [beforeDegreeKern, degree, afterDegreeKern, surd, radicalWithRule],
             context,
         );
     } else {
-        root = Layout.hpackNat([[surd, radicalWithRule]], context);
+        root = Layout.makeStaticHBox([surd, radicalWithRule], context);
     }
 
     root.width += endPadding;

--- a/packages/typesetter/src/typesetters/root.ts
+++ b/packages/typesetter/src/typesetters/root.ts
@@ -11,10 +11,10 @@ import type {Context} from "../types";
 
 export const typesetRoot = (
     // TODO: rename all uses of radical `index` to `degree` to match this
-    degree: Layout.Box | null,
-    radicand: Layout.Box,
+    degree: Layout.HBox | null,
+    radicand: Layout.HBox,
     context: Context,
-): Layout.Box => {
+): Layout.HBox => {
     const multiplier = multiplierForContext(context);
 
     // Give the radicand a minimal width in case it's empty

--- a/packages/typesetter/src/typesetters/subsup.ts
+++ b/packages/typesetter/src/typesetters/subsup.ts
@@ -28,7 +28,10 @@ export const typesetSubsup = (
     // filter them out.  Anything else that's in a box is some sort of compound
     // layout structure (frac, delimited, etc.) and should have its subscript
     // and/or superscript positioned based on the size of the box.
-    if (prevEditNode?.type !== "atom" && prevLayoutNode?.type === "Box") {
+    if (
+        prevEditNode?.type !== "atom" &&
+        (prevLayoutNode?.type === "HBox" || prevLayoutNode?.type === "VBox")
+    ) {
         const {
             superscriptBaselineDropMax,
             subscriptBaselineDropMin,
@@ -126,7 +129,7 @@ export const typesetSubsup = (
             );
 
             if (gap < gapMin) {
-                if (upList[0].type === "Kern" && upList[1].type === "Box") {
+                if (upList[0].type === "Kern" && upList[1].type === "HBox") {
                     // shift the superscript up to increase the gap
                     const correction = gapMin - gap;
                     upList[0].size += correction;

--- a/packages/typesetter/src/typesetters/subsup.ts
+++ b/packages/typesetter/src/typesetters/subsup.ts
@@ -5,12 +5,12 @@ import * as Layout from "../layout";
 import type {Context} from "../types";
 
 export const typesetSubsup = (
-    typesetChildren: readonly (Layout.Box | null)[],
+    typesetChildren: readonly (Layout.HBox | null)[],
     node: Editor.types.SubSup | Editor.ZSubSup,
     context: Context,
     prevEditNode?: Editor.types.Node | Editor.Focus,
     prevLayoutNode?: Layout.Node,
-): Layout.Box => {
+): Layout.VBox => {
     const [subBox, supBox] = typesetChildren;
 
     if (!supBox && !subBox) {

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -50,8 +50,7 @@ export const typesetTable = (
             } else {
                 // Use an empty Layout.Box for children that were null
                 cell = {
-                    type: "Box",
-                    kind: "hbox",
+                    type: "HBox",
                     shift: 0,
                     content: [],
                     // These values don't matter since the box is empty

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -6,22 +6,22 @@ import {fontSizeForContext, makeDelimiter} from "../utils";
 import type {Context} from "../types";
 
 type Row = {
-    children: Layout.Box[];
+    children: Layout.HBox[];
     height: number;
     depth: number;
 };
 type Col = {
-    children: Layout.Box[];
+    children: Layout.HBox[];
     width: number;
 };
 
 const COL_GAP = 50;
 
 export const typesetTable = (
-    typesetChildren: (Layout.Box | null)[],
+    typesetChildren: (Layout.HBox | null)[],
     node: Editor.types.Table | Editor.ZTable,
     context: Context,
-): Layout.Box => {
+): Layout.HBox => {
     const columns: Col[] = [];
     const rows: Row[] = [];
 

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -52,7 +52,10 @@ export const typesetTable = (
                 cell = {
                     type: "HBox",
                     shift: 0,
-                    content: [],
+                    content: {
+                        type: "static",
+                        nodes: [],
+                    },
                     // These values don't matter since the box is empty
                     fontSize: 0,
                     style: {},
@@ -102,7 +105,7 @@ export const typesetTable = (
     }
 
     const rowBoxes = rows.map((row) =>
-        Layout.hpackNat([row.children], context),
+        Layout.makeStaticHBox(row.children, context),
     );
     const width =
         columns.reduce((sum, col) => sum + col.width, 0) +
@@ -133,7 +136,7 @@ export const typesetTable = (
     const open = makeDelimiter("[", inner, thresholdOptions, context);
     const close = makeDelimiter("]", inner, thresholdOptions, context);
 
-    const table = Layout.hpackNat([[open, inner, close]], context);
+    const table = Layout.makeStaticHBox([open, inner, close], context);
 
     table.id = node.id;
     table.style = node.style;

--- a/packages/typesetter/src/utils.ts
+++ b/packages/typesetter/src/utils.ts
@@ -36,7 +36,7 @@ type ThresholdOptions = {
 // glyphs on that row.
 const getDelimiter = (
     char: string,
-    box: Layout.Box,
+    box: Layout.HBox | Layout.VBox,
     thresholdOptions: ThresholdOptions,
     context: Context,
 ): number => {
@@ -115,7 +115,7 @@ const getDelimiter = (
  */
 export const makeDelimiter = (
     char: string,
-    box: Layout.Box,
+    box: Layout.HBox | Layout.VBox,
     thresholdOptions: ThresholdOptions,
     context: Context,
 ): Layout.Glyph => {


### PR DESCRIPTION
This PR replaces the common `Box` layout node with `HBox` and `VBox` types.  The `content` property on these types are different as well with `HBox`'s content property having an explicit `Content` type more clearly differentiates static content from content containing a cursor or selection.