### PR TITLE
Make typesetting functions more consistent

### DIFF
--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -22,6 +22,7 @@ export type {
     ZFrac,
     ZLimits,
     ZRow,
+    ZRoot,
     ZSubSup,
     ZTable,
     State,

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -139,26 +139,28 @@ const childContextForLimits = (context: Context): Context => {
 };
 
 /**
+ * Typesets the children of a Focus and associated Zipper.
+ *
  * @param {Editor.Zipper} zipper
  * @param {Editor.Focus} focus
- * @param {Function} childContextForIndex
+ * @param {Function} contextForIndex
  */
 const getTypesetChildren = (
     zipper: Editor.Zipper,
     focus: Editor.Focus,
-    childContextForIndex: (index: number) => Context,
+    contextForIndex: (index: number) => Context,
 ): (Layout.HBox | null)[] => {
     return [
         ...focus.left.map((child, index) => {
-            return child && typesetRow(child, childContextForIndex(index));
+            return child && typesetRow(child, contextForIndex(index));
         }),
-        _typesetZipper(zipper, childContextForIndex(focus.left.length)),
+        _typesetZipper(zipper, contextForIndex(focus.left.length)),
         ...focus.right.map((child, index) => {
             return (
                 child &&
                 typesetRow(
                     child,
-                    childContextForIndex(focus.left.length + index + 1),
+                    contextForIndex(focus.left.length + index + 1),
                 )
             );
         }),

--- a/packages/typesetter/src/typesetters/delimited.ts
+++ b/packages/typesetter/src/typesetters/delimited.ts
@@ -6,7 +6,7 @@ import {makeDelimiter} from "../utils";
 import type {Context} from "../types";
 
 export const typesetDelimited = (
-    row: Layout.HBox,
+    typesetChildren: readonly (Layout.HBox | null)[],
     node: Editor.types.Delimited | Editor.ZDelimited,
     context: Context,
 ): Layout.HBox => {
@@ -14,6 +14,11 @@ export const typesetDelimited = (
         value: "both" as const,
         strict: true,
     };
+
+    const row = typesetChildren[0];
+    if (!row) {
+        throw new Error("Delimited's content should be defined");
+    }
 
     const open = makeDelimiter(
         node.leftDelim.value.char,

--- a/packages/typesetter/src/typesetters/limits.ts
+++ b/packages/typesetter/src/typesetters/limits.ts
@@ -8,14 +8,18 @@ import type {Context} from "../types";
 export const typesetLimits = (
     typesetChildren: readonly (Layout.HBox | null)[],
     node: Editor.types.Limits | Editor.ZLimits,
-    inner: Layout.Node,
     context: Context,
+    typesetNode: (node: Editor.types.Node, context: Context) => Layout.Node,
 ): Layout.VBox => {
     const [lowerBox, upperBox] = typesetChildren;
 
     if (!lowerBox) {
         throw new Error("Lower limit should always be defined");
     }
+
+    const inner = typesetNode(node.inner, {...context, operator: true});
+    inner.id = node.inner.id;
+    inner.style.color = node.inner.style.color;
 
     const innerWidth = Layout.getWidth(inner);
     const width = Math.max(

--- a/packages/typesetter/src/typesetters/root.ts
+++ b/packages/typesetter/src/typesetters/root.ts
@@ -1,3 +1,5 @@
+import * as Editor from "@math-blocks/editor-core";
+
 import * as Layout from "../layout";
 
 import {RadicalDegreeAlgorithm} from "../enums";
@@ -10,11 +12,19 @@ import {
 import type {Context} from "../types";
 
 export const typesetRoot = (
+    typesetChildren: readonly (Layout.HBox | null)[],
+    node: Editor.types.Root | Editor.ZRoot,
     // TODO: rename all uses of radical `index` to `degree` to match this
-    degree: Layout.HBox | null,
-    radicand: Layout.HBox,
+    // degree: Layout.HBox | null,
+    // radicand: Layout.HBox,
     context: Context,
 ): Layout.HBox => {
+    const [degree, radicand] = typesetChildren;
+
+    if (!radicand) {
+        throw new Error("Radicand must be defined");
+    }
+
     const multiplier = multiplierForContext(context);
 
     // Give the radicand a minimal width in case it's empty
@@ -106,6 +116,9 @@ export const typesetRoot = (
     }
 
     root.width += endPadding;
+
+    root.id = node.id;
+    root.style = node.style;
 
     return root;
 };

--- a/packages/typesetter/src/typesetters/root.ts
+++ b/packages/typesetter/src/typesetters/root.ts
@@ -14,9 +14,6 @@ import type {Context} from "../types";
 export const typesetRoot = (
     typesetChildren: readonly (Layout.HBox | null)[],
     node: Editor.types.Root | Editor.ZRoot,
-    // TODO: rename all uses of radical `index` to `degree` to match this
-    // degree: Layout.HBox | null,
-    // radicand: Layout.HBox,
     context: Context,
 ): Layout.HBox => {
     const [degree, radicand] = typesetChildren;


### PR DESCRIPTION
This PR makes `typesetDelimited` and `typesetRoot` have the same function signature as the other typesetting functions.  There's still some inconsistency in typeset.ts itself though that I'll deal with later.