### PR TITLE
Add optional 'delimiters' property to (Z)Table type

### DIFF
--- a/demo/src/editor/examples.ts
+++ b/demo/src/editor/examples.ts
@@ -1,159 +1,130 @@
-import * as Editor from "@math-blocks/editor-core";
+import {builders} from "@math-blocks/editor-core";
 
-const simpleRow = Editor.builders.row([
-    Editor.builders.glyph("2"),
-    Editor.builders.glyph("x"),
-    Editor.builders.subsup(undefined, [Editor.builders.glyph("2")]),
-    Editor.builders.glyph("+"),
-    Editor.builders.glyph("5"),
-    Editor.builders.glyph("="),
-    Editor.builders.glyph("1"),
-    Editor.builders.glyph("0"),
+const simpleRow = builders.row([
+    builders.glyph("2"),
+    builders.glyph("x"),
+    builders.subsup(undefined, [builders.glyph("2")]),
+    builders.glyph("+"),
+    builders.glyph("5"),
+    builders.glyph("="),
+    builders.glyph("1"),
+    builders.glyph("0"),
 ]);
 
-const delimiters = Editor.builders.row([
-    Editor.builders.glyph("x"),
-    Editor.builders.glyph("+"),
-    Editor.builders.delimited(
+const delimiters = builders.row([
+    builders.glyph("x"),
+    builders.glyph("+"),
+    builders.delimited(
         [
-            Editor.builders.frac(
+            builders.frac(
                 [
-                    Editor.builders.glyph("y"),
-                    Editor.builders.glyph("\u2212"),
-                    Editor.builders.glyph("1"),
+                    builders.glyph("y"),
+                    builders.glyph("\u2212"),
+                    builders.glyph("1"),
                 ],
-                [Editor.builders.glyph("x")],
+                [builders.glyph("x")],
             ),
         ],
-        Editor.builders.glyph("("),
-        Editor.builders.glyph(")"),
+        builders.glyph("("),
+        builders.glyph(")"),
     ),
-    Editor.builders.subsup(
-        [Editor.builders.glyph("n")],
-        [Editor.builders.glyph("2")],
-    ),
-    Editor.builders.glyph("+"),
-    Editor.builders.glyph("z"),
+    builders.subsup([builders.glyph("n")], [builders.glyph("2")]),
+    builders.glyph("+"),
+    builders.glyph("z"),
 ]);
 
-const allNodeTypes = Editor.builders.row([
-    Editor.builders.glyph("2"),
-    Editor.builders.glyph("+"),
-    Editor.builders.frac(
-        [Editor.builders.glyph("1")],
+const allNodeTypes = builders.row([
+    builders.glyph("2"),
+    builders.glyph("+"),
+    builders.frac(
+        [builders.glyph("1")],
         [
-            Editor.builders.root(
+            builders.root(
+                [builders.glyph("1"), builders.glyph("2"), builders.glyph("3")],
                 [
-                    Editor.builders.glyph("1"),
-                    Editor.builders.glyph("2"),
-                    Editor.builders.glyph("3"),
-                ],
-                [
-                    Editor.builders.glyph("x"),
-                    Editor.builders.subsup(undefined, [
-                        Editor.builders.glyph("2"),
-                    ]),
-                    Editor.builders.glyph("+"),
-                    Editor.builders.frac(
-                        [Editor.builders.glyph("1")],
+                    builders.glyph("x"),
+                    builders.subsup(undefined, [builders.glyph("2")]),
+                    builders.glyph("+"),
+                    builders.frac(
+                        [builders.glyph("1")],
                         [
-                            Editor.builders.glyph("a"),
-                            Editor.builders.subsup(
-                                [Editor.builders.glyph("n")],
-                                undefined,
-                            ),
+                            builders.glyph("a"),
+                            builders.subsup([builders.glyph("n")], undefined),
                         ],
                     ),
                 ],
             ),
         ],
     ),
-    Editor.builders.glyph("\u2212"),
-    Editor.builders.glyph("\u2212"),
-    Editor.builders.glyph("y"),
-    Editor.builders.glyph("+"),
-    Editor.builders.limits(
-        Editor.builders.row([
-            Editor.builders.glyph("l"),
-            Editor.builders.glyph("i"),
-            Editor.builders.glyph("m"),
+    builders.glyph("\u2212"),
+    builders.glyph("\u2212"),
+    builders.glyph("y"),
+    builders.glyph("+"),
+    builders.limits(
+        builders.row([
+            builders.glyph("l"),
+            builders.glyph("i"),
+            builders.glyph("m"),
         ]),
         [
-            Editor.builders.glyph("x"),
-            Editor.builders.glyph("\u2192"), // \rightarrow
-            Editor.builders.glyph("0"),
+            builders.glyph("x"),
+            builders.glyph("\u2192"), // \rightarrow
+            builders.glyph("0"),
         ],
     ),
-    Editor.builders.glyph("x"),
-    Editor.builders.glyph("+"),
-    Editor.builders.limits(
-        Editor.builders.glyph("\u2211"), // \sum
-        [
-            Editor.builders.glyph("i"),
-            Editor.builders.glyph("="),
-            Editor.builders.glyph("0"),
-        ],
-        [Editor.builders.glyph("\u221E")], // \infty
+    builders.glyph("x"),
+    builders.glyph("+"),
+    builders.limits(
+        builders.glyph("\u2211"), // \sum
+        [builders.glyph("i"), builders.glyph("="), builders.glyph("0")],
+        [builders.glyph("\u221E")], // \infty
     ),
-    Editor.builders.glyph("i"),
+    builders.glyph("i"),
 ]);
 
-const nestedFractions = Editor.builders.row([
-    Editor.builders.glyph("a"),
-    Editor.builders.glyph("+"),
-    Editor.builders.frac(
+const nestedFractions = builders.row([
+    builders.glyph("a"),
+    builders.glyph("+"),
+    builders.frac(
         [
-            Editor.builders.glyph("2"),
-            Editor.builders.glyph("+"),
-            Editor.builders.frac(
-                [
-                    Editor.builders.glyph("x"),
-                    Editor.builders.glyph("+"),
-                    Editor.builders.glyph("1"),
-                ],
-                [Editor.builders.glyph("1")],
+            builders.glyph("2"),
+            builders.glyph("+"),
+            builders.frac(
+                [builders.glyph("x"), builders.glyph("+"), builders.glyph("1")],
+                [builders.glyph("1")],
             ),
-            Editor.builders.glyph("+"),
-            Editor.builders.glyph("\u2212"),
-            Editor.builders.glyph("y"),
+            builders.glyph("+"),
+            builders.glyph("\u2212"),
+            builders.glyph("y"),
         ],
-        [Editor.builders.glyph("1")],
+        [builders.glyph("1")],
     ),
-    Editor.builders.glyph("+"),
-    Editor.builders.glyph("b"),
+    builders.glyph("+"),
+    builders.glyph("b"),
 ]);
 
-const addingFractions = Editor.builders.row([
-    Editor.builders.glyph("2"),
-    Editor.builders.glyph("+"),
-    Editor.builders.frac(
+const addingFractions = builders.row([
+    builders.glyph("2"),
+    builders.glyph("+"),
+    builders.frac(
         [
-            Editor.builders.frac(
-                [Editor.builders.glyph("a")],
-                [Editor.builders.glyph("b")],
-            ),
-            Editor.builders.glyph("+"),
-            Editor.builders.frac(
-                [Editor.builders.glyph("c")],
-                [Editor.builders.glyph("d")],
-            ),
+            builders.frac([builders.glyph("a")], [builders.glyph("b")]),
+            builders.glyph("+"),
+            builders.frac([builders.glyph("c")], [builders.glyph("d")]),
         ],
-        [Editor.builders.glyph("1")],
+        [builders.glyph("1")],
     ),
-    Editor.builders.glyph("+"),
-    Editor.builders.frac(
+    builders.glyph("+"),
+    builders.frac(
         [
-            Editor.builders.frac(
-                [Editor.builders.glyph("x")],
-                [Editor.builders.glyph("y")],
-            ),
-            Editor.builders.glyph("+"),
-            Editor.builders.glyph("1"),
+            builders.frac([builders.glyph("x")], [builders.glyph("y")]),
+            builders.glyph("+"),
+            builders.glyph("1"),
         ],
-        [Editor.builders.glyph("1")],
+        [builders.glyph("1")],
     ),
-    Editor.builders.glyph("\u2212"),
-    Editor.builders.glyph("y"),
+    builders.glyph("\u2212"),
+    builders.glyph("y"),
 ]);
 
 addingFractions.children[2].style.color = "teal";
@@ -162,29 +133,33 @@ addingFractions.children[2].children[0].style.color = "orange";
 // @ts-expect-error: we don't both refining the type since we know what it is
 addingFractions.children[2].children[0].children[0].style.color = "pink";
 
-const matrix = Editor.builders.row([
-    Editor.builders.glyph("A"),
-    Editor.builders.glyph("="),
-    Editor.builders.table(3, 3, [
-        // first row
-        [Editor.builders.glyph("a")],
-        [Editor.builders.glyph("b")],
-        [Editor.builders.glyph("c")],
-
-        // second row
-        [Editor.builders.glyph("d")],
+const matrix = builders.row([
+    builders.glyph("A"),
+    builders.glyph("="),
+    builders.table(
         [
-            Editor.builders.glyph("e"),
-            Editor.builders.glyph("+"),
-            Editor.builders.glyph("1"),
-        ],
-        [Editor.builders.glyph("f")],
+            // first row
+            [builders.glyph("a")],
+            [builders.glyph("b")],
+            [builders.glyph("c")],
 
-        // third row
-        [Editor.builders.glyph("0")],
-        [Editor.builders.glyph("0")],
-        [Editor.builders.glyph("1")],
-    ]),
+            // second row
+            [builders.glyph("d")],
+            [builders.glyph("e"), builders.glyph("+"), builders.glyph("1")],
+            [builders.glyph("f")],
+
+            // third row
+            [builders.glyph("0")],
+            [builders.glyph("0")],
+            [builders.glyph("1")],
+        ],
+        3,
+        3,
+        {
+            left: builders.glyph("["),
+            right: builders.glyph("]"),
+        },
+    ),
 ]);
 
 export const examples = [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "json-schema-to-typescript": "^9.1.1",
     "lint-staged": "^10.2.11",
     "mini-css-extract-plugin": "^1.3.8",
-    "prettier": "^2.0.5",
+    "prettier": "^2.3.1",
     "pretty-quick": "^2.0.1",
     "react-docgen-typescript-loader": "^3.6.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/editor-core/src/ast/builders.ts
+++ b/packages/editor-core/src/ast/builders.ts
@@ -76,16 +76,21 @@ export function delimited(
 }
 
 export function table(
+    cells: (readonly types.Node[] | null)[],
     colCount: number,
     rowCount: number,
-    cells: (readonly types.Node[] | null)[],
+    delimiters?: {
+        left: types.Atom;
+        right: types.Atom;
+    },
 ): types.Table {
     return {
         id: getId(),
         type: "table",
+        children: cells.map((cell) => cell && row(cell)),
         colCount,
         rowCount,
-        children: cells.map((cell) => cell && row(cell)),
+        delimiters,
         style: {},
     };
 }

--- a/packages/editor-core/src/ast/transforms.ts
+++ b/packages/editor-core/src/ast/transforms.ts
@@ -82,7 +82,6 @@ export const traverseZipper = (
     const focusRight = focus.right.map((row) => {
         return row && traverseRow(row, callback);
     });
-    // @ts-expect-error: TypeScript can't map a union of tuples
     let newFocus: Focus = {
         ...focus,
         left: focusLeft,

--- a/packages/editor-core/src/reducer/__tests__/matrix.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/matrix.test.ts
@@ -14,7 +14,7 @@ expect.extend({toEqualEditorNodes});
 
 describe("matrix", () => {
     describe("InsertMatrix", () => {
-        test("no selection", () => {
+        test("no selection, delimiters: 'brackets'", () => {
             const zipper: Zipper = {
                 row: zrow([], []),
                 breadcrumbs: [],
@@ -26,7 +26,10 @@ describe("matrix", () => {
                 selecting: false,
             };
 
-            const {zipper: result} = matrix(state, {type: "InsertMatrix"});
+            const {zipper: result} = matrix(state, {
+                type: "InsertMatrix",
+                delimiters: "brackets",
+            });
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
                 builders.table(
@@ -38,6 +41,45 @@ describe("matrix", () => {
                     ],
                     2,
                     2,
+                    {
+                        left: builders.glyph("["),
+                        right: builders.glyph("]"),
+                    },
+                ),
+            ]);
+        });
+
+        test("no selection, delimiters: 'parens'", () => {
+            const zipper: Zipper = {
+                row: zrow([], []),
+                breadcrumbs: [],
+            };
+            const state: State = {
+                startZipper: zipper,
+                endZipper: zipper,
+                zipper: zipper,
+                selecting: false,
+            };
+
+            const {zipper: result} = matrix(state, {
+                type: "InsertMatrix",
+                delimiters: "parens",
+            });
+            expect(result.breadcrumbs).toHaveLength(0);
+            expect(result.row.left).toEqualEditorNodes([
+                builders.table(
+                    [
+                        [builders.glyph("1")],
+                        [builders.glyph("0")],
+                        [builders.glyph("0")],
+                        [builders.glyph("1")],
+                    ],
+                    2,
+                    2,
+                    {
+                        left: builders.glyph("("),
+                        right: builders.glyph(")"),
+                    },
                 ),
             ]);
         });
@@ -62,7 +104,10 @@ describe("matrix", () => {
             };
             state = moveRight(state);
 
-            const {zipper: result} = matrix(state, {type: "InsertMatrix"});
+            const {zipper: result} = matrix(state, {
+                type: "InsertMatrix",
+                delimiters: "brackets",
+            });
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
                 builders.glyph("1"),
@@ -75,6 +120,10 @@ describe("matrix", () => {
                     ],
                     2,
                     2,
+                    {
+                        left: builders.glyph("["),
+                        right: builders.glyph("]"),
+                    },
                 ),
             ]);
             expect(result.row.selection).toEqual([]);

--- a/packages/editor-core/src/reducer/__tests__/matrix.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/matrix.test.ts
@@ -29,12 +29,16 @@ describe("matrix", () => {
             const {zipper: result} = matrix(state, {type: "InsertMatrix"});
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
-                builders.table(2, 2, [
-                    [builders.glyph("1")],
-                    [builders.glyph("0")],
-                    [builders.glyph("0")],
-                    [builders.glyph("1")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("1")],
+                        [builders.glyph("0")],
+                        [builders.glyph("0")],
+                        [builders.glyph("1")],
+                    ],
+                    2,
+                    2,
+                ),
             ]);
         });
 
@@ -62,12 +66,16 @@ describe("matrix", () => {
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
                 builders.glyph("1"),
-                builders.table(2, 2, [
-                    [builders.glyph("1")],
-                    [builders.glyph("0")],
-                    [builders.glyph("0")],
-                    [builders.glyph("1")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("1")],
+                        [builders.glyph("0")],
+                        [builders.glyph("0")],
+                        [builders.glyph("1")],
+                    ],
+                    2,
+                    2,
+                ),
             ]);
             expect(result.row.selection).toEqual([]);
             expect(result.row.right).toEqualEditorNodes([builders.glyph("2")]);
@@ -80,12 +88,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -101,14 +113,18 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(2, 3, [
-                    [builders.glyph("0")],
-                    [builders.glyph("0")],
-                    [builders.glyph("a")],
-                    [builders.glyph("b")],
-                    [builders.glyph("c")],
-                    [builders.glyph("d")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("0")],
+                        [builders.glyph("0")],
+                        [builders.glyph("a")],
+                        [builders.glyph("b")],
+                        [builders.glyph("c")],
+                        [builders.glyph("d")],
+                    ],
+                    2,
+                    3,
+                ),
             ]);
         });
 
@@ -117,12 +133,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -138,14 +158,18 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(2, 3, [
-                    [builders.glyph("a")],
-                    [builders.glyph("b")],
-                    [builders.glyph("0")],
-                    [builders.glyph("0")],
-                    [builders.glyph("c")],
-                    [builders.glyph("d")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("a")],
+                        [builders.glyph("b")],
+                        [builders.glyph("0")],
+                        [builders.glyph("0")],
+                        [builders.glyph("c")],
+                        [builders.glyph("d")],
+                    ],
+                    2,
+                    3,
+                ),
             ]);
         });
 
@@ -153,12 +177,16 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                     [],
                 ),
@@ -175,14 +203,18 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(2, 3, [
-                    [builders.glyph("a")],
-                    [builders.glyph("b")],
-                    [builders.glyph("c")],
-                    [builders.glyph("d")],
-                    [builders.glyph("0")],
-                    [builders.glyph("0")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("a")],
+                        [builders.glyph("b")],
+                        [builders.glyph("c")],
+                        [builders.glyph("d")],
+                        [builders.glyph("0")],
+                        [builders.glyph("0")],
+                    ],
+                    2,
+                    3,
+                ),
             ]);
         });
     });
@@ -193,12 +225,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -214,14 +250,18 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(3, 2, [
-                    [builders.glyph("0")],
-                    [builders.glyph("a")],
-                    [builders.glyph("b")],
-                    [builders.glyph("0")],
-                    [builders.glyph("c")],
-                    [builders.glyph("d")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("0")],
+                        [builders.glyph("a")],
+                        [builders.glyph("b")],
+                        [builders.glyph("0")],
+                        [builders.glyph("c")],
+                        [builders.glyph("d")],
+                    ],
+                    3,
+                    2,
+                ),
             ]);
         });
 
@@ -230,12 +270,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -251,14 +295,18 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(3, 2, [
-                    [builders.glyph("a")],
-                    [builders.glyph("0")],
-                    [builders.glyph("b")],
-                    [builders.glyph("c")],
-                    [builders.glyph("0")],
-                    [builders.glyph("d")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("a")],
+                        [builders.glyph("0")],
+                        [builders.glyph("b")],
+                        [builders.glyph("c")],
+                        [builders.glyph("0")],
+                        [builders.glyph("d")],
+                    ],
+                    3,
+                    2,
+                ),
             ]);
         });
 
@@ -266,12 +314,16 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                     [],
                 ),
@@ -288,14 +340,18 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(3, 2, [
-                    [builders.glyph("a")],
-                    [builders.glyph("b")],
-                    [builders.glyph("0")],
-                    [builders.glyph("c")],
-                    [builders.glyph("d")],
-                    [builders.glyph("0")],
-                ]),
+                builders.table(
+                    [
+                        [builders.glyph("a")],
+                        [builders.glyph("b")],
+                        [builders.glyph("0")],
+                        [builders.glyph("c")],
+                        [builders.glyph("d")],
+                        [builders.glyph("0")],
+                    ],
+                    3,
+                    2,
+                ),
             ]);
         });
     });
@@ -306,12 +362,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -327,10 +387,11 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(2, 1, [
-                    [builders.glyph("c")],
-                    [builders.glyph("d")],
-                ]),
+                builders.table(
+                    [[builders.glyph("c")], [builders.glyph("d")]],
+                    2,
+                    1,
+                ),
             ]);
         });
 
@@ -338,12 +399,16 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                     [],
                 ),
@@ -360,10 +425,11 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(2, 1, [
-                    [builders.glyph("a")],
-                    [builders.glyph("b")],
-                ]),
+                builders.table(
+                    [[builders.glyph("a")], [builders.glyph("b")]],
+                    2,
+                    1,
+                ),
             ]);
         });
 
@@ -372,12 +438,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -403,12 +473,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],
@@ -424,22 +498,27 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(1, 2, [
-                    [builders.glyph("b")],
-                    [builders.glyph("d")],
-                ]),
+                builders.table(
+                    [[builders.glyph("b")], [builders.glyph("d")]],
+                    1,
+                    2,
+                ),
             ]);
         });
         test("deleting the last column", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                     [],
                 ),
@@ -456,10 +535,11 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(1, 2, [
-                    [builders.glyph("a")],
-                    [builders.glyph("c")],
-                ]),
+                builders.table(
+                    [[builders.glyph("a")], [builders.glyph("c")]],
+                    1,
+                    2,
+                ),
             ]);
         });
         test("deleting all columns", () => {
@@ -467,12 +547,16 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(2, 2, [
-                            [builders.glyph("a")],
-                            [builders.glyph("b")],
-                            [builders.glyph("c")],
-                            [builders.glyph("d")],
-                        ]),
+                        builders.table(
+                            [
+                                [builders.glyph("a")],
+                                [builders.glyph("b")],
+                                [builders.glyph("c")],
+                                [builders.glyph("d")],
+                            ],
+                            2,
+                            2,
+                        ),
                     ],
                 ),
                 breadcrumbs: [],

--- a/packages/editor-core/src/reducer/__tests__/move-verticaly.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/move-verticaly.test.ts
@@ -19,21 +19,29 @@ const zipperToState = (zipper: Zipper): State => {
 };
 
 describe("moveVertically", () => {
-    const smallTable = builders.table(2, 2, [
-        [builders.glyph("a")],
-        [builders.glyph("b")],
-        [builders.glyph("c")],
-        [builders.glyph("d")],
-    ]);
+    const smallTable = builders.table(
+        [
+            [builders.glyph("a")],
+            [builders.glyph("b")],
+            [builders.glyph("c")],
+            [builders.glyph("d")],
+        ],
+        2,
+        2,
+    );
 
-    const largeTable = builders.table(2, 3, [
-        [builders.glyph("a")],
-        [builders.glyph("b")],
-        null,
-        null,
-        [builders.glyph("c")],
-        [builders.glyph("d")],
-    ]);
+    const largeTable = builders.table(
+        [
+            [builders.glyph("a")],
+            [builders.glyph("b")],
+            null,
+            null,
+            [builders.glyph("c")],
+            [builders.glyph("d")],
+        ],
+        2,
+        3,
+    );
 
     test("moving down", () => {
         const zipper: Zipper = {
@@ -131,12 +139,16 @@ describe("moveVertically", () => {
         const zipper: Zipper = {
             row: zrow(
                 [
-                    builders.table(2, 2, [
-                        [builders.glyph("a")],
-                        [builders.glyph("b")],
-                        [builders.glyph("c")],
-                        [builders.glyph("d")],
-                    ]),
+                    builders.table(
+                        [
+                            [builders.glyph("a")],
+                            [builders.glyph("b")],
+                            [builders.glyph("c")],
+                            [builders.glyph("d")],
+                        ],
+                        2,
+                        2,
+                    ),
                 ],
                 [],
             ),

--- a/packages/editor-core/src/reducer/matrix.ts
+++ b/packages/editor-core/src/reducer/matrix.ts
@@ -3,9 +3,11 @@ import * as types from "../ast/types";
 
 import type {State, Zipper, Breadcrumb, ZTable, ZRow} from "./types";
 
+// TODO: dedupe with math-keypad.ts
 export type MatrixActions =
     | {
           type: "InsertMatrix";
+          delimiters: "brackets" | "parens";
       }
     | {
           type: "AddRow";
@@ -134,6 +136,15 @@ export const matrix = (state: State, action: MatrixActions): State => {
             ],
             2,
             2,
+            action.delimiters === "brackets"
+                ? {
+                      left: builders.glyph("["),
+                      right: builders.glyph("]"),
+                  }
+                : {
+                      left: builders.glyph("("),
+                      right: builders.glyph(")"),
+                  },
         );
 
         if (selection.length > 0) {

--- a/packages/editor-core/src/reducer/matrix.ts
+++ b/packages/editor-core/src/reducer/matrix.ts
@@ -125,12 +125,16 @@ export const matrix = (state: State, action: MatrixActions): State => {
     if (action.type === "InsertMatrix") {
         const zipper = state.zipper;
         const {left, selection} = zipper.row;
-        const newNode = builders.table(2, 2, [
-            [builders.glyph("1")],
-            [builders.glyph("0")],
-            [builders.glyph("0")],
-            [builders.glyph("1")],
-        ]);
+        const newNode = builders.table(
+            [
+                [builders.glyph("1")],
+                [builders.glyph("0")],
+                [builders.glyph("0")],
+                [builders.glyph("1")],
+            ],
+            2,
+            2,
+        );
 
         if (selection.length > 0) {
             const newLeft = [...left, newNode];

--- a/packages/editor-core/src/reducer/types.ts
+++ b/packages/editor-core/src/reducer/types.ts
@@ -1,5 +1,11 @@
 import * as types from "../ast/types";
 
+type Zipperize<T extends types.Node> = {
+    type: `z${T["type"]}`;
+    left: readonly (types.Row | null)[];
+    right: readonly (types.Row | null)[];
+} & Omit<T, "children" | "type">;
+
 type ZCommon = {id: number; style: types.Style};
 
 export type ZRow = ZCommon & {
@@ -9,73 +15,12 @@ export type ZRow = ZCommon & {
     right: readonly types.Node[];
 };
 
-export type ZFrac =
-    | (ZCommon & {
-          type: "zfrac";
-          left: readonly [];
-          right: readonly [types.Row];
-      })
-    | (ZCommon & {
-          type: "zfrac";
-          left: readonly [types.Row];
-          right: readonly [];
-      });
-
-// TODO: consider splitting up SubSup into three different types.
-// If both `sub` and `sup` are `null` then the node is invalid.
-export type ZSubSup =
-    | (ZCommon & {
-          type: "zsubsup";
-          left: readonly [];
-          right: readonly [types.Row | null];
-      })
-    | (ZCommon & {
-          type: "zsubsup";
-          left: readonly [types.Row | null];
-          right: readonly [];
-      });
-
-export type ZLimits =
-    | (ZCommon & {
-          type: "zlimits";
-          left: readonly [];
-          right: readonly [types.Row | null];
-          inner: types.Node;
-      })
-    | (ZCommon & {
-          type: "zlimits";
-          left: readonly [types.Row];
-          right: readonly [];
-          inner: types.Node;
-      });
-
-export type ZRoot =
-    | (ZCommon & {
-          type: "zroot";
-          left: readonly [];
-          right: readonly [types.Row];
-      })
-    | (ZCommon & {
-          type: "zroot";
-          left: readonly [types.Row | null];
-          right: readonly [];
-      });
-
-export type ZDelimited = ZCommon & {
-    type: "zdelimited";
-    left: readonly [];
-    right: readonly [];
-    leftDelim: types.Atom;
-    rightDelim: types.Atom;
-};
-
-export type ZTable = ZCommon & {
-    type: "ztable";
-    left: readonly (types.Row | null)[];
-    right: readonly (types.Row | null)[];
-    rowCount: number;
-    colCount: number;
-};
+export type ZFrac = Zipperize<types.Frac>;
+export type ZSubSup = Zipperize<types.SubSup>;
+export type ZLimits = Zipperize<types.Limits>;
+export type ZRoot = Zipperize<types.Root>;
+export type ZDelimited = Zipperize<types.Delimited>;
+export type ZTable = Zipperize<types.Table>;
 
 export type Focus = ZFrac | ZSubSup | ZLimits | ZRoot | ZDelimited | ZTable;
 

--- a/packages/editor-core/src/reducer/util.ts
+++ b/packages/editor-core/src/reducer/util.ts
@@ -148,6 +148,7 @@ export const table = (focus: ZTable, replacement: types.Row): types.Table => {
         type: "table",
         rowCount: focus.rowCount,
         colCount: focus.colCount,
+        delimiters: focus.delimiters,
         children: [...focus.left, replacement, ...focus.right],
         style: focus.style,
     };
@@ -159,6 +160,7 @@ export const ztable = (node: types.Table, index: number): ZTable => {
         type: "ztable",
         rowCount: node.rowCount,
         colCount: node.colCount,
+        delimiters: node.delimiters,
         left: node.children.slice(0, index),
         right: node.children.slice(index + 1),
         style: node.style,
@@ -255,7 +257,7 @@ export const nodeToFocus = (
 };
 
 export const insertRight = <
-    T extends {left: readonly types.Node[]; right: readonly types.Node[]}
+    T extends {left: readonly types.Node[]; right: readonly types.Node[]},
 >(
     zrow: T,
     node: types.Node,

--- a/packages/editor-core/src/shared-types.ts
+++ b/packages/editor-core/src/shared-types.ts
@@ -7,9 +7,9 @@ export type Row<A, C> = C & {
 
 export type Delimited<A, C> = C & {
     type: "delimited";
-    // How do we limit what can be used as a delimiter?
-    leftDelim: Atom<A, C>;
     children: readonly [Row<A, C>];
+    // How do we limit what can be used as a delimiter?s
+    leftDelim: Atom<A, C>;
     rightDelim: Atom<A, C>;
 };
 
@@ -18,6 +18,11 @@ export type Table<A, C> = C & {
     children: readonly (Row<A, C> | null)[];
     rowCount: number;
     colCount: number;
+    // How do we limit what can be used as a delimiter?s
+    delimiters?: {
+        left: Atom<A, C>;
+        right: Atom<A, C>;
+    };
 };
 
 export type SubSup<A, C> = C & {

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
@@ -1,72 +1,72 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 477.96000000000004 186.06" width="477.96000000000004" height="186.06" style="background:white">
     <g fill="currentColor" stroke="currentColor">
-        <g transform="translate(0,109.2)" id="23">
+        <g transform="translate(0,109.2)" id="25">
             <g transform="translate(43.08,0)" id="1"></g>
-            <g transform="translate(116.28,0)" id="13">
+            <g transform="translate(116.28,0)" id="15">
                 <g transform="translate(31.68,0)" id="undefined">
                     <g transform="translate(0,-59.28)" id="undefined">
-                        <g transform="translate(0,0)" id="14"></g>
-                        <g transform="translate(58.36,0)" id="15"></g>
-                        <g transform="translate(236.7,0)" id="16"></g>
+                        <g transform="translate(0,0)" id="16"></g>
+                        <g transform="translate(58.36,0)" id="17"></g>
+                        <g transform="translate(236.7,0)" id="18"></g>
                     </g>
                     <g transform="translate(0,0.7199999999999989)" id="undefined">
-                        <g transform="translate(0,0)" id="17"></g>
-                        <g transform="translate(58.36,0)" id="18">
+                        <g transform="translate(0,0)" id="19"></g>
+                        <g transform="translate(58.36,0)" id="20">
                             <g transform="translate(50.44,0)" id="7"></g>
                         </g>
-                        <g transform="translate(236.7,0)" id="19"></g>
+                        <g transform="translate(236.7,0)" id="21"></g>
                     </g>
                     <g transform="translate(0,60.72)" id="undefined">
-                        <g transform="translate(0,0)" id="20"></g>
-                        <g transform="translate(58.36,0)" id="21"></g>
-                        <g transform="translate(236.7,0)" id="22"></g>
+                        <g transform="translate(0,0)" id="22"></g>
+                        <g transform="translate(58.36,0)" id="23"></g>
+                        <g transform="translate(236.7,0)" id="24"></g>
                     </g>
                 </g>
             </g>
         </g>
-        <g transform="translate(0,109.2)" id="23">
+        <g transform="translate(0,109.2)" id="25">
             <path id="0" style="opacity:1" aria-hidden="true" d="M 714,0 L 714,30 C 660,30 640,53 611,119L 374,662 L 333,662 L 121,160 C 73,46 59,30 3,30L 3,0 L 213,0 L 213,30 C 166,30 146,36 146,64C 146,82 151,97 157,113L 202,219 L 458,219 L 497,129 C 510,99 514,81 514,67C 514,32 475,30 445,30L 445,0 ZM 443,259 L 217,259 L 330,539 L 333,539 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
             <g transform="translate(43.08,0)" id="1">
                 <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,327 L 658,395 L 62,395 L 62,327 ZM 658,123 L 658,190 L 62,190 L 62,123 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
             </g>
-            <g transform="translate(116.28,0)" id="13">
+            <g transform="translate(116.28,0)" id="15">
                 <path id="undefined" style="opacity:1" aria-hidden="true" d="M 418,-1281 L 418,-1231 L 231,-1231 L 231,1770 L 418,1770 L 418,1820 L 128,1820 L 128,-1281 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                 <g transform="translate(31.68,0)" id="undefined">
                     <g transform="translate(0,-59.28)" id="undefined">
-                        <g transform="translate(0,0)" id="14">
+                        <g transform="translate(0,0)" id="16">
                             <path id="2" style="opacity:1" aria-hidden="true" d="M 502,472 L 449,472 L 413,426 L 409,426 C 388,456 358,479 305,479C 174,479 49,341 49,159C 49,43 100,-12 172,-12C 229,-12 288,22 339,85L 346,85 C 343,67 339,53 339,38C 339,5 359,-10 395,-10C 455,-10 497,33 539,97L 519,112 C 506,95 477,60 445,60C 429,60 425,68 425,81C 425,96 430,118 430,118ZM 389,344 C 389,313 378,240 358,181C 329,96 285,54 218,54C 168,54 138,77 138,169C 138,303 202,441 302,441C 358,441 389,397 389,344Z" transform="translate(0.030000000000001137, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(58.36,0)" id="15">
+                        <g transform="translate(58.36,0)" id="17">
                             <path id="3" style="opacity:1" aria-hidden="true" d="M 198,402 L 257,705 L 235,705 L 97,694 L 97,668 C 97,668 116,670 127,670C 147,670 163,663 163,641C 163,629 160,610 159,606L 46,25 C 95,0 146,-12 204,-12C 382,-12 483,140 483,304C 483,424 421,479 342,479C 289,479 246,450 203,402ZM 184,316 C 205,363 249,423 313,423C 358,423 395,390 395,300C 395,148 338,30 219,30C 177,30 148,54 135,66Z" transform="translate(73.63, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(236.7,0)" id="16">
+                        <g transform="translate(236.7,0)" id="18">
                             <path id="4" style="opacity:1" aria-hidden="true" d="M 358,123 C 327,85 288,57 219,57C 161,57 109,77 109,184C 109,300 170,446 280,446C 312,446 329,434 329,419C 329,403 310,375 310,349C 310,327 324,314 348,314C 385,314 404,346 404,386C 404,451 353,479 290,479C 146,479 26,335 26,169C 26,68 71,-12 179,-12C 269,-12 334,44 375,108Z" transform="translate(29.89, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                     <g transform="translate(0,0.7199999999999989)" id="undefined">
-                        <g transform="translate(0,0)" id="17">
+                        <g transform="translate(0,0)" id="19">
                             <path id="5" style="opacity:1" aria-hidden="true" d="M 529,705 L 507,705 L 371,694 L 371,668 C 371,668 390,670 402,670C 432,670 437,656 437,639C 437,625 434,607 434,607L 401,439 L 398,439 C 374,464 341,479 296,479C 157,479 37,340 37,162C 37,45 89,-12 163,-12C 222,-12 279,24 329,85L 337,85 C 335,73 332,54 332,42C 332,11 353,-10 393,-10C 462,-10 499,53 530,97L 510,112 C 496,93 469,60 437,60C 424,60 418,65 418,79C 418,92 423,121 423,121ZM 346,177 C 319,101 274,54 206,54C 157,54 126,78 126,169C 126,299 190,441 291,441C 349,441 377,394 377,351C 377,333 372,252 346,177Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(58.36,0)" id="18">
+                        <g transform="translate(58.36,0)" id="20">
                             <path id="6" style="opacity:1" aria-hidden="true" d="M 357,122 C 317,72 262,57 216,57C 149,57 112,88 112,189L 112,202 C 228,211 404,262 404,390C 404,467 339,479 296,479C 139,479 28,319 28,164C 28,84 58,-12 177,-12C 243,-12 315,17 375,107ZM 114,231 C 133,330 202,448 276,448C 306,448 318,428 318,393C 318,298 227,238 114,231Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
                             <g transform="translate(50.44,0)" id="7">
                                 <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                             </g>
                             <path id="8" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(123.64, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(236.7,0)" id="19">
+                        <g transform="translate(236.7,0)" id="21">
                             <path id="9" style="opacity:1" aria-hidden="true" d="M 190,467 L 186,426 L 270,426 L 205,37 C 194,-29 168,-193 115,-193C 77,-193 110,-104 50,-104C 24,-104 10,-125 10,-153C 10,-188 35,-225 99,-225C 236,-225 282,-1 296,85L 353,426 L 447,426 L 453,467 L 358,467 L 370,538 C 385,623 410,682 461,682C 485,682 487,658 491,633C 494,612 504,594 531,594C 552,594 571,609 571,638C 571,681 537,711 476,711C 390,711 349,665 323,618C 300,577 288,523 276,467Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                     <g transform="translate(0,60.72)" id="undefined">
-                        <g transform="translate(0,0)" id="20">
+                        <g transform="translate(0,0)" id="22">
                             <path id="10" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(1.83, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(58.36,0)" id="21">
+                        <g transform="translate(58.36,0)" id="23">
                             <path id="11" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(74.32, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(236.7,0)" id="22">
+                        <g transform="translate(236.7,0)" id="24">
                             <path id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(27.46, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>

--- a/packages/react/src/__tests__/math-keypad.test.tsx
+++ b/packages/react/src/__tests__/math-keypad.test.tsx
@@ -58,29 +58,48 @@ describe("MathKeypad", () => {
         expect(mockKeyDown).toHaveBeenCalled();
     });
 
-    test("'+ matrix' should trigger 'InsertMatrix' editing event", () => {
+    test("'+ bmatrix' should trigger 'InsertMatrix' editing event", () => {
         // Arrange
         const editMock = jest.fn();
         render(<TestComp editMock={editMock} />);
 
         // Act
         screen.getByRole("textbox").focus();
-        userEvent.click(screen.getByText("+ matrix"));
+        userEvent.click(screen.getByText("+ bmatrix"));
 
         // Assert
-        expect(editMock).toHaveBeenCalledWith({type: "InsertMatrix"});
+        expect(editMock).toHaveBeenCalledWith({
+            type: "InsertMatrix",
+            delimiters: "brackets",
+        });
+    });
+
+    test("'+ pmatrix' should trigger 'InsertMatrix' editing event", () => {
+        // Arrange
+        const editMock = jest.fn();
+        render(<TestComp editMock={editMock} />);
+
+        // Act
+        screen.getByRole("textbox").focus();
+        userEvent.click(screen.getByText("+ pmatrix"));
+
+        // Assert
+        expect(editMock).toHaveBeenCalledWith({
+            type: "InsertMatrix",
+            delimiters: "parens",
+        });
     });
 
     // TODO: create a separate button component so that we only have to test
     // the focus behavior once.
-    test("clicking '+ matrix' doesn't unfocus input", () => {
+    test("clicking '+ bmatrix' doesn't unfocus input", () => {
         // Arrange
         const editMock = jest.fn();
         render(<TestComp editMock={editMock} />);
 
         // Act
         screen.getByRole("textbox").focus();
-        userEvent.click(screen.getByText("+ matrix"));
+        userEvent.click(screen.getByText("+ bmatrix"));
 
         // Assert
         expect(screen.getByRole("textbox")).toHaveFocus();

--- a/packages/react/src/math-keypad.tsx
+++ b/packages/react/src/math-keypad.tsx
@@ -11,6 +11,7 @@ type CharButton = {
 export type EditingEvent =
     | {
           type: "InsertMatrix";
+          delimiters: "brackets" | "parens";
       }
     | {
           type: "AddColumn";
@@ -89,11 +90,27 @@ const MathKeypad: React.FunctionComponent<EmptyProps> = () => {
                 <div
                     className={styles.item2}
                     onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => handleMatrixClick({type: "InsertMatrix"})}
+                    onClick={() =>
+                        handleMatrixClick({
+                            type: "InsertMatrix",
+                            delimiters: "brackets",
+                        })
+                    }
                 >
-                    + matrix
+                    + bmatrix
                 </div>
-                <div></div>
+                <div
+                    className={styles.item2}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() =>
+                        handleMatrixClick({
+                            type: "InsertMatrix",
+                            delimiters: "parens",
+                        })
+                    }
+                >
+                    + pmatrix
+                </div>
                 <div></div>
                 <div
                     className={styles.item2}

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -868,26 +868,34 @@ export const Matrix: Story<EmptyProps> = (args, {loaded: fontData}) => {
     const matrix = Editor.builders.row([
         Editor.builders.glyph("A"),
         Editor.builders.glyph("="),
-        Editor.builders.table(3, 3, [
-            // first row
-            [Editor.builders.glyph("a")],
-            [Editor.builders.glyph("b")],
-            [Editor.builders.glyph("c")],
-
-            // second row
-            [Editor.builders.glyph("d")],
+        Editor.builders.table(
             [
-                Editor.builders.glyph("e"),
-                Editor.builders.glyph("+"),
-                Editor.builders.glyph("1"),
-            ],
-            [Editor.builders.glyph("f")],
+                // first row
+                [Editor.builders.glyph("a")],
+                [Editor.builders.glyph("b")],
+                [Editor.builders.glyph("c")],
 
-            // third row
-            [Editor.builders.glyph("0")],
-            [Editor.builders.glyph("0")],
-            [Editor.builders.glyph("1")],
-        ]),
+                // second row
+                [Editor.builders.glyph("d")],
+                [
+                    Editor.builders.glyph("e"),
+                    Editor.builders.glyph("+"),
+                    Editor.builders.glyph("1"),
+                ],
+                [Editor.builders.glyph("f")],
+
+                // third row
+                [Editor.builders.glyph("0")],
+                [Editor.builders.glyph("0")],
+                [Editor.builders.glyph("1")],
+            ],
+            3,
+            3,
+            {
+                left: Editor.builders.glyph("["),
+                right: Editor.builders.glyph("]"),
+            },
+        ),
     ]);
 
     const fontSize = 60;

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -21,7 +21,7 @@ export const typesetTable = (
     typesetChildren: (Layout.HBox | null)[],
     node: Editor.types.Table | Editor.ZTable,
     context: Context,
-): Layout.HBox => {
+): Layout.HBox | Layout.VBox => {
     const columns: Col[] = [];
     const rows: Row[] = [];
 
@@ -133,8 +133,25 @@ export const typesetTable = (
         strict: true,
     };
 
-    const open = makeDelimiter("[", inner, thresholdOptions, context);
-    const close = makeDelimiter("]", inner, thresholdOptions, context);
+    if (!node.delimiters) {
+        inner.id = node.id;
+        inner.style = node.style;
+
+        return inner;
+    }
+
+    const open = makeDelimiter(
+        node.delimiters.left.value.char,
+        inner,
+        thresholdOptions,
+        context,
+    );
+    const close = makeDelimiter(
+        node.delimiters.right.value.char,
+        inner,
+        thresholdOptions,
+        context,
+    );
 
     const table = Layout.makeStaticHBox([open, inner, close], context);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12148,6 +12148,11 @@ prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
+prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
+  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
+
 prettier@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"


### PR DESCRIPTION
Fixes #419.

This PR also introduces `Zipperize<T extends types.Node>` to simplify the various zipper types we have.  This is at the cost of type accuracy, e.g. ZFrac should only support a single element in `.left` or `.right` but now those are each typed as `(types.Row | null)[]`.

I also had to update prettier to handle the new string template literal type.