### PR TITLE
Typeset child callback

### DIFF
--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -12,7 +12,7 @@ import {typesetLimits} from "./typesetters/limits";
 import {typesetRoot} from "./typesetters/root";
 import {typesetSubsup} from "./typesetters/subsup";
 import {typesetTable} from "./typesetters/table";
-import {typesetAtom, maybeAddOperatorPadding} from "./typesetters/atom";
+import {maybeAddOperatorPadding} from "./typesetters/atom";
 
 import type {Context} from "./types";
 import type {Scene} from "./scene-graph";
@@ -174,7 +174,7 @@ const typesetNode = (
             return typesetTable(typesetChild, node, context);
         }
         case "atom": {
-            return typesetAtom(node, context);
+            return maybeAddOperatorPadding(prevEditNode, node, context);
         }
         default:
             throw new UnreachableCaseError(node);
@@ -188,22 +188,10 @@ const typesetNodes = (
     prevLayoutNode?: Layout.Node,
 ): readonly Layout.Node[] => {
     return nodes.map((child) => {
-        if (child.type === "atom") {
-            const result = maybeAddOperatorPadding(prevChild, child, context);
-            prevLayoutNode = result;
-            prevChild = child;
-            return result;
-        } else {
-            const result = typesetNode(
-                child,
-                context,
-                prevChild,
-                prevLayoutNode,
-            );
-            prevLayoutNode = result;
-            prevChild = child;
-            return result;
-        }
+        const result = typesetNode(child, context, prevChild, prevLayoutNode);
+        prevLayoutNode = result;
+        prevChild = child;
+        return result;
     });
 };
 

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -3,7 +3,7 @@ import * as Editor from "@math-blocks/editor-core";
 
 import * as Layout from "./layout";
 import {processBox} from "./scene-graph";
-import {MathStyle, RenderMode} from "./enums";
+import {RenderMode} from "./enums";
 import {fontSizeForContext} from "./utils";
 
 import {typesetDelimited} from "./typesetters/delimited";
@@ -67,89 +67,32 @@ const ensureMinDepthAndHeight = (dim: Layout.Dim, context: Context): void => {
     dim.height = Math.max(dim.height, height);
 };
 
-const childContextForFrac = (context: Context): Context => {
-    const {mathStyle} = context;
-
-    const childMathStyle = {
-        [MathStyle.Display]: MathStyle.Text,
-        [MathStyle.Text]: MathStyle.Script,
-        [MathStyle.Script]: MathStyle.ScriptScript,
-        [MathStyle.ScriptScript]: MathStyle.ScriptScript,
-    }[mathStyle];
-
-    const childContext: Context = {
-        ...context,
-        mathStyle: childMathStyle,
-    };
-
-    return childContext;
-};
-
-const childContextForSubsup = (context: Context): Context => {
-    const {mathStyle} = context;
-
-    const childMathStyle = {
-        [MathStyle.Display]: MathStyle.Script,
-        [MathStyle.Text]: MathStyle.Script,
-        [MathStyle.Script]: MathStyle.ScriptScript,
-        [MathStyle.ScriptScript]: MathStyle.ScriptScript,
-    }[mathStyle];
-
-    const childContext: Context = {
-        ...context,
-        mathStyle: childMathStyle,
-        cramped: true,
-    };
-
-    return childContext;
-};
-
-const childContextForLimits = (context: Context): Context => {
-    const {mathStyle} = context;
-
-    const childMathStyle = {
-        [MathStyle.Display]: MathStyle.Script,
-        [MathStyle.Text]: MathStyle.Script,
-        [MathStyle.Script]: MathStyle.ScriptScript,
-        [MathStyle.ScriptScript]: MathStyle.ScriptScript,
-    }[mathStyle];
-
-    const childContext: Context = {
-        ...context,
-        mathStyle: childMathStyle,
-        cramped: true,
-    };
-
-    return childContext;
-};
-
-/**
- * Typesets the children of a Focus and associated Zipper.
- *
- * @param {Editor.Zipper} zipper
- * @param {Editor.Focus} focus
- * @param {Function} contextForIndex
- */
-const getTypesetChildren = (
+const getTypesetChildFromZipper = (
     zipper: Editor.Zipper,
     focus: Editor.Focus,
-    contextForIndex: (index: number) => Context,
-): (Layout.HBox | null)[] => {
-    return [
-        ...focus.left.map((child, index) => {
-            return child && typesetRow(child, contextForIndex(index));
-        }),
-        _typesetZipper(zipper, contextForIndex(focus.left.length)),
-        ...focus.right.map((child, index) => {
-            return (
-                child &&
-                typesetRow(
-                    child,
-                    contextForIndex(focus.left.length + index + 1),
-                )
-            );
-        }),
-    ];
+): ((index: number, context: Context) => Layout.HBox | null) => {
+    return (index: number, context: Context): Layout.HBox | null => {
+        if (index < focus.left.length) {
+            const child = focus.left[index];
+            return child && typesetRow(child, context);
+        } else if (index === focus.left.length) {
+            return _typesetZipper(zipper, context);
+        } else {
+            const child = focus.right[index - focus.left.length - 1];
+            return child && typesetRow(child, context);
+        }
+    };
+};
+
+const getTypesetChildFromNodes = <
+    T extends readonly (Editor.types.Row | null)[],
+>(
+    children: T,
+): ((index: number, context: Context) => Layout.HBox | null) => {
+    return (index: number, context: Context): Layout.HBox | null => {
+        const child = children[index];
+        return child && typesetRow(child, context);
+    };
 };
 
 const typesetFocus = (
@@ -159,29 +102,14 @@ const typesetFocus = (
     prevEditNode?: Editor.types.Node,
     prevLayoutNode?: Layout.Node,
 ): Layout.Node => {
+    const typesetChild = getTypesetChildFromZipper(zipper, focus);
     switch (focus.type) {
         case "zfrac": {
-            const childContext = childContextForFrac(context);
-
-            const typesetChildren = getTypesetChildren(
-                zipper,
-                focus,
-                () => childContext,
-            );
-
-            return typesetFrac(typesetChildren, focus, context);
+            return typesetFrac(typesetChild, focus, context);
         }
         case "zsubsup": {
-            const childContext = childContextForSubsup(context);
-
-            const typesetChildren = getTypesetChildren(
-                zipper,
-                focus,
-                () => childContext,
-            );
-
             return typesetSubsup(
-                typesetChildren,
+                typesetChild,
                 focus,
                 context,
                 prevEditNode,
@@ -189,50 +117,16 @@ const typesetFocus = (
             );
         }
         case "zroot": {
-            const indexContext: Context = {
-                ...context,
-                // It doesn't matter what the mathStyle is of the parent, we
-                // always use ScriptScript for root indicies.
-                mathStyle: MathStyle.ScriptScript,
-            };
-
-            const typesetChildren = getTypesetChildren(zipper, focus, (index) =>
-                index === 0 ? indexContext : context,
-            );
-
-            return typesetRoot(typesetChildren, focus, context);
+            return typesetRoot(typesetChild, focus, context);
         }
         case "zlimits": {
-            // TODO: render as a subsup if mathStyle isn't MathStyle.Display
-            const childContext = childContextForLimits(context);
-
-            const typesetChildren = getTypesetChildren(
-                zipper,
-                focus,
-                () => childContext,
-            );
-
-            return typesetLimits(typesetChildren, focus, context, typesetNode);
+            return typesetLimits(typesetChild, focus, context, typesetNode);
         }
         case "zdelimited": {
-            const typesetChildren = getTypesetChildren(
-                zipper,
-                focus,
-                () => context,
-            );
-
-            return typesetDelimited(typesetChildren, focus, context);
+            return typesetDelimited(typesetChild, focus, context);
         }
         case "ztable": {
-            const childContext = childContextForFrac(context);
-
-            const typesetChildren = getTypesetChildren(
-                zipper,
-                focus,
-                () => childContext,
-            );
-
-            return typesetTable(typesetChildren, focus, context);
+            return typesetTable(typesetChild, focus, context);
         }
         default:
             throw new UnreachableCaseError(focus);
@@ -251,23 +145,12 @@ const typesetNode = (
             return typesetRow(node, context);
         }
         case "frac": {
-            const childContext = childContextForFrac(context);
-
-            const typesetChildren = node.children.map((child) =>
-                typesetRow(child, childContext),
-            );
-
-            return typesetFrac(typesetChildren, node, context);
+            const typesetChild = getTypesetChildFromNodes(node.children);
+            return typesetFrac(typesetChild, node, context);
         }
         case "subsup": {
-            const childContext = childContextForSubsup(context);
-
-            const typesetChildren = node.children.map(
-                (child) => child && typesetRow(child, childContext),
-            );
-
             return typesetSubsup(
-                typesetChildren,
+                getTypesetChildFromNodes(node.children),
                 node,
                 context,
                 prevEditNode,
@@ -275,45 +158,20 @@ const typesetNode = (
             );
         }
         case "root": {
-            const [deg, rad] = node.children;
-
-            const radicand = typesetRow(rad, context);
-            const degree =
-                deg &&
-                typesetRow(deg, {
-                    ...context,
-                    // It doesn't matter what the mathStyle is of the parent, we
-                    // always use ScriptScript for root indicies.
-                    mathStyle: MathStyle.ScriptScript,
-                });
-
-            return typesetRoot([degree, radicand], node, context);
+            const typesetChild = getTypesetChildFromNodes(node.children);
+            return typesetRoot(typesetChild, node, context);
         }
         case "limits": {
-            // TODO: render as a subsup if mathStyle isn't MathStyle.Display
-            const childContext = childContextForLimits(context);
-
-            const typesetChildren = node.children.map(
-                (child) => child && typesetRow(child, childContext),
-            );
-
-            return typesetLimits(typesetChildren, node, context, typesetNode);
+            const typesetChild = getTypesetChildFromNodes(node.children);
+            return typesetLimits(typesetChild, node, context, typesetNode);
         }
         case "delimited": {
-            const typesetChildren = node.children.map((child) =>
-                typesetRow(child, context),
-            );
-
-            return typesetDelimited(typesetChildren, node, context);
+            const typesetChild = getTypesetChildFromNodes(node.children);
+            return typesetDelimited(typesetChild, node, context);
         }
         case "table": {
-            const childContext = childContextForFrac(context);
-
-            const typesetChildren = node.children.map((child) => {
-                return child && typesetRow(child, childContext);
-            });
-
-            return typesetTable(typesetChildren, node, context);
+            const typesetChild = getTypesetChildFromNodes(node.children);
+            return typesetTable(typesetChild, node, context);
         }
         case "atom": {
             return typesetAtom(node, context);

--- a/packages/typesetter/src/typesetters/delimited.ts
+++ b/packages/typesetter/src/typesetters/delimited.ts
@@ -6,7 +6,7 @@ import {makeDelimiter} from "../utils";
 import type {Context} from "../types";
 
 export const typesetDelimited = (
-    typesetChildren: readonly (Layout.HBox | null)[],
+    typesetChild: (index: number, context: Context) => Layout.HBox | null,
     node: Editor.types.Delimited | Editor.ZDelimited,
     context: Context,
 ): Layout.HBox => {
@@ -15,7 +15,7 @@ export const typesetDelimited = (
         strict: true,
     };
 
-    const row = typesetChildren[0];
+    const row = typesetChild(0, context);
     if (!row) {
         throw new Error("Delimited's content should be defined");
     }

--- a/packages/typesetter/src/typesetters/frac.ts
+++ b/packages/typesetter/src/typesetters/frac.ts
@@ -11,12 +11,33 @@ const makeList = (
     box: Layout.HBox,
 ): readonly Layout.Node[] => [Layout.makeKern(size), box];
 
+const childContextForFrac = (context: Context): Context => {
+    const {mathStyle} = context;
+
+    const childMathStyle = {
+        [MathStyle.Display]: MathStyle.Text,
+        [MathStyle.Text]: MathStyle.Script,
+        [MathStyle.Script]: MathStyle.ScriptScript,
+        [MathStyle.ScriptScript]: MathStyle.ScriptScript,
+    }[mathStyle];
+
+    const childContext: Context = {
+        ...context,
+        mathStyle: childMathStyle,
+    };
+
+    return childContext;
+};
+
 export const typesetFrac = (
-    typesetChildren: readonly (Layout.HBox | null)[],
+    typesetChild: (index: number, context: Context) => Layout.HBox | null,
     node: Editor.types.Frac | Editor.ZFrac,
     context: Context,
 ): Layout.VBox => {
-    let [numBox, denBox] = typesetChildren;
+    const childContext = childContextForFrac(context);
+    let numBox = typesetChild(0, childContext);
+    let denBox = typesetChild(1, childContext);
+
     if (!numBox || !denBox) {
         throw new Error("The numerator and denominator must both be defined");
     }

--- a/packages/typesetter/src/typesetters/limits.ts
+++ b/packages/typesetter/src/typesetters/limits.ts
@@ -1,17 +1,39 @@
 import * as Editor from "@math-blocks/editor-core";
 
 import * as Layout from "../layout";
+import {MathStyle} from "../enums";
 
 import type {Context} from "../types";
 
-// TODO: render as a subsup if mathStyle isn't MathStyle.Display
+const childContextForLimits = (context: Context): Context => {
+    const {mathStyle} = context;
+
+    const childMathStyle = {
+        [MathStyle.Display]: MathStyle.Script,
+        [MathStyle.Text]: MathStyle.Script,
+        [MathStyle.Script]: MathStyle.ScriptScript,
+        [MathStyle.ScriptScript]: MathStyle.ScriptScript,
+    }[mathStyle];
+
+    const childContext: Context = {
+        ...context,
+        mathStyle: childMathStyle,
+        cramped: true,
+    };
+
+    return childContext;
+};
+
+// TODO: render as a subsup if context.mathStyle isn't MathStyle.Display
 export const typesetLimits = (
-    typesetChildren: readonly (Layout.HBox | null)[],
+    typesetChild: (index: number, context: Context) => Layout.HBox | null,
     node: Editor.types.Limits | Editor.ZLimits,
     context: Context,
     typesetNode: (node: Editor.types.Node, context: Context) => Layout.Node,
 ): Layout.VBox => {
-    const [lowerBox, upperBox] = typesetChildren;
+    const childContext = childContextForLimits(context);
+    const lowerBox = typesetChild(0, childContext);
+    const upperBox = typesetChild(1, childContext);
 
     if (!lowerBox) {
         throw new Error("Lower limit should always be defined");

--- a/packages/typesetter/src/typesetters/root.ts
+++ b/packages/typesetter/src/typesetters/root.ts
@@ -1,6 +1,7 @@
 import * as Editor from "@math-blocks/editor-core";
 
 import * as Layout from "../layout";
+import {MathStyle} from "../enums";
 
 import {RadicalDegreeAlgorithm} from "../enums";
 import {
@@ -12,11 +13,18 @@ import {
 import type {Context} from "../types";
 
 export const typesetRoot = (
-    typesetChildren: readonly (Layout.HBox | null)[],
+    typesetChild: (index: number, context: Context) => Layout.HBox | null,
     node: Editor.types.Root | Editor.ZRoot,
     context: Context,
 ): Layout.HBox => {
-    const [degree, radicand] = typesetChildren;
+    const degreeContext = {
+        ...context,
+        // It doesn't matter what the mathStyle is of the parent, we
+        // always use ScriptScript for root indicies.
+        mathStyle: MathStyle.ScriptScript,
+    };
+    const degree = typesetChild(0, degreeContext);
+    const radicand = typesetChild(1, context);
 
     if (!radicand) {
         throw new Error("Radicand must be defined");

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -2,6 +2,7 @@ import * as Editor from "@math-blocks/editor-core";
 
 import * as Layout from "../layout";
 import {fontSizeForContext, makeDelimiter} from "../utils";
+import {MathStyle} from "../enums";
 
 import type {Context} from "../types";
 
@@ -17,13 +18,32 @@ type Col = {
 
 const COL_GAP = 50;
 
+const childContextForTable = (context: Context): Context => {
+    const {mathStyle} = context;
+
+    const childMathStyle = {
+        [MathStyle.Display]: MathStyle.Text,
+        [MathStyle.Text]: MathStyle.Script,
+        [MathStyle.Script]: MathStyle.ScriptScript,
+        [MathStyle.ScriptScript]: MathStyle.ScriptScript,
+    }[mathStyle];
+
+    const childContext: Context = {
+        ...context,
+        mathStyle: childMathStyle,
+    };
+
+    return childContext;
+};
+
 export const typesetTable = (
-    typesetChildren: (Layout.HBox | null)[],
+    typesetChild: (index: number, context: Context) => Layout.HBox | null,
     node: Editor.types.Table | Editor.ZTable,
     context: Context,
 ): Layout.HBox | Layout.VBox => {
     const columns: Col[] = [];
     const rows: Row[] = [];
+    const childContext = childContextForTable(context);
 
     // Group cells into rows and columns and determine the width of each
     // columna and the depth/height of each row.
@@ -42,7 +62,7 @@ export const typesetTable = (
                     depth: 0,
                 };
             }
-            let cell = typesetChildren[j * node.colCount + i];
+            let cell = typesetChild(j * node.colCount + i, childContext);
             if (cell) {
                 columns[i].width = Math.max(cell.width, columns[i].width);
                 rows[j].height = Math.max(cell.height, rows[j].height);


### PR DESCRIPTION
Replacing `getTypesetChildren` with functions that return callbacks that can be used by each specific node typesetter allows us to move node specific logic into those functions.