### PR TITLE
Convert row to table when pressing down

### DIFF
--- a/demo/src/editor/editor-page.tsx
+++ b/demo/src/editor/editor-page.tsx
@@ -9,7 +9,7 @@ import {RadicalDegreeAlgorithm} from "@math-blocks/typesetter";
 import FormattingPalette from "./formatting-palette";
 import {examples} from "./examples";
 
-const initialExample = 5;
+const initialExample = 0;
 
 const EditorPage: React.FunctionComponent = () => {
     const [stixFontData, setStixFontData] = React.useState<FontData | null>(
@@ -19,10 +19,8 @@ const EditorPage: React.FunctionComponent = () => {
     const [bonumFontData, setBonumFontData] = React.useState<FontData | null>(
         null,
     );
-    const [
-        pagellaFontData,
-        setPagellaFontData,
-    ] = React.useState<FontData | null>(null);
+    const [pagellaFontData, setPagellaFontData] =
+        React.useState<FontData | null>(null);
     const [scholaFontData, setScholaFontData] = React.useState<FontData | null>(
         null,
     );
@@ -43,9 +41,8 @@ const EditorPage: React.FunctionComponent = () => {
         },
     });
 
-    const [radicalDegreeAlgorithm, setRadicalDegreeAlgorithm] = React.useState<
-        RadicalDegreeAlgorithm
-    >(RadicalDegreeAlgorithm.OpenType);
+    const [radicalDegreeAlgorithm, setRadicalDegreeAlgorithm] =
+        React.useState<RadicalDegreeAlgorithm>(RadicalDegreeAlgorithm.OpenType);
 
     const [showHitboxes, setShowHitboxes] = React.useState<boolean>(false);
 

--- a/demo/src/editor/examples.ts
+++ b/demo/src/editor/examples.ts
@@ -3,7 +3,6 @@ import {builders} from "@math-blocks/editor-core";
 const simpleRow = builders.row([
     builders.glyph("2"),
     builders.glyph("x"),
-    builders.subsup(undefined, [builders.glyph("2")]),
     builders.glyph("+"),
     builders.glyph("5"),
     builders.glyph("="),

--- a/demo/src/editor/examples.ts
+++ b/demo/src/editor/examples.ts
@@ -135,7 +135,7 @@ addingFractions.children[2].children[0].children[0].style.color = "pink";
 const matrix = builders.row([
     builders.glyph("A"),
     builders.glyph("="),
-    builders.table(
+    builders.matrix(
         [
             // first row
             [builders.glyph("a")],

--- a/packages/editor-core/src/ast/builders.ts
+++ b/packages/editor-core/src/ast/builders.ts
@@ -76,6 +76,7 @@ export function delimited(
 }
 
 export function table(
+    subtype: "matrix" | "algebra",
     cells: (readonly types.Node[] | null)[],
     colCount: number,
     rowCount: number,
@@ -87,12 +88,26 @@ export function table(
     return {
         id: getId(),
         type: "table",
+        subtype,
         children: cells.map((cell) => cell && row(cell)),
         colCount,
         rowCount,
         delimiters,
         style: {},
+        gutterWidth: 0,
     };
+}
+
+export function matrix(
+    cells: (readonly types.Node[] | null)[],
+    colCount: number,
+    rowCount: number,
+    delimiters?: {
+        left: types.Atom;
+        right: types.Atom;
+    },
+): types.Table {
+    return table("matrix", cells, colCount, rowCount, delimiters);
 }
 
 export function atom(value: types.Glyph): types.Atom {

--- a/packages/editor-core/src/ast/builders.ts
+++ b/packages/editor-core/src/ast/builders.ts
@@ -84,6 +84,7 @@ export function table(
         left: types.Atom;
         right: types.Atom;
     },
+    gutterWidth?: number,
 ): types.Table {
     return {
         id: getId(),
@@ -94,8 +95,16 @@ export function table(
         rowCount,
         delimiters,
         style: {},
-        gutterWidth: undefined,
+        gutterWidth,
     };
+}
+
+export function algebra(
+    cells: (readonly types.Node[] | null)[],
+    colCount: number,
+    rowCount: number,
+): types.Table {
+    return table("algebra", cells, colCount, rowCount, undefined, 0);
 }
 
 export function matrix(

--- a/packages/editor-core/src/ast/builders.ts
+++ b/packages/editor-core/src/ast/builders.ts
@@ -94,7 +94,7 @@ export function table(
         rowCount,
         delimiters,
         style: {},
-        gutterWidth: 0,
+        gutterWidth: undefined,
     };
 }
 

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -14,6 +14,7 @@ export {
     selectionZipperFromZippers,
 } from "./reducer/convert";
 export {stateFromZipper} from "./reducer/test-util";
+export {zrowToRow} from "./reducer/util";
 export type {
     Breadcrumb,
     Focus,

--- a/packages/editor-core/src/parser/lexer.ts
+++ b/packages/editor-core/src/parser/lexer.ts
@@ -95,7 +95,8 @@ export type Token =
     | Lim
     | EOL;
 
-const TOKEN_REGEX = /([1-9]*[0-9]\.?[0-9]*|\.[0-9]+)|(\*|\u00B7|\u00B1|\+|\u2212|=|\(|\)|\.\.\.)|(sin|cos|tan|[a-z])/gi;
+const TOKEN_REGEX =
+    /([1-9]*[0-9]\.?[0-9]*|\.[0-9]+)|(\*|\u00B7|\u00B1|\+|\u2212|=|\(|\)|\.\.\.)|(sin|cos|tan|[a-z])/gi;
 
 // TODO: include ids of source glyphs in parsed tokens
 
@@ -311,6 +312,7 @@ const lex = (node: types.Node, path: number[], offset: number): Node => {
         case "table": {
             return {
                 type: "table",
+                subtype: node.subtype,
                 colCount: node.colCount,
                 rowCount: node.rowCount,
                 children: node.children.map((child) => child && lexRow(child)),

--- a/packages/editor-core/src/reducer/__tests__/matrix.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/matrix.test.ts
@@ -32,7 +32,7 @@ describe("matrix", () => {
             });
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("1")],
                         [builders.glyph("0")],
@@ -67,7 +67,7 @@ describe("matrix", () => {
             });
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("1")],
                         [builders.glyph("0")],
@@ -111,7 +111,7 @@ describe("matrix", () => {
             expect(result.breadcrumbs).toHaveLength(0);
             expect(result.row.left).toEqualEditorNodes([
                 builders.glyph("1"),
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("1")],
                         [builders.glyph("0")],
@@ -137,7 +137,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -162,7 +162,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("0")],
                         [builders.glyph("0")],
@@ -182,7 +182,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -207,7 +207,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("a")],
                         [builders.glyph("b")],
@@ -226,7 +226,7 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -252,7 +252,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("a")],
                         [builders.glyph("b")],
@@ -274,7 +274,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -299,7 +299,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("0")],
                         [builders.glyph("a")],
@@ -319,7 +319,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -344,7 +344,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("a")],
                         [builders.glyph("0")],
@@ -363,7 +363,7 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -389,7 +389,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [
                         [builders.glyph("a")],
                         [builders.glyph("b")],
@@ -411,7 +411,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -436,7 +436,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [[builders.glyph("c")], [builders.glyph("d")]],
                     2,
                     1,
@@ -448,7 +448,7 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -474,7 +474,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [[builders.glyph("a")], [builders.glyph("b")]],
                     2,
                     1,
@@ -487,7 +487,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -522,7 +522,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -547,7 +547,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [[builders.glyph("b")], [builders.glyph("d")]],
                     1,
                     2,
@@ -558,7 +558,7 @@ describe("matrix", () => {
             const zipper: Zipper = {
                 row: zrow(
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],
@@ -584,7 +584,7 @@ describe("matrix", () => {
 
             const row = zipperToRow(state.zipper);
             expect(row.children).toEqualEditorNodes([
-                builders.table(
+                builders.matrix(
                     [[builders.glyph("a")], [builders.glyph("c")]],
                     1,
                     2,
@@ -596,7 +596,7 @@ describe("matrix", () => {
                 row: zrow(
                     [],
                     [
-                        builders.table(
+                        builders.matrix(
                             [
                                 [builders.glyph("a")],
                                 [builders.glyph("b")],

--- a/packages/editor-core/src/reducer/__tests__/matrix.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/matrix.test.ts
@@ -161,6 +161,19 @@ describe("matrix", () => {
             state = matrix(state, {type: "AddRow", side: "above"});
 
             const row = zipperToRow(state.zipper);
+            row.children; // ?
+            builders.matrix(
+                [
+                    [builders.glyph("0")],
+                    [builders.glyph("0")],
+                    [builders.glyph("a")],
+                    [builders.glyph("b")],
+                    [builders.glyph("c")],
+                    [builders.glyph("d")],
+                ],
+                2,
+                3,
+            ); // ?
             expect(row.children).toEqualEditorNodes([
                 builders.matrix(
                     [

--- a/packages/editor-core/src/reducer/__tests__/move-verticaly.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/move-verticaly.test.ts
@@ -4,19 +4,11 @@ import {moveLeft} from "../move-left";
 import {moveRight} from "../move-right";
 import {moveVertically} from "../move-vertically";
 import {toEqualEditorNodes, zrow} from "../test-util";
+import {zipperToState} from "../util";
 
-import type {Zipper, State} from "../types";
+import type {Zipper} from "../types";
 
 expect.extend({toEqualEditorNodes});
-
-const zipperToState = (zipper: Zipper): State => {
-    return {
-        startZipper: zipper,
-        endZipper: zipper,
-        zipper: zipper,
-        selecting: false,
-    };
-};
 
 describe("moveVertically", () => {
     const smallTable = builders.table(

--- a/packages/editor-core/src/reducer/__tests__/move-verticaly.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/move-verticaly.test.ts
@@ -11,7 +11,7 @@ import type {Zipper} from "../types";
 expect.extend({toEqualEditorNodes});
 
 describe("moveVertically", () => {
-    const smallTable = builders.table(
+    const smallTable = builders.matrix(
         [
             [builders.glyph("a")],
             [builders.glyph("b")],
@@ -22,7 +22,7 @@ describe("moveVertically", () => {
         2,
     );
 
-    const largeTable = builders.table(
+    const largeTable = builders.matrix(
         [
             [builders.glyph("a")],
             [builders.glyph("b")],
@@ -131,7 +131,7 @@ describe("moveVertically", () => {
         const zipper: Zipper = {
             row: zrow(
                 [
-                    builders.table(
+                    builders.matrix(
                         [
                             [builders.glyph("a")],
                             [builders.glyph("b")],

--- a/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
@@ -1,0 +1,52 @@
+import {verticalWork} from "../vertical-work";
+import {stateFromZipper, toEqualEditorNodes, row, zrow} from "../test-util";
+
+import type {Zipper} from "../types";
+
+expect.extend({toEqualEditorNodes});
+
+describe("verticalWork", () => {
+    test("pressing down splits the row into a table", () => {
+        const zipper: Zipper = {
+            row: zrow([], row("2x+5=10").children),
+            breadcrumbs: [],
+        };
+        const state = stateFromZipper(zipper);
+
+        const newState = verticalWork(state);
+
+        const focus = newState.zipper.breadcrumbs[0].focus;
+        if (focus.type !== "ztable") {
+            throw new Error("focus should be a ZTable");
+        }
+        expect(focus.left).toHaveLength(10);
+
+        // Empty cells are place at the start and end
+        expect(focus.left[0]?.children).toEqualEditorNodes([]);
+        expect(focus.left[1]?.children).toEqualEditorNodes(row("2x").children);
+        // Empty cells are placed in front of each plus/minus opeartor
+        expect(focus.left[2]?.children).toEqualEditorNodes([]);
+        expect(focus.left[3]?.children).toEqualEditorNodes(row("+").children);
+        expect(focus.left[4]?.children).toEqualEditorNodes(row("5").children);
+        // Empty cells are placed around each relationship operator
+        expect(focus.left[5]?.children).toEqualEditorNodes([]);
+        expect(focus.left[6]?.children).toEqualEditorNodes(row("=").children);
+        expect(focus.left[7]?.children).toEqualEditorNodes([]);
+        expect(focus.left[8]?.children).toEqualEditorNodes(row("10").children);
+        expect(focus.left[9]?.children).toEqualEditorNodes([]);
+
+        // The cursor is placed in the first column of the second row
+        expect(focus.right).toHaveLength(9);
+
+        // All cells in the second row are empty to being with
+        expect(focus.right[0]?.children).toEqualEditorNodes([]);
+        expect(focus.right[1]?.children).toEqualEditorNodes([]);
+        expect(focus.right[2]?.children).toEqualEditorNodes([]);
+        expect(focus.right[3]?.children).toEqualEditorNodes([]);
+        expect(focus.right[4]?.children).toEqualEditorNodes([]);
+        expect(focus.right[5]?.children).toEqualEditorNodes([]);
+        expect(focus.right[6]?.children).toEqualEditorNodes([]);
+        expect(focus.right[7]?.children).toEqualEditorNodes([]);
+        expect(focus.right[8]?.children).toEqualEditorNodes([]);
+    });
+});

--- a/packages/editor-core/src/reducer/matrix.ts
+++ b/packages/editor-core/src/reducer/matrix.ts
@@ -127,7 +127,7 @@ export const matrix = (state: State, action: MatrixActions): State => {
     if (action.type === "InsertMatrix") {
         const zipper = state.zipper;
         const {left, selection} = zipper.row;
-        const newNode = builders.table(
+        const newNode = builders.matrix(
             [
                 [builders.glyph("1")],
                 [builders.glyph("0")],

--- a/packages/editor-core/src/reducer/move-vertically.ts
+++ b/packages/editor-core/src/reducer/move-vertically.ts
@@ -9,7 +9,7 @@ export const moveVertically = (
     direction: "up" | "down",
 ): State => {
     if (state.selecting) {
-        return verticalWork(state);
+        return direction === "down" ? verticalWork(state) : state;
     }
 
     const {breadcrumbs} = state.zipper;
@@ -98,5 +98,5 @@ export const moveVertically = (
         };
     }
 
-    return verticalWork(state);
+    return direction === "down" ? verticalWork(state) : state;
 };

--- a/packages/editor-core/src/reducer/move-vertically.ts
+++ b/packages/editor-core/src/reducer/move-vertically.ts
@@ -1,5 +1,6 @@
 import * as types from "../ast/types";
 import * as util from "./util";
+import {verticalWork} from "./vertical-work";
 
 import type {ZRow, Zipper, State} from "./types";
 
@@ -8,7 +9,7 @@ export const moveVertically = (
     direction: "up" | "down",
 ): State => {
     if (state.selecting) {
-        return state;
+        return verticalWork(state);
     }
 
     const {breadcrumbs} = state.zipper;
@@ -97,5 +98,5 @@ export const moveVertically = (
         };
     }
 
-    return state;
+    return verticalWork(state);
 };

--- a/packages/editor-core/src/reducer/util.ts
+++ b/packages/editor-core/src/reducer/util.ts
@@ -11,6 +11,8 @@ import type {
     ZDelimited,
     Focus,
     ZTable,
+    Zipper,
+    State,
 } from "./types";
 
 export const frac = (focus: ZFrac, replacement: types.Row): types.Frac => {
@@ -149,6 +151,7 @@ export const table = (focus: ZTable, replacement: types.Row): types.Table => {
         rowCount: focus.rowCount,
         colCount: focus.colCount,
         delimiters: focus.delimiters,
+        gutterWidth: focus.gutterWidth,
         children: [...focus.left, replacement, ...focus.right],
         style: focus.style,
     };
@@ -161,6 +164,7 @@ export const ztable = (node: types.Table, index: number): ZTable => {
         rowCount: node.rowCount,
         colCount: node.colCount,
         delimiters: node.delimiters,
+        gutterWidth: node.gutterWidth,
         left: node.children.slice(0, index),
         right: node.children.slice(index + 1),
         style: node.style,
@@ -290,3 +294,12 @@ export const zrow = (
     right,
     style: style ?? {},
 });
+
+export const zipperToState = (zipper: Zipper): State => {
+    return {
+        startZipper: zipper,
+        endZipper: zipper,
+        zipper: zipper,
+        selecting: false,
+    };
+};

--- a/packages/editor-core/src/reducer/util.ts
+++ b/packages/editor-core/src/reducer/util.ts
@@ -148,6 +148,7 @@ export const table = (focus: ZTable, replacement: types.Row): types.Table => {
     return {
         id: focus.id,
         type: "table",
+        subtype: focus.subtype,
         rowCount: focus.rowCount,
         colCount: focus.colCount,
         delimiters: focus.delimiters,
@@ -161,6 +162,7 @@ export const ztable = (node: types.Table, index: number): ZTable => {
     return {
         id: node.id,
         type: "ztable",
+        subtype: node.subtype,
         rowCount: node.rowCount,
         colCount: node.colCount,
         delimiters: node.delimiters,

--- a/packages/editor-core/src/reducer/vertical-work.ts
+++ b/packages/editor-core/src/reducer/vertical-work.ts
@@ -1,0 +1,121 @@
+import {getId} from "@math-blocks/core";
+import type {State, ZTable, Zipper} from "./types";
+
+import * as types from "../ast/types";
+import * as builders from "../ast/builders";
+import * as util from "./util";
+
+export const verticalWork = (state: State): State => {
+    // TODO:
+    // - check if cursor is at the root level
+    // - if it is, when pressing down, replace the root level row with a table
+    //   with the root level row as the first table row and an empty table row
+    //   below it
+    // - update the logic to split the root level row into multiple cells with
+    //   - empty cells being added to the start and end
+    //   - empty cells being added around relationship operators
+    //   - empty cells being added before binary plus/minus operations
+    //
+    // Does it make sense if the root is not a Row?  Is this how we could prevent
+    // users from exiting the table?
+
+    const {zipper} = state;
+
+    if (zipper.breadcrumbs.length > 0) {
+        return state;
+    }
+
+    // TODO: figure out which cell the cursor should be in after splitting up
+    // the row.
+    const row = util.zrowToRow(zipper.row);
+    const splitRows: (types.Row | null)[] = [];
+    let prevChildren: types.Node[] = [];
+    let prevChild: types.Node | null = null;
+    // Invariants:
+    // - child is either directly to splitRows in its own cell or it's added to
+    //   prevChildren
+    for (const child of row.children) {
+        if (
+            child.type === "atom" &&
+            ["+", "\u2212"].includes(child.value.char)
+        ) {
+            if (
+                prevChild?.type !== "atom" ||
+                !["+", "\u2212"].includes(prevChild.value.char)
+            ) {
+                if (prevChildren.length > 0) {
+                    splitRows.push(builders.row(prevChildren));
+                    prevChildren = [];
+                }
+                // Place an extra cell in front of the '+'
+                splitRows.push(builders.row([]));
+                // splitRows.push(builders.row([]));
+                // splitRows.push(null);
+                splitRows.push(null);
+                splitRows.push(builders.row([child]));
+            } else {
+                prevChildren.push(child);
+            }
+        } else if (
+            child.type === "atom" &&
+            ["=", ">", "<"].includes(child.value.char)
+        ) {
+            if (prevChildren.length > 0) {
+                splitRows.push(builders.row(prevChildren));
+                prevChildren = [];
+            }
+            // Place extra cells around the '='
+            splitRows.push(builders.row([]));
+            splitRows.push(builders.row([child]));
+            splitRows.push(builders.row([]));
+        } else {
+            prevChildren.push(child);
+        }
+        prevChild = child;
+    }
+    if (prevChildren.length > 0) {
+        splitRows.push(builders.row(prevChildren));
+    }
+
+    const left = [builders.row([]), ...splitRows, builders.row([])];
+    // left.push(builders.row([])); // first cell in second table row
+    const right: (types.Row | null)[] = [];
+    // empty cells below first table row's splitRows
+    for (let i = 0; i < splitRows.length; i++) {
+        if (splitRows[i] == null) {
+            right.push(null);
+        } else {
+            right.push(builders.row([]));
+        }
+    }
+    right.push(builders.row([])); // last cell in second table row
+
+    const table: ZTable = {
+        id: getId(),
+        type: "ztable",
+        rowCount: 2,
+        colCount: splitRows.length + 2,
+        left,
+        right,
+        style: {},
+        gutterWidth: 0,
+    };
+
+    const newZipper: Zipper = {
+        row: util.zrow(getId(), [], []),
+        breadcrumbs: [
+            {
+                row: {
+                    id: getId(),
+                    type: "bcrow",
+                    left: [],
+                    right: [],
+                    style: {},
+                },
+                focus: table,
+            },
+        ],
+    };
+
+    return util.zipperToState(newZipper);
+};

--- a/packages/editor-core/src/reducer/vertical-work.ts
+++ b/packages/editor-core/src/reducer/vertical-work.ts
@@ -6,16 +6,6 @@ import * as builders from "../ast/builders";
 import * as util from "./util";
 
 export const verticalWork = (state: State): State => {
-    // TODO:
-    // - check if cursor is at the root level
-    // - if it is, when pressing down, replace the root level row with a table
-    //   with the root level row as the first table row and an empty table row
-    //   below it
-    // - update the logic to split the root level row into multiple cells with
-    //   - empty cells being added to the start and end
-    //   - empty cells being added around relationship operators
-    //   - empty cells being added before binary plus/minus operations
-    //
     // Does it make sense if the root is not a Row?  Is this how we could prevent
     // users from exiting the table?
 

--- a/packages/editor-core/src/reducer/vertical-work.ts
+++ b/packages/editor-core/src/reducer/vertical-work.ts
@@ -49,9 +49,6 @@ export const verticalWork = (state: State): State => {
                 }
                 // Place an extra cell in front of the '+'
                 splitRows.push(builders.row([]));
-                // splitRows.push(builders.row([]));
-                // splitRows.push(null);
-                splitRows.push(null);
                 splitRows.push(builders.row([child]));
             } else {
                 prevChildren.push(child);
@@ -93,6 +90,7 @@ export const verticalWork = (state: State): State => {
     const table: ZTable = {
         id: getId(),
         type: "ztable",
+        subtype: "algebra",
         rowCount: 2,
         colCount: splitRows.length + 2,
         left,

--- a/packages/editor-core/src/shared-types.ts
+++ b/packages/editor-core/src/shared-types.ts
@@ -15,6 +15,7 @@ export type Delimited<A, C> = C & {
 
 export type Table<A, C> = C & {
     type: "table";
+    subtype: "matrix" | "algebra";
     children: readonly (Row<A, C> | null)[];
     rowCount: number;
     colCount: number;

--- a/packages/editor-core/src/shared-types.ts
+++ b/packages/editor-core/src/shared-types.ts
@@ -18,6 +18,7 @@ export type Table<A, C> = C & {
     children: readonly (Row<A, C> | null)[];
     rowCount: number;
     colCount: number;
+    gutterWidth?: number;
     // How do we limit what can be used as a delimiter?s
     delimiters?: {
         left: Atom<A, C>;

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 377.96000000000004 186.06" width="377.96000000000004" height="186.06" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 477.96000000000004 186.06" width="477.96000000000004" height="186.06" style="background:white">
     <g fill="currentColor" stroke="currentColor">
         <g transform="translate(0,109.2)" id="25">
             <g transform="translate(43.08,0)" id="1"></g>
@@ -7,20 +7,20 @@
                 <g transform="translate(31.68,0)" id="undefined">
                     <g transform="translate(0,-59.28)" id="undefined">
                         <g transform="translate(0,0)" id="16"></g>
-                        <g transform="translate(33.36,0)" id="17"></g>
-                        <g transform="translate(161.7,0)" id="18"></g>
+                        <g transform="translate(58.36,0)" id="17"></g>
+                        <g transform="translate(236.7,0)" id="18"></g>
                     </g>
                     <g transform="translate(0,0.7199999999999989)" id="undefined">
                         <g transform="translate(0,0)" id="19"></g>
-                        <g transform="translate(33.36,0)" id="20">
-                            <g transform="translate(25.44,0)" id="7"></g>
+                        <g transform="translate(58.36,0)" id="20">
+                            <g transform="translate(50.44,0)" id="7"></g>
                         </g>
-                        <g transform="translate(161.7,0)" id="21"></g>
+                        <g transform="translate(236.7,0)" id="21"></g>
                     </g>
                     <g transform="translate(0,60.72)" id="undefined">
                         <g transform="translate(0,0)" id="22"></g>
-                        <g transform="translate(33.36,0)" id="23"></g>
-                        <g transform="translate(161.7,0)" id="24"></g>
+                        <g transform="translate(58.36,0)" id="23"></g>
+                        <g transform="translate(236.7,0)" id="24"></g>
                     </g>
                 </g>
             </g>
@@ -37,41 +37,41 @@
                         <g transform="translate(0,0)" id="16">
                             <path id="2" style="opacity:1" aria-hidden="true" d="M 502,472 L 449,472 L 413,426 L 409,426 C 388,456 358,479 305,479C 174,479 49,341 49,159C 49,43 100,-12 172,-12C 229,-12 288,22 339,85L 346,85 C 343,67 339,53 339,38C 339,5 359,-10 395,-10C 455,-10 497,33 539,97L 519,112 C 506,95 477,60 445,60C 429,60 425,68 425,81C 425,96 430,118 430,118ZM 389,344 C 389,313 378,240 358,181C 329,96 285,54 218,54C 168,54 138,77 138,169C 138,303 202,441 302,441C 358,441 389,397 389,344Z" transform="translate(0.030000000000001137, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(33.36,0)" id="17">
-                            <path id="3" style="opacity:1" aria-hidden="true" d="M 198,402 L 257,705 L 235,705 L 97,694 L 97,668 C 97,668 116,670 127,670C 147,670 163,663 163,641C 163,629 160,610 159,606L 46,25 C 95,0 146,-12 204,-12C 382,-12 483,140 483,304C 483,424 421,479 342,479C 289,479 246,450 203,402ZM 184,316 C 205,363 249,423 313,423C 358,423 395,390 395,300C 395,148 338,30 219,30C 177,30 148,54 135,66Z" transform="translate(48.63, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(58.36,0)" id="17">
+                            <path id="3" style="opacity:1" aria-hidden="true" d="M 198,402 L 257,705 L 235,705 L 97,694 L 97,668 C 97,668 116,670 127,670C 147,670 163,663 163,641C 163,629 160,610 159,606L 46,25 C 95,0 146,-12 204,-12C 382,-12 483,140 483,304C 483,424 421,479 342,479C 289,479 246,450 203,402ZM 184,316 C 205,363 249,423 313,423C 358,423 395,390 395,300C 395,148 338,30 219,30C 177,30 148,54 135,66Z" transform="translate(73.63, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(161.7,0)" id="18">
-                            <path id="4" style="opacity:1" aria-hidden="true" d="M 358,123 C 327,85 288,57 219,57C 161,57 109,77 109,184C 109,300 170,446 280,446C 312,446 329,434 329,419C 329,403 310,375 310,349C 310,327 324,314 348,314C 385,314 404,346 404,386C 404,451 353,479 290,479C 146,479 26,335 26,169C 26,68 71,-12 179,-12C 269,-12 334,44 375,108Z" transform="translate(4.889999999999999, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(236.7,0)" id="18">
+                            <path id="4" style="opacity:1" aria-hidden="true" d="M 358,123 C 327,85 288,57 219,57C 161,57 109,77 109,184C 109,300 170,446 280,446C 312,446 329,434 329,419C 329,403 310,375 310,349C 310,327 324,314 348,314C 385,314 404,346 404,386C 404,451 353,479 290,479C 146,479 26,335 26,169C 26,68 71,-12 179,-12C 269,-12 334,44 375,108Z" transform="translate(29.89, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                     <g transform="translate(0,0.7199999999999989)" id="undefined">
                         <g transform="translate(0,0)" id="19">
                             <path id="5" style="opacity:1" aria-hidden="true" d="M 529,705 L 507,705 L 371,694 L 371,668 C 371,668 390,670 402,670C 432,670 437,656 437,639C 437,625 434,607 434,607L 401,439 L 398,439 C 374,464 341,479 296,479C 157,479 37,340 37,162C 37,45 89,-12 163,-12C 222,-12 279,24 329,85L 337,85 C 335,73 332,54 332,42C 332,11 353,-10 393,-10C 462,-10 499,53 530,97L 510,112 C 496,93 469,60 437,60C 424,60 418,65 418,79C 418,92 423,121 423,121ZM 346,177 C 319,101 274,54 206,54C 157,54 126,78 126,169C 126,299 190,441 291,441C 349,441 377,394 377,351C 377,333 372,252 346,177Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(33.36,0)" id="20">
-                            <path id="6" style="opacity:1" aria-hidden="true" d="M 357,122 C 317,72 262,57 216,57C 149,57 112,88 112,189L 112,202 C 228,211 404,262 404,390C 404,467 339,479 296,479C 139,479 28,319 28,164C 28,84 58,-12 177,-12C 243,-12 315,17 375,107ZM 114,231 C 133,330 202,448 276,448C 306,448 318,428 318,393C 318,298 227,238 114,231Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-                            <g transform="translate(25.44,0)" id="7">
+                        <g transform="translate(58.36,0)" id="20">
+                            <path id="6" style="opacity:1" aria-hidden="true" d="M 357,122 C 317,72 262,57 216,57C 149,57 112,88 112,189L 112,202 C 228,211 404,262 404,390C 404,467 339,479 296,479C 139,479 28,319 28,164C 28,84 58,-12 177,-12C 243,-12 315,17 375,107ZM 114,231 C 133,330 202,448 276,448C 306,448 318,428 318,393C 318,298 227,238 114,231Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
+                            <g transform="translate(50.44,0)" id="7">
                                 <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                             </g>
-                            <path id="8" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(98.64, 0) scale(0.06, -0.06)"></path>
+                            <path id="8" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(123.64, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(161.7,0)" id="21">
-                            <path id="9" style="opacity:1" aria-hidden="true" d="M 190,467 L 186,426 L 270,426 L 205,37 C 194,-29 168,-193 115,-193C 77,-193 110,-104 50,-104C 24,-104 10,-125 10,-153C 10,-188 35,-225 99,-225C 236,-225 282,-1 296,85L 353,426 L 447,426 L 453,467 L 358,467 L 370,538 C 385,623 410,682 461,682C 485,682 487,658 491,633C 494,612 504,594 531,594C 552,594 571,609 571,638C 571,681 537,711 476,711C 390,711 349,665 323,618C 300,577 288,523 276,467Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(236.7,0)" id="21">
+                            <path id="9" style="opacity:1" aria-hidden="true" d="M 190,467 L 186,426 L 270,426 L 205,37 C 194,-29 168,-193 115,-193C 77,-193 110,-104 50,-104C 24,-104 10,-125 10,-153C 10,-188 35,-225 99,-225C 236,-225 282,-1 296,85L 353,426 L 447,426 L 453,467 L 358,467 L 370,538 C 385,623 410,682 461,682C 485,682 487,658 491,633C 494,612 504,594 531,594C 552,594 571,609 571,638C 571,681 537,711 476,711C 390,711 349,665 323,618C 300,577 288,523 276,467Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                     <g transform="translate(0,60.72)" id="undefined">
                         <g transform="translate(0,0)" id="22">
                             <path id="10" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(1.83, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(33.36,0)" id="23">
-                            <path id="11" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(49.32, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(58.36,0)" id="23">
+                            <path id="11" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(74.32, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(161.7,0)" id="24">
-                            <path id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(2.459999999999999, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(236.7,0)" id="24">
+                            <path id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(27.46, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                 </g>
-                <path id="undefined" style="opacity:1" aria-hidden="true" d="M 400,-1281 L 400,1820 L 110,1820 L 110,1770 L 297,1770 L 297,-1231 L 110,-1231 L 110,-1281 Z" transform="translate(228, 0) scale(0.06, -0.06)"></path>
+                <path id="undefined" style="opacity:1" aria-hidden="true" d="M 400,-1281 L 400,1820 L 110,1820 L 110,1770 L 297,1770 L 297,-1231 L 110,-1231 L 110,-1281 Z" transform="translate(328, 0) scale(0.06, -0.06)"></path>
             </g>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 477.96000000000004 186.06" width="477.96000000000004" height="186.06" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 377.96000000000004 186.06" width="377.96000000000004" height="186.06" style="background:white">
     <g fill="currentColor" stroke="currentColor">
         <g transform="translate(0,109.2)" id="25">
             <g transform="translate(43.08,0)" id="1"></g>
@@ -7,20 +7,20 @@
                 <g transform="translate(31.68,0)" id="undefined">
                     <g transform="translate(0,-59.28)" id="undefined">
                         <g transform="translate(0,0)" id="16"></g>
-                        <g transform="translate(58.36,0)" id="17"></g>
-                        <g transform="translate(236.7,0)" id="18"></g>
+                        <g transform="translate(33.36,0)" id="17"></g>
+                        <g transform="translate(161.7,0)" id="18"></g>
                     </g>
                     <g transform="translate(0,0.7199999999999989)" id="undefined">
                         <g transform="translate(0,0)" id="19"></g>
-                        <g transform="translate(58.36,0)" id="20">
-                            <g transform="translate(50.44,0)" id="7"></g>
+                        <g transform="translate(33.36,0)" id="20">
+                            <g transform="translate(25.44,0)" id="7"></g>
                         </g>
-                        <g transform="translate(236.7,0)" id="21"></g>
+                        <g transform="translate(161.7,0)" id="21"></g>
                     </g>
                     <g transform="translate(0,60.72)" id="undefined">
                         <g transform="translate(0,0)" id="22"></g>
-                        <g transform="translate(58.36,0)" id="23"></g>
-                        <g transform="translate(236.7,0)" id="24"></g>
+                        <g transform="translate(33.36,0)" id="23"></g>
+                        <g transform="translate(161.7,0)" id="24"></g>
                     </g>
                 </g>
             </g>
@@ -37,41 +37,41 @@
                         <g transform="translate(0,0)" id="16">
                             <path id="2" style="opacity:1" aria-hidden="true" d="M 502,472 L 449,472 L 413,426 L 409,426 C 388,456 358,479 305,479C 174,479 49,341 49,159C 49,43 100,-12 172,-12C 229,-12 288,22 339,85L 346,85 C 343,67 339,53 339,38C 339,5 359,-10 395,-10C 455,-10 497,33 539,97L 519,112 C 506,95 477,60 445,60C 429,60 425,68 425,81C 425,96 430,118 430,118ZM 389,344 C 389,313 378,240 358,181C 329,96 285,54 218,54C 168,54 138,77 138,169C 138,303 202,441 302,441C 358,441 389,397 389,344Z" transform="translate(0.030000000000001137, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(58.36,0)" id="17">
-                            <path id="3" style="opacity:1" aria-hidden="true" d="M 198,402 L 257,705 L 235,705 L 97,694 L 97,668 C 97,668 116,670 127,670C 147,670 163,663 163,641C 163,629 160,610 159,606L 46,25 C 95,0 146,-12 204,-12C 382,-12 483,140 483,304C 483,424 421,479 342,479C 289,479 246,450 203,402ZM 184,316 C 205,363 249,423 313,423C 358,423 395,390 395,300C 395,148 338,30 219,30C 177,30 148,54 135,66Z" transform="translate(73.63, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(33.36,0)" id="17">
+                            <path id="3" style="opacity:1" aria-hidden="true" d="M 198,402 L 257,705 L 235,705 L 97,694 L 97,668 C 97,668 116,670 127,670C 147,670 163,663 163,641C 163,629 160,610 159,606L 46,25 C 95,0 146,-12 204,-12C 382,-12 483,140 483,304C 483,424 421,479 342,479C 289,479 246,450 203,402ZM 184,316 C 205,363 249,423 313,423C 358,423 395,390 395,300C 395,148 338,30 219,30C 177,30 148,54 135,66Z" transform="translate(48.63, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(236.7,0)" id="18">
-                            <path id="4" style="opacity:1" aria-hidden="true" d="M 358,123 C 327,85 288,57 219,57C 161,57 109,77 109,184C 109,300 170,446 280,446C 312,446 329,434 329,419C 329,403 310,375 310,349C 310,327 324,314 348,314C 385,314 404,346 404,386C 404,451 353,479 290,479C 146,479 26,335 26,169C 26,68 71,-12 179,-12C 269,-12 334,44 375,108Z" transform="translate(29.89, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(161.7,0)" id="18">
+                            <path id="4" style="opacity:1" aria-hidden="true" d="M 358,123 C 327,85 288,57 219,57C 161,57 109,77 109,184C 109,300 170,446 280,446C 312,446 329,434 329,419C 329,403 310,375 310,349C 310,327 324,314 348,314C 385,314 404,346 404,386C 404,451 353,479 290,479C 146,479 26,335 26,169C 26,68 71,-12 179,-12C 269,-12 334,44 375,108Z" transform="translate(4.889999999999999, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                     <g transform="translate(0,0.7199999999999989)" id="undefined">
                         <g transform="translate(0,0)" id="19">
                             <path id="5" style="opacity:1" aria-hidden="true" d="M 529,705 L 507,705 L 371,694 L 371,668 C 371,668 390,670 402,670C 432,670 437,656 437,639C 437,625 434,607 434,607L 401,439 L 398,439 C 374,464 341,479 296,479C 157,479 37,340 37,162C 37,45 89,-12 163,-12C 222,-12 279,24 329,85L 337,85 C 335,73 332,54 332,42C 332,11 353,-10 393,-10C 462,-10 499,53 530,97L 510,112 C 496,93 469,60 437,60C 424,60 418,65 418,79C 418,92 423,121 423,121ZM 346,177 C 319,101 274,54 206,54C 157,54 126,78 126,169C 126,299 190,441 291,441C 349,441 377,394 377,351C 377,333 372,252 346,177Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(58.36,0)" id="20">
-                            <path id="6" style="opacity:1" aria-hidden="true" d="M 357,122 C 317,72 262,57 216,57C 149,57 112,88 112,189L 112,202 C 228,211 404,262 404,390C 404,467 339,479 296,479C 139,479 28,319 28,164C 28,84 58,-12 177,-12C 243,-12 315,17 375,107ZM 114,231 C 133,330 202,448 276,448C 306,448 318,428 318,393C 318,298 227,238 114,231Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
-                            <g transform="translate(50.44,0)" id="7">
+                        <g transform="translate(33.36,0)" id="20">
+                            <path id="6" style="opacity:1" aria-hidden="true" d="M 357,122 C 317,72 262,57 216,57C 149,57 112,88 112,189L 112,202 C 228,211 404,262 404,390C 404,467 339,479 296,479C 139,479 28,319 28,164C 28,84 58,-12 177,-12C 243,-12 315,17 375,107ZM 114,231 C 133,330 202,448 276,448C 306,448 318,428 318,393C 318,298 227,238 114,231Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                            <g transform="translate(25.44,0)" id="7">
                                 <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                             </g>
-                            <path id="8" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(123.64, 0) scale(0.06, -0.06)"></path>
+                            <path id="8" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(98.64, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(236.7,0)" id="21">
-                            <path id="9" style="opacity:1" aria-hidden="true" d="M 190,467 L 186,426 L 270,426 L 205,37 C 194,-29 168,-193 115,-193C 77,-193 110,-104 50,-104C 24,-104 10,-125 10,-153C 10,-188 35,-225 99,-225C 236,-225 282,-1 296,85L 353,426 L 447,426 L 453,467 L 358,467 L 370,538 C 385,623 410,682 461,682C 485,682 487,658 491,633C 494,612 504,594 531,594C 552,594 571,609 571,638C 571,681 537,711 476,711C 390,711 349,665 323,618C 300,577 288,523 276,467Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(161.7,0)" id="21">
+                            <path id="9" style="opacity:1" aria-hidden="true" d="M 190,467 L 186,426 L 270,426 L 205,37 C 194,-29 168,-193 115,-193C 77,-193 110,-104 50,-104C 24,-104 10,-125 10,-153C 10,-188 35,-225 99,-225C 236,-225 282,-1 296,85L 353,426 L 447,426 L 453,467 L 358,467 L 370,538 C 385,623 410,682 461,682C 485,682 487,658 491,633C 494,612 504,594 531,594C 552,594 571,609 571,638C 571,681 537,711 476,711C 390,711 349,665 323,618C 300,577 288,523 276,467Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                     <g transform="translate(0,60.72)" id="undefined">
                         <g transform="translate(0,0)" id="22">
                             <path id="10" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(1.83, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(58.36,0)" id="23">
-                            <path id="11" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(74.32, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(33.36,0)" id="23">
+                            <path id="11" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(49.32, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <g transform="translate(236.7,0)" id="24">
-                            <path id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(27.46, 0) scale(0.06, -0.06)"></path>
+                        <g transform="translate(161.7,0)" id="24">
+                            <path id="12" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(2.459999999999999, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
                 </g>
-                <path id="undefined" style="opacity:1" aria-hidden="true" d="M 400,-1281 L 400,1820 L 110,1820 L 110,1770 L 297,1770 L 297,-1231 L 110,-1231 L 110,-1281 Z" transform="translate(328, 0) scale(0.06, -0.06)"></path>
+                <path id="undefined" style="opacity:1" aria-hidden="true" d="M 400,-1281 L 400,1820 L 110,1820 L 110,1770 L 297,1770 L 297,-1231 L 110,-1231 L 110,-1281 Z" transform="translate(228, 0) scale(0.06, -0.06)"></path>
             </g>
         </g>
     </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-showing-work-vertically.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-showing-work-vertically.svg
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 927.74 120" width="927.74" height="120" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 477.73999999999995 120" width="477.73999999999995" height="120" style="background:white">
     <g fill="currentColor" stroke="currentColor">
         <g transform="translate(0,75.48)" id="34">
             <g transform="translate(0,0)" id="13">
                 <g transform="translate(0,-29.28)" id="undefined">
                     <g transform="translate(0,0)" id="14"></g>
-                    <g transform="translate(25,0)" id="15"></g>
-                    <g transform="translate(138.24,0)" id="16"></g>
-                    <g transform="translate(292.04,0)" id="17">
-                        <g transform="translate(25,0)" id="2"></g>
+                    <g transform="translate(0,0)" id="15"></g>
+                    <g transform="translate(63.239999999999995,0)" id="16"></g>
+                    <g transform="translate(167.04000000000002,0)" id="17">
+                        <g transform="translate(0,0)" id="2"></g>
                     </g>
-                    <g transform="translate(415.24,0)" id="18"></g>
-                    <g transform="translate(494.94,0)" id="19"></g>
-                    <g transform="translate(544.94,0)" id="20">
-                        <g transform="translate(25,0)" id="4"></g>
+                    <g transform="translate(240.24,0)" id="18"></g>
+                    <g transform="translate(269.94,0)" id="19"></g>
+                    <g transform="translate(269.94,0)" id="20">
+                        <g transform="translate(0,0)" id="4"></g>
                     </g>
-                    <g transform="translate(668.1400000000001,0)" id="21"></g>
-                    <g transform="translate(791.3400000000001,0)" id="22"></g>
-                    <g transform="translate(900.7400000000001,0)" id="23"></g>
+                    <g transform="translate(343.14,0)" id="21"></g>
+                    <g transform="translate(416.34,0)" id="22"></g>
+                    <g transform="translate(475.73999999999995,0)" id="23"></g>
                 </g>
                 <g transform="translate(0,30.720000000000002)" id="undefined">
                     <g transform="translate(0,0)" id="24"></g>
-                    <g transform="translate(25,0)" id="25"></g>
-                    <g transform="translate(138.24,0)" id="26">
-                        <g transform="translate(25,0)" id="7"></g>
+                    <g transform="translate(0,0)" id="25"></g>
+                    <g transform="translate(63.239999999999995,0)" id="26">
+                        <g transform="translate(0,0)" id="7"></g>
                     </g>
-                    <g transform="translate(292.04,0)" id="27">
-                        <g transform="translate(25,0)" id="9"></g>
+                    <g transform="translate(167.04000000000002,0)" id="27">
+                        <g transform="translate(0,0)" id="9"></g>
                     </g>
-                    <g transform="translate(415.24,0)" id="28"></g>
-                    <g transform="translate(494.94,0)" id="29"></g>
-                    <g transform="translate(544.94,0)" id="30"></g>
-                    <g transform="translate(668.1400000000001,0)" id="31">
-                        <g transform="translate(25,0)" id="11"></g>
+                    <g transform="translate(240.24,0)" id="28"></g>
+                    <g transform="translate(269.94,0)" id="29"></g>
+                    <g transform="translate(269.94,0)" id="30"></g>
+                    <g transform="translate(343.14,0)" id="31">
+                        <g transform="translate(0,0)" id="11"></g>
                     </g>
-                    <g transform="translate(791.3400000000001,0)" id="32"></g>
-                    <g transform="translate(900.7400000000001,0)" id="33"></g>
+                    <g transform="translate(416.34,0)" id="32"></g>
+                    <g transform="translate(475.73999999999995,0)" id="33"></g>
                 </g>
             </g>
         </g>
@@ -43,60 +43,60 @@
             <g transform="translate(0,0)" id="13">
                 <g transform="translate(0,-29.28)" id="undefined">
                     <g transform="translate(0,0)" id="14"></g>
-                    <g transform="translate(25,0)" id="15">
-                        <path id="0" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
-                        <path id="1" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(54.7, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(0,0)" id="15">
+                        <path id="0" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                        <path id="1" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(138.24,0)" id="16"></g>
-                    <g transform="translate(292.04,0)" id="17">
-                        <g transform="translate(25,0)" id="2">
+                    <g transform="translate(63.239999999999995,0)" id="16"></g>
+                    <g transform="translate(167.04000000000002,0)" id="17">
+                        <g transform="translate(0,0)" id="2">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
-                    <g transform="translate(415.24,0)" id="18">
-                        <path id="3" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(240.24,0)" id="18">
+                        <path id="3" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(494.94,0)" id="19"></g>
-                    <g transform="translate(544.94,0)" id="20">
-                        <g transform="translate(25,0)" id="4">
+                    <g transform="translate(269.94,0)" id="19"></g>
+                    <g transform="translate(269.94,0)" id="20">
+                        <g transform="translate(0,0)" id="4">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,327 L 658,395 L 62,395 L 62,327 ZM 658,123 L 658,190 L 62,190 L 62,123 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
-                    <g transform="translate(668.1400000000001,0)" id="21"></g>
-                    <g transform="translate(791.3400000000001,0)" id="22">
-                        <path id="5" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
-                        <path id="6" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(54.7, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(343.14,0)" id="21"></g>
+                    <g transform="translate(416.34,0)" id="22">
+                        <path id="5" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                        <path id="6" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(900.7400000000001,0)" id="23"></g>
+                    <g transform="translate(475.73999999999995,0)" id="23"></g>
                 </g>
                 <g transform="translate(0,30.720000000000002)" id="undefined">
                     <g transform="translate(0,0)" id="24"></g>
-                    <g transform="translate(25,0)" id="25"></g>
-                    <g transform="translate(138.24,0)" id="26">
-                        <g transform="translate(25,0)" id="7">
+                    <g transform="translate(0,0)" id="25"></g>
+                    <g transform="translate(63.239999999999995,0)" id="26">
+                        <g transform="translate(0,0)" id="7">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <path id="8" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(98.2, 0) scale(0.06, -0.06)"></path>
+                        <path id="8" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(73.2, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(292.04,0)" id="27">
-                        <g transform="translate(25,0)" id="9">
-                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
-                        </g>
-                    </g>
-                    <g transform="translate(415.24,0)" id="28">
-                        <path id="10" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
-                    </g>
-                    <g transform="translate(494.94,0)" id="29"></g>
-                    <g transform="translate(544.94,0)" id="30"></g>
-                    <g transform="translate(668.1400000000001,0)" id="31">
-                        <g transform="translate(25,0)" id="11">
+                    <g transform="translate(167.04000000000002,0)" id="27">
+                        <g transform="translate(0,0)" id="9">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
-                    <g transform="translate(791.3400000000001,0)" id="32">
-                        <path id="12" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(39.85, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(240.24,0)" id="28">
+                        <path id="10" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(900.7400000000001,0)" id="33"></g>
+                    <g transform="translate(269.94,0)" id="29"></g>
+                    <g transform="translate(269.94,0)" id="30"></g>
+                    <g transform="translate(343.14,0)" id="31">
+                        <g transform="translate(0,0)" id="11">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(416.34,0)" id="32">
+                        <path id="12" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(14.85, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(475.73999999999995,0)" id="33"></g>
                 </g>
             </g>
         </g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-showing-work-vertically.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-showing-work-vertically.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 477.73999999999995 120" width="477.73999999999995" height="120" style="background:white">
+    <g fill="currentColor" stroke="currentColor">
+        <g transform="translate(0,75.48)" id="34">
+            <g transform="translate(0,0)" id="13">
+                <g transform="translate(0,-29.28)" id="undefined">
+                    <g transform="translate(0,0)" id="14"></g>
+                    <g transform="translate(0,0)" id="15"></g>
+                    <g transform="translate(63.239999999999995,0)" id="16"></g>
+                    <g transform="translate(167.04000000000002,0)" id="17">
+                        <g transform="translate(0,0)" id="2"></g>
+                    </g>
+                    <g transform="translate(240.24,0)" id="18"></g>
+                    <g transform="translate(269.94,0)" id="19"></g>
+                    <g transform="translate(269.94,0)" id="20">
+                        <g transform="translate(0,0)" id="4"></g>
+                    </g>
+                    <g transform="translate(343.14,0)" id="21"></g>
+                    <g transform="translate(416.34,0)" id="22"></g>
+                    <g transform="translate(475.73999999999995,0)" id="23"></g>
+                </g>
+                <g transform="translate(0,30.720000000000002)" id="undefined">
+                    <g transform="translate(0,0)" id="24"></g>
+                    <g transform="translate(0,0)" id="25"></g>
+                    <g transform="translate(63.239999999999995,0)" id="26">
+                        <g transform="translate(0,0)" id="7"></g>
+                    </g>
+                    <g transform="translate(167.04000000000002,0)" id="27">
+                        <g transform="translate(0,0)" id="9"></g>
+                    </g>
+                    <g transform="translate(240.24,0)" id="28"></g>
+                    <g transform="translate(269.94,0)" id="29"></g>
+                    <g transform="translate(269.94,0)" id="30"></g>
+                    <g transform="translate(343.14,0)" id="31">
+                        <g transform="translate(0,0)" id="11"></g>
+                    </g>
+                    <g transform="translate(416.34,0)" id="32"></g>
+                    <g transform="translate(475.73999999999995,0)" id="33"></g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0,75.48)" id="34">
+            <g transform="translate(0,0)" id="13">
+                <g transform="translate(0,-29.28)" id="undefined">
+                    <g transform="translate(0,0)" id="14"></g>
+                    <g transform="translate(0,0)" id="15">
+                        <path id="0" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                        <path id="1" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(63.239999999999995,0)" id="16"></g>
+                    <g transform="translate(167.04000000000002,0)" id="17">
+                        <g transform="translate(0,0)" id="2">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(240.24,0)" id="18">
+                        <path id="3" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(269.94,0)" id="19"></g>
+                    <g transform="translate(269.94,0)" id="20">
+                        <g transform="translate(0,0)" id="4">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,327 L 658,395 L 62,395 L 62,327 ZM 658,123 L 658,190 L 62,190 L 62,123 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(343.14,0)" id="21"></g>
+                    <g transform="translate(416.34,0)" id="22">
+                        <path id="5" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                        <path id="6" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(475.73999999999995,0)" id="23"></g>
+                </g>
+                <g transform="translate(0,30.720000000000002)" id="undefined">
+                    <g transform="translate(0,0)" id="24"></g>
+                    <g transform="translate(0,0)" id="25"></g>
+                    <g transform="translate(63.239999999999995,0)" id="26">
+                        <g transform="translate(0,0)" id="7">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                        <path id="8" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(73.2, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(167.04000000000002,0)" id="27">
+                        <g transform="translate(0,0)" id="9">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(240.24,0)" id="28">
+                        <path id="10" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(269.94,0)" id="29"></g>
+                    <g transform="translate(269.94,0)" id="30"></g>
+                    <g transform="translate(343.14,0)" id="31">
+                        <g transform="translate(0,0)" id="11">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(416.34,0)" id="32">
+                        <path id="12" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(14.85, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(475.73999999999995,0)" id="33"></g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-showing-work-vertically.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-showing-work-vertically.svg
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 477.73999999999995 120" width="477.73999999999995" height="120" style="background:white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 927.74 120" width="927.74" height="120" style="background:white">
     <g fill="currentColor" stroke="currentColor">
         <g transform="translate(0,75.48)" id="34">
             <g transform="translate(0,0)" id="13">
                 <g transform="translate(0,-29.28)" id="undefined">
                     <g transform="translate(0,0)" id="14"></g>
-                    <g transform="translate(0,0)" id="15"></g>
-                    <g transform="translate(63.239999999999995,0)" id="16"></g>
-                    <g transform="translate(167.04000000000002,0)" id="17">
-                        <g transform="translate(0,0)" id="2"></g>
+                    <g transform="translate(25,0)" id="15"></g>
+                    <g transform="translate(138.24,0)" id="16"></g>
+                    <g transform="translate(292.04,0)" id="17">
+                        <g transform="translate(25,0)" id="2"></g>
                     </g>
-                    <g transform="translate(240.24,0)" id="18"></g>
-                    <g transform="translate(269.94,0)" id="19"></g>
-                    <g transform="translate(269.94,0)" id="20">
-                        <g transform="translate(0,0)" id="4"></g>
+                    <g transform="translate(415.24,0)" id="18"></g>
+                    <g transform="translate(494.94,0)" id="19"></g>
+                    <g transform="translate(544.94,0)" id="20">
+                        <g transform="translate(25,0)" id="4"></g>
                     </g>
-                    <g transform="translate(343.14,0)" id="21"></g>
-                    <g transform="translate(416.34,0)" id="22"></g>
-                    <g transform="translate(475.73999999999995,0)" id="23"></g>
+                    <g transform="translate(668.1400000000001,0)" id="21"></g>
+                    <g transform="translate(791.3400000000001,0)" id="22"></g>
+                    <g transform="translate(900.7400000000001,0)" id="23"></g>
                 </g>
                 <g transform="translate(0,30.720000000000002)" id="undefined">
                     <g transform="translate(0,0)" id="24"></g>
-                    <g transform="translate(0,0)" id="25"></g>
-                    <g transform="translate(63.239999999999995,0)" id="26">
-                        <g transform="translate(0,0)" id="7"></g>
+                    <g transform="translate(25,0)" id="25"></g>
+                    <g transform="translate(138.24,0)" id="26">
+                        <g transform="translate(25,0)" id="7"></g>
                     </g>
-                    <g transform="translate(167.04000000000002,0)" id="27">
-                        <g transform="translate(0,0)" id="9"></g>
+                    <g transform="translate(292.04,0)" id="27">
+                        <g transform="translate(25,0)" id="9"></g>
                     </g>
-                    <g transform="translate(240.24,0)" id="28"></g>
-                    <g transform="translate(269.94,0)" id="29"></g>
-                    <g transform="translate(269.94,0)" id="30"></g>
-                    <g transform="translate(343.14,0)" id="31">
-                        <g transform="translate(0,0)" id="11"></g>
+                    <g transform="translate(415.24,0)" id="28"></g>
+                    <g transform="translate(494.94,0)" id="29"></g>
+                    <g transform="translate(544.94,0)" id="30"></g>
+                    <g transform="translate(668.1400000000001,0)" id="31">
+                        <g transform="translate(25,0)" id="11"></g>
                     </g>
-                    <g transform="translate(416.34,0)" id="32"></g>
-                    <g transform="translate(475.73999999999995,0)" id="33"></g>
+                    <g transform="translate(791.3400000000001,0)" id="32"></g>
+                    <g transform="translate(900.7400000000001,0)" id="33"></g>
                 </g>
             </g>
         </g>
@@ -43,60 +43,60 @@
             <g transform="translate(0,0)" id="13">
                 <g transform="translate(0,-29.28)" id="undefined">
                     <g transform="translate(0,0)" id="14"></g>
-                    <g transform="translate(0,0)" id="15">
-                        <path id="0" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-                        <path id="1" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(25,0)" id="15">
+                        <path id="0" style="opacity:1" aria-hidden="true" d="M 464,160 L 435,160 C 412,100 399,79 346,79L 207,79 L 137,76 L 137,81 L 269,206 C 375,313 432,382 432,471C 432,576 353,644 240,644C 143,644 75,588 44,491L 68,481 C 105,556 149,579 214,579C 291,579 339,531 339,456C 339,351 289,288 190,186L 38,34 L 38,0 L 432,0 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
+                        <path id="1" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(54.7, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(63.239999999999995,0)" id="16"></g>
-                    <g transform="translate(167.04000000000002,0)" id="17">
-                        <g transform="translate(0,0)" id="2">
+                    <g transform="translate(138.24,0)" id="16"></g>
+                    <g transform="translate(292.04,0)" id="17">
+                        <g transform="translate(25,0)" id="2">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
-                    <g transform="translate(240.24,0)" id="18">
-                        <path id="3" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(415.24,0)" id="18">
+                        <path id="3" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(269.94,0)" id="19"></g>
-                    <g transform="translate(269.94,0)" id="20">
-                        <g transform="translate(0,0)" id="4">
+                    <g transform="translate(494.94,0)" id="19"></g>
+                    <g transform="translate(544.94,0)" id="20">
+                        <g transform="translate(25,0)" id="4">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,327 L 658,395 L 62,395 L 62,327 ZM 658,123 L 658,190 L 62,190 L 62,123 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
-                    <g transform="translate(343.14,0)" id="21"></g>
-                    <g transform="translate(416.34,0)" id="22">
-                        <path id="5" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-                        <path id="6" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(29.7, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(668.1400000000001,0)" id="21"></g>
+                    <g transform="translate(791.3400000000001,0)" id="22">
+                        <path id="5" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
+                        <path id="6" style="opacity:1" aria-hidden="true" d="M 468,317 C 468,523 378,642 249,642C 104,642 27,510 27,320C 27,143 86,-11 247,-11C 404,-11 468,146 468,317ZM 371,311 C 371,119 326,25 247,25C 167,25 123,121 123,315C 123,513 167,608 246,608C 328,608 371,514 371,311Z" transform="translate(54.7, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(475.73999999999995,0)" id="23"></g>
+                    <g transform="translate(900.7400000000001,0)" id="23"></g>
                 </g>
                 <g transform="translate(0,30.720000000000002)" id="undefined">
                     <g transform="translate(0,0)" id="24"></g>
-                    <g transform="translate(0,0)" id="25"></g>
-                    <g transform="translate(63.239999999999995,0)" id="26">
-                        <g transform="translate(0,0)" id="7">
+                    <g transform="translate(25,0)" id="25"></g>
+                    <g transform="translate(138.24,0)" id="26">
+                        <g transform="translate(25,0)" id="7">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
-                        <path id="8" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(73.2, 0) scale(0.06, -0.06)"></path>
+                        <path id="8" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(98.2, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(167.04000000000002,0)" id="27">
-                        <g transform="translate(0,0)" id="9">
-                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
-                        </g>
-                    </g>
-                    <g transform="translate(240.24,0)" id="28">
-                        <path id="10" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
-                    </g>
-                    <g transform="translate(269.94,0)" id="29"></g>
-                    <g transform="translate(269.94,0)" id="30"></g>
-                    <g transform="translate(343.14,0)" id="31">
-                        <g transform="translate(0,0)" id="11">
+                    <g transform="translate(292.04,0)" id="27">
+                        <g transform="translate(25,0)" id="9">
                             <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
                         </g>
                     </g>
-                    <g transform="translate(416.34,0)" id="32">
-                        <path id="12" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(14.85, 0) scale(0.06, -0.06)"></path>
+                    <g transform="translate(415.24,0)" id="28">
+                        <path id="10" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(25, 0) scale(0.06, -0.06)"></path>
                     </g>
-                    <g transform="translate(475.73999999999995,0)" id="33"></g>
+                    <g transform="translate(494.94,0)" id="29"></g>
+                    <g transform="translate(544.94,0)" id="30"></g>
+                    <g transform="translate(668.1400000000001,0)" id="31">
+                        <g transform="translate(25,0)" id="11">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 62,293 L 62,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(791.3400000000001,0)" id="32">
+                        <path id="12" style="opacity:1" aria-hidden="true" d="M 417,549 L 433,630 L 159,630 L 97,369 L 109,354 C 123,354 128,354 154,352C 292,345 370,304 370,179C 370,75 307,37 236,37C 172,37 139,86 99,86C 74,86 59,66 59,43C 59,6 97,-13 174,-13C 333,-13 443,65 443,219C 443,376 320,423 202,432L 155,435 L 182,549 Z" transform="translate(39.85, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(900.7400000000001,0)" id="33"></g>
                 </g>
             </g>
         </g>

--- a/packages/react/src/__tests__/renderer.test.tsx
+++ b/packages/react/src/__tests__/renderer.test.tsx
@@ -664,5 +664,10 @@ describe("renderer", () => {
             const Matrix = await storyToComponent(stories.Matrix);
             expect(<Matrix />).toMatchSVGSnapshot();
         });
+
+        test("showing work vertically", async () => {
+            const VerticalWork = await storyToComponent(stories.VerticalWork);
+            expect(<VerticalWork />).toMatchSVGSnapshot();
+        });
     });
 });

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -868,7 +868,7 @@ export const Matrix: Story<EmptyProps> = (args, {loaded: fontData}) => {
     const matrix = Editor.builders.row([
         Editor.builders.glyph("A"),
         Editor.builders.glyph("="),
-        Editor.builders.table(
+        Editor.builders.matrix(
             [
                 // first row
                 [Editor.builders.glyph("a")],

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -910,3 +910,51 @@ export const Matrix: Story<EmptyProps> = (args, {loaded: fontData}) => {
 
     return <MathRenderer scene={prod} style={style} />;
 };
+
+export const VerticalWork: Story<EmptyProps> = (args, {loaded: fontData}) => {
+    const {builders} = Editor;
+    const verticalWork = builders.row([
+        builders.table(
+            "algebra",
+            [
+                // first row
+                [],
+                [builders.glyph("2"), builders.glyph("x")],
+                [],
+                [builders.glyph("+")],
+                [builders.glyph("5")],
+                [],
+                [builders.glyph("=")],
+                [],
+                [builders.glyph("1"), builders.glyph("0")],
+                [],
+
+                // second row
+                [],
+                [],
+                [builders.glyph("\u2212"), builders.glyph("y")],
+                [builders.glyph("\u2212")],
+                [builders.glyph("5")],
+                [],
+                [],
+                [builders.glyph("\u2212")],
+                [builders.glyph("5")],
+                [],
+            ],
+            10,
+            2,
+        ),
+    ]);
+
+    const fontSize = 60;
+    const context: Typesetter.Context = {
+        fontData: fontData,
+        baseFontSize: fontSize,
+        mathStyle: Typesetter.MathStyle.Display,
+        renderMode: Typesetter.RenderMode.Dynamic,
+        cramped: false,
+    };
+    const prod = Typesetter.typeset(verticalWork, context);
+
+    return <MathRenderer scene={prod} style={style} />;
+};

--- a/packages/react/src/stories/2-math-renderer.stories.tsx
+++ b/packages/react/src/stories/2-math-renderer.stories.tsx
@@ -914,8 +914,7 @@ export const Matrix: Story<EmptyProps> = (args, {loaded: fontData}) => {
 export const VerticalWork: Story<EmptyProps> = (args, {loaded: fontData}) => {
     const {builders} = Editor;
     const verticalWork = builders.row([
-        builders.table(
-            "algebra",
+        builders.algebra(
             [
                 // first row
                 [],

--- a/packages/typesetter/src/layout.ts
+++ b/packages/typesetter/src/layout.ts
@@ -22,7 +22,7 @@ type Common = {
     style: Style;
 };
 
-type Content =
+export type Content =
     | {
           type: "static";
           nodes: readonly Node[];

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -17,9 +17,19 @@ import {maybeAddOperatorPadding} from "./typesetters/atom";
 import type {Context} from "./types";
 import type {Scene} from "./scene-graph";
 
-const typesetRow = (row: Editor.types.Row, context: Context): Layout.HBox => {
+const typesetRow = (
+    row: Editor.types.Row,
+    context: Context,
+    padFirstOperator?: boolean,
+): Layout.HBox => {
     const box = Layout.makeStaticHBox(
-        typesetNodes(row.children, context),
+        typesetNodes(
+            row.children,
+            context,
+            undefined,
+            undefined,
+            padFirstOperator,
+        ),
         context,
     );
     box.id = row.id;
@@ -71,15 +81,19 @@ const getTypesetChildFromZipper = (
     zipper: Editor.Zipper,
     focus: Editor.Focus,
 ): ((index: number, context: Context) => Layout.HBox | null) => {
-    return (index: number, context: Context): Layout.HBox | null => {
+    return (
+        index: number,
+        context: Context,
+        padFirstOperator?: boolean,
+    ): Layout.HBox | null => {
         if (index < focus.left.length) {
             const child = focus.left[index];
-            return child && typesetRow(child, context);
+            return child && typesetRow(child, context, padFirstOperator);
         } else if (index === focus.left.length) {
-            return _typesetZipper(zipper, context);
+            return _typesetZipper(zipper, context, padFirstOperator);
         } else {
             const child = focus.right[index - focus.left.length - 1];
-            return child && typesetRow(child, context);
+            return child && typesetRow(child, context, padFirstOperator);
         }
     };
 };
@@ -89,9 +103,13 @@ const getTypesetChildFromNodes = <
 >(
     children: T,
 ): ((index: number, context: Context) => Layout.HBox | null) => {
-    return (index: number, context: Context): Layout.HBox | null => {
+    return (
+        index: number,
+        context: Context,
+        padFirstOperator?: boolean,
+    ): Layout.HBox | null => {
         const child = children[index];
-        return child && typesetRow(child, context);
+        return child && typesetRow(child, context, padFirstOperator);
     };
 };
 
@@ -138,6 +156,7 @@ const typesetNode = (
     context: Context,
     prevEditNode?: Editor.types.Node | Editor.Focus,
     prevLayoutNode?: Layout.Node,
+    padFirstOperator?: boolean,
 ): Layout.Node => {
     switch (node.type) {
         case "row": {
@@ -174,7 +193,12 @@ const typesetNode = (
             return typesetTable(typesetChild, node, context);
         }
         case "atom": {
-            return maybeAddOperatorPadding(prevEditNode, node, context);
+            return maybeAddOperatorPadding(
+                prevEditNode,
+                node,
+                context,
+                padFirstOperator,
+            );
         }
         default:
             throw new UnreachableCaseError(node);
@@ -186,9 +210,16 @@ const typesetNodes = (
     context: Context,
     prevChild?: Editor.types.Node | Editor.Focus,
     prevLayoutNode?: Layout.Node,
+    padFirstOperator?: boolean,
 ): readonly Layout.Node[] => {
-    return nodes.map((child) => {
-        const result = typesetNode(child, context, prevChild, prevLayoutNode);
+    return nodes.map((child, index) => {
+        const result = typesetNode(
+            child,
+            context,
+            prevChild,
+            prevLayoutNode,
+            index === 0 ? padFirstOperator : undefined,
+        );
         prevLayoutNode = result;
         prevChild = child;
         return result;
@@ -198,6 +229,7 @@ const typesetNodes = (
 const _typesetZipper = (
     zipper: Editor.Zipper,
     context: Context,
+    padFirstOperator?: boolean,
 ): Layout.HBox => {
     // The bottommost crumb is the outermost row
     const [crumb, ...restCrumbs] = zipper.breadcrumbs;
@@ -210,7 +242,15 @@ const _typesetZipper = (
         };
         const nodes: Layout.Node[] = [];
 
-        nodes.push(...typesetNodes(row.left, context));
+        nodes.push(
+            ...typesetNodes(
+                row.left,
+                context,
+                undefined,
+                undefined,
+                padFirstOperator,
+            ),
+        );
         nodes.push(
             typesetFocus(
                 crumb.focus,
@@ -226,6 +266,7 @@ const _typesetZipper = (
                 context,
                 crumb.focus, // previous edit node
                 nodes[nodes.length - 1], // previous layout node
+                padFirstOperator,
             ),
         );
 
@@ -242,7 +283,13 @@ const _typesetZipper = (
         const row = zipper.row;
 
         const input = [...row.left, ...row.selection, ...row.right];
-        const output = typesetNodes(input, context);
+        const output = typesetNodes(
+            input,
+            context,
+            undefined,
+            undefined,
+            padFirstOperator,
+        );
 
         const firstCut = row.left.length;
         const secondCut = firstCut + row.selection.length;

--- a/packages/typesetter/src/typeset.ts
+++ b/packages/typesetter/src/typeset.ts
@@ -232,7 +232,7 @@ const typesetFocus = (
                 () => childContext,
             );
 
-            return typesetTable(typesetChildren, focus, context);
+            return typesetTable(typesetChildren, focus, context, zipper);
         }
         default:
             throw new UnreachableCaseError(focus);

--- a/packages/typesetter/src/typesetters/atom.ts
+++ b/packages/typesetter/src/typesetters/atom.ts
@@ -54,19 +54,22 @@ export const maybeAddOperatorPadding = (
     prevNode: Editor.types.Node | Editor.Focus | undefined,
     currentNode: Editor.types.Atom,
     context: Context,
+    padOperator?: boolean,
 ): Layout.Node => {
     const glyph = typesetAtom(currentNode, context);
     const fontSize = fontSizeForContext(context);
-    const result = shouldHavePadding(prevNode, currentNode, context)
-        ? Layout.makeStaticHBox(
-              [
-                  Layout.makeKern(fontSize / 4),
-                  glyph,
-                  Layout.makeKern(fontSize / 4),
-              ],
-              context,
-          )
-        : glyph;
+    const result =
+        (padOperator && Editor.util.isOperator(currentNode)) ||
+        shouldHavePadding(prevNode, currentNode, context)
+            ? Layout.makeStaticHBox(
+                  [
+                      Layout.makeKern(fontSize / 4),
+                      glyph,
+                      Layout.makeKern(fontSize / 4),
+                  ],
+                  context,
+              )
+            : glyph;
     if (result !== glyph) {
         result.id = glyph.id;
         delete glyph.id;

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -163,7 +163,7 @@ export const typesetTable = (
     }
 
     const cursorIndex = node.type === "ztable" ? node.left.length : -1;
-    if (cursorIndex !== -1) {
+    if (node.subtype === "algebra" && cursorIndex !== -1) {
         const cursorCol = cursorIndex % node.colCount;
         if (columns[cursorCol].width === 0) {
             columns[cursorCol].width = 32;


### PR DESCRIPTION
Fixes #420.  It automatically pads operators as need to match the non-table rendering.  There will need to be some followup work to make navigating and deleting things better.