### PR TITLE
Remove the bottom row if empty when cursor is not in it

### DIFF
--- a/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
@@ -13,7 +13,7 @@ describe("verticalWork", () => {
         };
         const state = stateFromZipper(zipper);
 
-        const newState = verticalWork(state);
+        const newState = verticalWork(state, "down");
 
         const focus = newState.zipper.breadcrumbs[0].focus;
         if (focus.type !== "ztable") {
@@ -57,7 +57,7 @@ describe("verticalWork", () => {
         };
         const state = stateFromZipper(zipper);
 
-        const newState = verticalWork(verticalWork(state));
+        const newState = verticalWork(verticalWork(state, "down"), "down");
 
         const focus = newState.zipper.breadcrumbs[0].focus;
         if (focus.type !== "ztable") {
@@ -83,15 +83,15 @@ describe("verticalWork", () => {
         expect(focus.right).toHaveLength(9);
 
         // All cells in the second row are empty to begin with
-        expect(focus.right[0]?.children).toEqualEditorNodes([]);
-        expect(focus.right[1]?.children).toEqualEditorNodes([]);
-        expect(focus.right[2]?.children).toEqualEditorNodes([]);
-        expect(focus.right[3]?.children).toEqualEditorNodes([]);
-        expect(focus.right[4]?.children).toEqualEditorNodes([]);
-        expect(focus.right[5]?.children).toEqualEditorNodes([]);
-        expect(focus.right[6]?.children).toEqualEditorNodes([]);
-        expect(focus.right[7]?.children).toEqualEditorNodes([]);
-        expect(focus.right[8]?.children).toEqualEditorNodes([]);
+        expect(focus.left[10]?.children).toEqualEditorNodes([]);
+        expect(focus.left[11]?.children).toEqualEditorNodes([]);
+        expect(focus.left[12]?.children).toEqualEditorNodes([]);
+        expect(focus.left[13]?.children).toEqualEditorNodes([]);
+        expect(focus.left[14]?.children).toEqualEditorNodes([]);
+        expect(focus.left[15]?.children).toEqualEditorNodes([]);
+        expect(focus.left[16]?.children).toEqualEditorNodes([]);
+        expect(focus.left[17]?.children).toEqualEditorNodes([]);
+        expect(focus.left[18]?.children).toEqualEditorNodes([]);
 
         // All cells in the third row are empty to begin with
         expect(focus.right[0]?.children).toEqualEditorNodes([]);
@@ -114,7 +114,10 @@ describe("verticalWork", () => {
         };
         const state = stateFromZipper(zipper);
 
-        const newState = verticalWork(verticalWork(verticalWork(state)));
+        const newState = verticalWork(
+            verticalWork(verticalWork(state, "down"), "down"),
+            "down",
+        );
 
         const focus = newState.zipper.breadcrumbs[0].focus;
         if (focus.type !== "ztable") {
@@ -122,5 +125,60 @@ describe("verticalWork", () => {
         }
 
         expect(focus.rowCount).toEqual(3);
+    });
+
+    test("pressing up from inside an empty third row will remove that row", () => {
+        const zipper: Zipper = {
+            row: zrow([], row("2x+5=10").children),
+            breadcrumbs: [],
+        };
+        const state = stateFromZipper(zipper);
+
+        const newState = verticalWork(
+            verticalWork(verticalWork(state, "down"), "down"),
+            "up",
+        );
+
+        const focus = newState.zipper.breadcrumbs[0].focus;
+        if (focus.type !== "ztable") {
+            throw new Error("focus should be a ZTable");
+        }
+        expect(focus.left).toHaveLength(10);
+
+        // Empty cells are place at the start and end
+        expect(focus.left[0]?.children).toEqualEditorNodes([]);
+        expect(focus.left[1]?.children).toEqualEditorNodes(row("2x").children);
+        // Empty cells are placed in front of each plus/minus opeartor
+        expect(focus.left[2]?.children).toEqualEditorNodes([]);
+        expect(focus.left[3]?.children).toEqualEditorNodes(row("+").children);
+        expect(focus.left[4]?.children).toEqualEditorNodes(row("5").children);
+        // Empty cells are placed around each relationship operator
+        expect(focus.left[5]?.children).toEqualEditorNodes([]);
+        expect(focus.left[6]?.children).toEqualEditorNodes(row("=").children);
+        expect(focus.left[7]?.children).toEqualEditorNodes([]);
+        expect(focus.left[8]?.children).toEqualEditorNodes(row("10").children);
+        expect(focus.left[9]?.children).toEqualEditorNodes([]);
+
+        // The cursor is placed in the first column of the second row
+        expect(focus.right).toHaveLength(9);
+        expect(focus.rowCount).toEqual(2);
+
+        expect(focus.rowStyles).toEqual([null, null]);
+    });
+
+    test("pressing up from from inside an empty second row will join the cells in the row", () => {
+        const zipper: Zipper = {
+            row: zrow([], row("2x+5=10").children),
+            breadcrumbs: [],
+        };
+        const state = stateFromZipper(zipper);
+
+        const newState = verticalWork(verticalWork(state, "down"), "up");
+
+        expect(newState.zipper.breadcrumbs).toHaveLength(0);
+        expect(newState.zipper.row.left).toEqualEditorNodes([]);
+        expect(newState.zipper.row.right).toEqualEditorNodes(
+            row("2x+5=10").children,
+        );
     });
 });

--- a/packages/editor-core/src/reducer/move-vertically.ts
+++ b/packages/editor-core/src/reducer/move-vertically.ts
@@ -9,12 +9,18 @@ export const moveVertically = (
     direction: "up" | "down",
 ): State => {
     if (state.selecting) {
-        return direction === "down" ? verticalWork(state) : state;
+        return verticalWork(state, direction);
     }
 
     const {breadcrumbs} = state.zipper;
     const crumb = breadcrumbs[breadcrumbs.length - 1];
     if (crumb?.focus.type === "ztable") {
+        if (crumb.focus.subtype === "algebra" && direction === "up") {
+            const newState = verticalWork(state, direction);
+            if (newState !== state) {
+                return newState;
+            }
+        }
         const {colCount, rowCount, left, right} = crumb.focus;
 
         const oldRow: ZRow = state.zipper.row;
@@ -56,7 +62,7 @@ export const moveVertically = (
         }
 
         if (!focusedChild) {
-            return direction === "down" ? verticalWork(state) : state;
+            return verticalWork(state, direction);
         }
 
         // TODO: determine cursorIndex based on column alignment, e.g. if
@@ -98,5 +104,5 @@ export const moveVertically = (
         };
     }
 
-    return direction === "down" ? verticalWork(state) : state;
+    return verticalWork(state, direction);
 };


### PR DESCRIPTION
If the cursor moves into the top row and the second row is empty then we merge the contents of all the cells into a single `Row` which takes us back to the original state we started with.  This fixes #422.