### PR TITLE
Improve horizontal navigation when showing work vertically

### DIFF
--- a/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
@@ -368,6 +368,50 @@ describe("verticalWork", () => {
             expect(newZipper.row.left).toEqualEditorNodes([]);
             expect(newZipper.row.right).toEqualEditorNodes([glyph("5")]);
         });
+
+        test("can't exit table to right even if last column is empty", () => {
+            const node: types.Table = builders.algebra(
+                [
+                    // first row
+                    [],
+                    [glyph("2"), glyph("x")],
+                    [glyph("+")],
+                    [glyph("5")],
+                    [],
+
+                    // second row
+                    [],
+                    [],
+                    [glyph("\u2212")],
+                    [glyph("5")],
+                    [],
+
+                    // third row
+                    [],
+                    [glyph("2"), glyph("x")],
+                    [glyph("+")],
+                    [glyph("0")],
+                    [],
+                ],
+                5,
+                3,
+            );
+
+            const zipper: Zipper = {
+                row: util.zrow(getId(), row("0").children, []),
+                breadcrumbs: [
+                    {
+                        row: bcRow,
+                        focus: util.nodeToFocus(node, 13),
+                    },
+                ],
+            };
+
+            const state = stateFromZipper(zipper);
+            const newState = moveRight(state);
+
+            expect(state).toEqual(newState);
+        });
     });
 
     describe("entering characters", () => {

--- a/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
+++ b/packages/editor-core/src/reducer/__tests__/vertical-work.test.ts
@@ -412,6 +412,50 @@ describe("verticalWork", () => {
 
             expect(state).toEqual(newState);
         });
+
+        test("can't wrap around from one row to the previous when navigating left even if there's a empty column", () => {
+            const node: types.Table = builders.algebra(
+                [
+                    // first row
+                    [],
+                    [glyph("2"), glyph("x")],
+                    [glyph("+")],
+                    [glyph("5")],
+                    [],
+
+                    // second row
+                    [],
+                    [],
+                    [glyph("\u2212")],
+                    [glyph("5")],
+                    [],
+
+                    // third row
+                    [],
+                    [glyph("2"), glyph("x")],
+                    [glyph("+")],
+                    [glyph("0")],
+                    [],
+                ],
+                5,
+                3,
+            );
+
+            const zipper: Zipper = {
+                row: util.zrow(getId(), [], row("2x").children),
+                breadcrumbs: [
+                    {
+                        row: bcRow,
+                        focus: util.nodeToFocus(node, 11),
+                    },
+                ],
+            };
+
+            const state = stateFromZipper(zipper);
+            const newState = moveLeft(state);
+
+            expect(state).toEqual(newState);
+        });
     });
 
     describe("entering characters", () => {

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-vertically-don't-pad-an-empty-cell-in-the-bottom-row-if-there-is-an-non-empty-cell-above.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-vertically-don't-pad-an-empty-cell-in-the-bottom-row-if-there-is-an-non-empty-cell-above.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 242.23999999999998 180" width="242.23999999999998" height="180">
+    <g fill="currentColor" stroke="currentColor">
+        <g transform="translate(0,105.48)" id="21">
+            <g transform="translate(0,0)" id="5">
+                <g transform="translate(0,-59.28)" id="undefined">
+                    <g transform="translate(0,0)" id="6"></g>
+                    <g transform="translate(33.54,0)" id="7"></g>
+                    <g transform="translate(136.44,0)" id="8">
+                        <g transform="translate(0,0)" id="1"></g>
+                    </g>
+                    <g transform="translate(209.64,0)" id="9"></g>
+                    <g transform="translate(209.64,0)" id="10"></g>
+                </g>
+                <g transform="translate(0,0.7199999999999989)" id="undefined">
+                    <g transform="translate(0,0)" id="11"></g>
+                    <g transform="translate(33.54,0)" id="12">
+                        <g transform="translate(0,0)" id="3"></g>
+                    </g>
+                    <g transform="translate(136.44,0)" id="13"></g>
+                    <g transform="translate(209.64,0)" id="14"></g>
+                    <g transform="translate(209.64,0)" id="15"></g>
+                </g>
+                <g transform="translate(0,60.72)" id="undefined">
+                    <g transform="translate(0,0)" id="16"></g>
+                    <g transform="translate(33.54,0)" id="22">
+                        <rect type="rect" x="50.45" y="-46.2" width="2" height="60"></rect>
+                    </g>
+                    <g transform="translate(136.44,0)" id="18"></g>
+                    <g transform="translate(209.64,0)" id="19"></g>
+                    <g transform="translate(209.64,0)" id="20"></g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0,105.48)" id="21">
+            <g transform="translate(0,0)" id="5">
+                <g transform="translate(0,-59.28)" id="undefined">
+                    <g transform="translate(0,0)" id="6">
+                        <path id="0" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(33.54,0)" id="7"></g>
+                    <g transform="translate(136.44,0)" id="8">
+                        <g transform="translate(0,0)" id="1">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,327 L 658,395 L 62,395 L 62,327 ZM 658,123 L 658,190 L 62,190 L 62,123 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(209.64,0)" id="9"></g>
+                    <g transform="translate(209.64,0)" id="10">
+                        <path id="2" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                </g>
+                <g transform="translate(0,0.7199999999999989)" id="undefined">
+                    <g transform="translate(0,0)" id="11"></g>
+                    <g transform="translate(33.54,0)" id="12">
+                        <g transform="translate(0,0)" id="3">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                        <path id="4" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(73.2, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(136.44,0)" id="13"></g>
+                    <g transform="translate(209.64,0)" id="14"></g>
+                    <g transform="translate(209.64,0)" id="15"></g>
+                </g>
+                <g transform="translate(0,60.72)" id="undefined">
+                    <g transform="translate(0,0)" id="16"></g>
+                    <g transform="translate(33.54,0)" id="22"></g>
+                    <g transform="translate(136.44,0)" id="18"></g>
+                    <g transform="translate(209.64,0)" id="19"></g>
+                    <g transform="translate(209.64,0)" id="20"></g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-vertically-don't-pad-an-empty-cell-in-the-middle-row-if-there-is-non-empty-cells-in-below-it.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-vertically-don't-pad-an-empty-cell-in-the-middle-row-if-there-is-non-empty-cells-in-below-it.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 242.23999999999998 180" width="242.23999999999998" height="180">
+    <g fill="currentColor" stroke="currentColor">
+        <g transform="translate(0,105.48)" id="21">
+            <g transform="translate(0,0)" id="5">
+                <g transform="translate(0,-59.28)" id="undefined">
+                    <g transform="translate(0,0)" id="6"></g>
+                    <g transform="translate(33.54,0)" id="7"></g>
+                    <g transform="translate(136.44,0)" id="8">
+                        <g transform="translate(0,0)" id="1"></g>
+                    </g>
+                    <g transform="translate(209.64,0)" id="9"></g>
+                    <g transform="translate(209.64,0)" id="10"></g>
+                </g>
+                <g transform="translate(0,0.7199999999999989)" id="undefined">
+                    <g transform="translate(0,0)" id="22">
+                        <rect type="rect" x="7.77" y="-46.2" width="2" height="60"></rect>
+                    </g>
+                    <g transform="translate(33.54,0)" id="12"></g>
+                    <g transform="translate(136.44,0)" id="13"></g>
+                    <g transform="translate(209.64,0)" id="14"></g>
+                    <g transform="translate(209.64,0)" id="15"></g>
+                </g>
+                <g transform="translate(0,60.72)" id="undefined">
+                    <g transform="translate(0,0)" id="16"></g>
+                    <g transform="translate(33.54,0)" id="17">
+                        <g transform="translate(0,0)" id="3"></g>
+                    </g>
+                    <g transform="translate(136.44,0)" id="18"></g>
+                    <g transform="translate(209.64,0)" id="19"></g>
+                    <g transform="translate(209.64,0)" id="20"></g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0,105.48)" id="21">
+            <g transform="translate(0,0)" id="5">
+                <g transform="translate(0,-59.28)" id="undefined">
+                    <g transform="translate(0,0)" id="6">
+                        <path id="0" style="opacity:1" aria-hidden="true" d="M 315,298 L 312,298 L 300,349 C 286,403 267,447 243,475L 228,475 L 89,459 L 89,429 C 89,429 104,432 120,432C 186,433 203,406 230,322L 258,231 L 186,126 C 147,70 129,69 125,69C 108,69 84,82 62,82C 38,82 23,60 23,40C 23,15 38,-9 81,-9C 141,-9 174,38 206,90L 270,194 L 274,194 L 299,93 C 313,28 335,-10 381,-10C 449,-10 491,58 520,102L 499,118 C 472,82 453,62 427,62C 396,62 376,99 348,191L 327,259 L 388,356 C 405,384 419,398 442,398C 455,398 478,388 494,388C 521,388 540,411 540,435C 540,463 528,479 490,479C 431,479 391,430 364,382Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(33.54,0)" id="7"></g>
+                    <g transform="translate(136.44,0)" id="8">
+                        <g transform="translate(0,0)" id="1">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,327 L 658,395 L 62,395 L 62,327 ZM 658,123 L 658,190 L 62,190 L 62,123 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                    </g>
+                    <g transform="translate(209.64,0)" id="9"></g>
+                    <g transform="translate(209.64,0)" id="10">
+                        <path id="2" style="opacity:1" aria-hidden="true" d="M 251,325 C 239,405 232,437 210,475L 195,475 L 53,464 L 53,435 C 53,435 74,437 88,437C 149,437 154,388 161,343L 220,-9 C 192,-52 112,-165 93,-165C 71,-165 60,-112 22,-112C -1,-112 -17,-125 -17,-155C -17,-192 18,-220 60,-220C 136,-220 197,-112 289,15C 341,87 398,173 452,268C 484,322 496,367 496,406C 496,449 470,482 433,482C 404,482 389,464 389,443C 389,405 438,377 438,351C 438,327 429,303 405,264L 290,79 L 284,79 L 275,179 Z" transform="translate(0, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                </g>
+                <g transform="translate(0,0.7199999999999989)" id="undefined">
+                    <g transform="translate(0,0)" id="22"></g>
+                    <g transform="translate(33.54,0)" id="12"></g>
+                    <g transform="translate(136.44,0)" id="13"></g>
+                    <g transform="translate(209.64,0)" id="14"></g>
+                    <g transform="translate(209.64,0)" id="15"></g>
+                </g>
+                <g transform="translate(0,60.72)" id="undefined">
+                    <g transform="translate(0,0)" id="16"></g>
+                    <g transform="translate(33.54,0)" id="17">
+                        <g transform="translate(0,0)" id="3">
+                            <path id="undefined" style="opacity:1" aria-hidden="true" d="M 658,225 L 658,293 L 396,293 L 396,558 L 324,558 L 324,293 L 62,293 L 62,225 L 324,225 L 324,-40 L 396,-40 L 396,225 Z" transform="translate(15, 0) scale(0.06, -0.06)"></path>
+                        </g>
+                        <path id="4" style="opacity:1" aria-hidden="true" d="M 426,0 L 426,28 C 334,28 297,46 297,95L 297,639 L 268,639 L 74,584 L 74,551 C 105,561 156,567 176,567C 201,567 209,553 209,518L 209,95 C 209,45 174,28 80,28L 80,0 Z" transform="translate(73.2, 0) scale(0.06, -0.06)"></path>
+                    </g>
+                    <g transform="translate(136.44,0)" id="18"></g>
+                    <g transform="translate(209.64,0)" id="19"></g>
+                    <g transform="translate(209.64,0)" id="20"></g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-vertically-don't-pad-an-empty-cell-in-the-middle-row-if-there-is-non-empty-cells-in-below-it.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-showing-work-vertically-don't-pad-an-empty-cell-in-the-middle-row-if-there-is-non-empty-cells-in-below-it.svg
@@ -13,10 +13,10 @@
                     <g transform="translate(209.64,0)" id="10"></g>
                 </g>
                 <g transform="translate(0,0.7199999999999989)" id="undefined">
-                    <g transform="translate(0,0)" id="22">
-                        <rect type="rect" x="7.77" y="-46.2" width="2" height="60"></rect>
+                    <g transform="translate(0,0)" id="11"></g>
+                    <g transform="translate(33.54,0)" id="22">
+                        <rect type="rect" x="50.45" y="-46.2" width="2" height="60"></rect>
                     </g>
-                    <g transform="translate(33.54,0)" id="12"></g>
                     <g transform="translate(136.44,0)" id="13"></g>
                     <g transform="translate(209.64,0)" id="14"></g>
                     <g transform="translate(209.64,0)" id="15"></g>
@@ -50,8 +50,8 @@
                     </g>
                 </g>
                 <g transform="translate(0,0.7199999999999989)" id="undefined">
-                    <g transform="translate(0,0)" id="22"></g>
-                    <g transform="translate(33.54,0)" id="12"></g>
+                    <g transform="translate(0,0)" id="11"></g>
+                    <g transform="translate(33.54,0)" id="22"></g>
                     <g transform="translate(136.44,0)" id="13"></g>
                     <g transform="translate(209.64,0)" id="14"></g>
                     <g transform="translate(209.64,0)" id="15"></g>

--- a/packages/react/src/__tests__/renderer.test.tsx
+++ b/packages/react/src/__tests__/renderer.test.tsx
@@ -764,5 +764,8 @@ describe("renderer", () => {
             );
             expect(<MathRenderer scene={scene} />).toMatchSVGSnapshot();
         });
+
+        // TODO: write tests for the third row, when there are items in the
+        // second row as well.
     });
 });

--- a/packages/react/src/__tests__/renderer.test.tsx
+++ b/packages/react/src/__tests__/renderer.test.tsx
@@ -765,7 +765,130 @@ describe("renderer", () => {
             expect(<MathRenderer scene={scene} />).toMatchSVGSnapshot();
         });
 
-        // TODO: write tests for the third row, when there are items in the
-        // second row as well.
+        test("don't pad an empty cell in the bottom row if there is an non-empty cell above", async () => {
+            const {glyph} = Editor.builders;
+            const node: Editor.types.Table = Editor.builders.algebra(
+                [
+                    // first row
+                    [glyph("x")],
+                    [],
+                    [glyph("=")],
+                    [],
+                    [glyph("y")],
+
+                    // second row
+                    [],
+                    [glyph("+"), glyph("1")],
+                    [],
+                    [],
+                    [],
+
+                    // third row
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                ],
+                5,
+                3,
+            );
+
+            const bcRow: Editor.BreadcrumbRow = {
+                id: Core.getId(),
+                type: "bcrow",
+                left: [],
+                right: [],
+                style: {},
+            };
+
+            const zipper: Editor.Zipper = {
+                row: Editor.zrow(Core.getId(), [], []),
+                breadcrumbs: [
+                    {
+                        row: bcRow,
+                        // third row, second column
+                        focus: Editor.nodeToFocus(node, 11),
+                    },
+                ],
+            };
+
+            const fontData = await stixFontLoader();
+            const fontSize = 60;
+            const context = {
+                fontData: fontData,
+                baseFontSize: fontSize,
+                mathStyle: Typesetter.MathStyle.Display,
+                renderMode: Typesetter.RenderMode.Dynamic,
+                cramped: false,
+            };
+            const options = {showCursor: true};
+
+            const scene = Typesetter.typesetZipper(zipper, context, options);
+            expect(<MathRenderer scene={scene} />).toMatchSVGSnapshot();
+        });
+
+        test("don't pad an empty cell in the middle row if there is non-empty cells in below it", async () => {
+            const {glyph} = Editor.builders;
+            const node: Editor.types.Table = Editor.builders.algebra(
+                [
+                    // first row
+                    [glyph("x")],
+                    [],
+                    [glyph("=")],
+                    [],
+                    [glyph("y")],
+
+                    // second row
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+
+                    // third row
+                    [],
+                    [glyph("+"), glyph("1")],
+                    [],
+                    [],
+                    [],
+                ],
+                5,
+                3,
+            );
+
+            const bcRow: Editor.BreadcrumbRow = {
+                id: Core.getId(),
+                type: "bcrow",
+                left: [],
+                right: [],
+                style: {},
+            };
+
+            const zipper: Editor.Zipper = {
+                row: Editor.zrow(Core.getId(), [], []),
+                breadcrumbs: [
+                    {
+                        row: bcRow,
+                        // second row, second column
+                        focus: Editor.nodeToFocus(node, 5),
+                    },
+                ],
+            };
+
+            const fontData = await stixFontLoader();
+            const fontSize = 60;
+            const context = {
+                fontData: fontData,
+                baseFontSize: fontSize,
+                mathStyle: Typesetter.MathStyle.Display,
+                renderMode: Typesetter.RenderMode.Dynamic,
+                cramped: false,
+            };
+            const options = {showCursor: true};
+
+            const scene = Typesetter.typesetZipper(zipper, context, options);
+            expect(<MathRenderer scene={scene} />).toMatchSVGSnapshot();
+        });
     });
 });

--- a/packages/react/src/__tests__/renderer.test.tsx
+++ b/packages/react/src/__tests__/renderer.test.tsx
@@ -871,7 +871,7 @@ describe("renderer", () => {
                     {
                         row: bcRow,
                         // second row, second column
-                        focus: Editor.nodeToFocus(node, 5),
+                        focus: Editor.nodeToFocus(node, 6),
                     },
                 ],
             };

--- a/packages/typesetter/src/typesetters/__tests__/table.test.ts
+++ b/packages/typesetter/src/typesetters/__tests__/table.test.ts
@@ -1,0 +1,140 @@
+import fs from "fs";
+import path from "path";
+// @ts-expect-error: Blob is only available in node 15.7.0 onward
+import {Blob} from "buffer";
+import * as Core from "@math-blocks/core";
+import * as Editor from "@math-blocks/editor-core";
+import {getFontData, parse} from "@math-blocks/opentype";
+import type {FontData} from "@math-blocks/opentype";
+
+import {MathStyle, RenderMode} from "../../enums";
+import {typeset} from "../../typeset";
+
+let stixFontData: FontData | null = null;
+
+// TODO: dedupe with renderer.test.tsx
+const stixFontLoader = async (): Promise<FontData> => {
+    if (stixFontData) {
+        return stixFontData;
+    }
+
+    const fontPath = path.join(
+        __dirname,
+        "../../../../../assets/STIX2Math.otf",
+    );
+    const buffer = fs.readFileSync(fontPath);
+    const blob = new Blob([buffer]);
+
+    const font = await parse(blob);
+    stixFontData = getFontData(font, "STIX2");
+
+    return stixFontData;
+};
+
+describe("typesetTable", () => {
+    test("navigating across the bottom row should not change the content layout", async () => {
+        const {glyph} = Editor.builders;
+        const node: Editor.types.Table = Editor.builders.algebra(
+            [
+                // first row
+                [],
+                [glyph("2"), glyph("x")],
+                [],
+                [glyph("+")],
+                [glyph("5")],
+                [],
+                [glyph("=")],
+                [],
+                [glyph("1"), glyph("0")],
+                [],
+
+                // second row
+                [],
+                [],
+                [],
+                [glyph("\u2212")],
+                [glyph("5")],
+                [],
+                [],
+                [glyph("\u2212")],
+                [glyph("5")],
+                [],
+
+                // third row
+                [],
+                [glyph("2"), glyph("x")],
+                [],
+                [glyph("+")],
+                [glyph("0")],
+                [],
+                [glyph("=")],
+                [],
+                [glyph("5")],
+                [],
+            ],
+            10,
+            3,
+        );
+
+        const bcRow: Editor.BreadcrumbRow = {
+            id: Core.getId(),
+            type: "bcrow",
+            left: [],
+            right: [],
+            style: {},
+        };
+
+        const zipper: Editor.Zipper = {
+            row: Editor.zrow(Core.getId(), [], [glyph("2"), glyph("x")]),
+            breadcrumbs: [
+                {
+                    row: bcRow,
+                    focus: Editor.nodeToFocus(node, 21),
+                },
+            ],
+        };
+
+        const moveRight = (
+            state: Editor.State,
+            count: number,
+        ): Editor.State => {
+            let newState = state;
+            for (let i = 0; i < count; i++) {
+                newState = Editor.reducer(newState, {type: "ArrowRight"});
+            }
+            return newState;
+        };
+
+        const fontData = await stixFontLoader();
+        const fontSize = 60;
+        const context = {
+            fontData: fontData,
+            baseFontSize: fontSize,
+            mathStyle: MathStyle.Display,
+            renderMode: RenderMode.Dynamic,
+            cramped: false,
+        };
+        const options = {showCursor: true};
+
+        // TODO: figure out why the content layer returned by typsetZipper
+        // differs when the cursor position is updated.
+        const originalScene = typeset(
+            Editor.zipperToRow(zipper),
+            context,
+            options,
+        );
+
+        // We start with 1 here because originalScene is 0
+        for (let i = 1; i < 8; i++) {
+            const state = moveRight(Editor.stateFromZipper(zipper), i);
+
+            const updatedScene = typeset(
+                Editor.zipperToRow(state.zipper),
+                context,
+                options,
+            );
+
+            expect(updatedScene).toEqual(originalScene);
+        }
+    });
+});

--- a/packages/typesetter/src/typesetters/table.ts
+++ b/packages/typesetter/src/typesetters/table.ts
@@ -176,7 +176,26 @@ export const typesetTable = (
         const col = cursorIndex % node.colCount;
         const zrow = zipper?.row;
 
-        if (zrow) {
+        // We don't want to add padding to cells in a column if the current
+        // cell is empty and there's another cell that isn't empty.
+        let canAddPadding = true;
+        if (node.rowCount > 2) {
+            const child1 = children[1 * node.colCount + col];
+            const child2 = children[2 * node.colCount + col];
+            const length1 = child1?.children?.length ?? 0;
+            const length2 = child2?.children?.length ?? 0;
+            if (length1 !== length2 && length1 * length2 === 0) {
+                const row = Math.floor(cursorIndex / node.colCount);
+                if (row === 1 && length1 === 0) {
+                    canAddPadding = false;
+                }
+                if (row === 2 && length2 === 0) {
+                    canAddPadding = false;
+                }
+            }
+        }
+
+        if (zrow && canAddPadding) {
             if (
                 isCellEqualSign(topRowChildren[col + 1]) &&
                 zrow.left.length === 0


### PR DESCRIPTION
This PR makes the following changes:
- simplifies skip cell code by reformulating it as an `allowed` cells array where true/false values indicate that the cell is allowed/disallowed
- don't add padding when the cursor is in an empty cell if there's another cell in the same column that is not empty
- add a test to verify that navigating across the third column in a carefully crafted example doesn't change the content layer in the scene graph
