### PR TITLE
Update TypeScript to 4.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sloc": "^0.2.1",
     "ts-loader": "^6.2.1",
     "type-coverage": "^2.17.2",
-    "typescript": "4.3.2",
+    "typescript": "4.4.2",
     "typescript-plugin-css-modules": "^3.2.0",
     "utility-types": "^3.10.0",
     "vite": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15153,10 +15153,10 @@ typescript-plugin-css-modules@^3.2.0:
     stylus "^0.54.7"
     tsconfig-paths "^3.9.0"
 
-typescript@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
This version adds support for Inlay Hints.
<img width="397" alt="Screen Shot 2021-08-28 at 12 56 37 PM" src="https://user-images.githubusercontent.com/1044413/131225298-1239ff83-0280-4b20-b748-7200efa7846c.png">
