### PR TITLE
Replace string literals in semantic nodes with an enum

### DIFF
--- a/packages/editor-core/src/parser/vertical-work.ts
+++ b/packages/editor-core/src/parser/vertical-work.ts
@@ -1,5 +1,6 @@
 import {getId} from "@math-blocks/core";
 import * as Parser from "@math-blocks/parser-factory";
+import {NodeType} from "@math-blocks/semantic";
 
 import * as types from "../token/types";
 import {range, zip} from "./util";
@@ -174,7 +175,7 @@ export const parseVerticalWork = (
             : undefined;
 
     return {
-        type: "VerticalAdditionToRelation",
+        type: NodeType.VerticalAdditionToRelation,
         id: getId(),
         loc: table.loc,
         originalRelation: before,

--- a/packages/editor-core/src/printer/__tests__/printer.test.ts
+++ b/packages/editor-core/src/printer/__tests__/printer.test.ts
@@ -9,6 +9,8 @@ import {textRepsToTable} from "../../reducer/vertical-work/test-util";
 
 import {print} from "../printer";
 
+const {NodeType} = Semantic;
+
 expect.extend({toEqualEditorNode});
 
 declare global {
@@ -472,16 +474,16 @@ describe("print", () => {
 
     test("leading subtraction", () => {
         const ast: Semantic.types.NumericNode = {
-            type: "add",
+            type: NodeType.Add,
             id: 0,
             args: [
                 {
-                    type: "neg",
+                    type: NodeType.Neg,
                     id: 1,
                     subtraction: true,
-                    arg: {type: "Identifier", name: "a", id: 2},
+                    arg: {type: NodeType.Identifier, name: "a", id: 2},
                 },
-                {type: "Identifier", name: "b", id: 3},
+                {type: NodeType.Identifier, name: "b", id: 3},
             ],
         } as const;
 
@@ -640,7 +642,7 @@ describe("print", () => {
         // TODO: create Semantic.builders.vertAdd() to help with writing tests
         test("actions and before values at the start", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -672,7 +674,7 @@ describe("print", () => {
 
         test("negative numbers at the start of a row", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -702,7 +704,7 @@ describe("print", () => {
 
         test("actions before and after start row", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -723,7 +725,7 @@ describe("print", () => {
 
         test("actions before start row and aligned with items in start row", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -755,7 +757,7 @@ describe("print", () => {
 
         test("actions before start row and cells in next column aligned", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -788,7 +790,7 @@ describe("print", () => {
 
         test("more terms", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -820,7 +822,7 @@ describe("print", () => {
 
         test("more interleaving", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -854,7 +856,7 @@ describe("print", () => {
 
         test("three rows", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -905,7 +907,7 @@ describe("print", () => {
 
         test("three rows with leading action term", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {
@@ -966,7 +968,7 @@ describe("print", () => {
 
         test("two rows with leading action term", () => {
             const vertAdd: Semantic.types.VerticalAdditionToRelation = {
-                type: "VerticalAdditionToRelation",
+                type: NodeType.VerticalAdditionToRelation,
                 id: getId(),
                 relOp: "eq",
                 originalRelation: {

--- a/packages/parser-factory/src/builders.ts
+++ b/packages/parser-factory/src/builders.ts
@@ -3,6 +3,7 @@
  * with semantic nodes.
  */
 import {getId} from "@math-blocks/core";
+import {NodeType} from "@math-blocks/semantic";
 
 import * as types from "./types";
 
@@ -10,7 +11,7 @@ export const identifier = (
     name: string,
     loc?: types.SourceLocation,
 ): types.Identifier => ({
-    type: "Identifier",
+    type: NodeType.Identifier,
     id: getId(),
     name,
     loc,
@@ -20,14 +21,14 @@ export const number = <T extends string>(
     value: T,
     loc?: types.SourceLocation,
 ): types.Num => ({
-    type: "number",
+    type: NodeType.Number,
     id: getId(),
     value: value.replace(/-/g, "\u2212"),
     loc,
 });
 
 export const ellipsis = (loc?: types.SourceLocation): types.Ellipsis => ({
-    type: "ellipsis",
+    type: NodeType.Ellipsis,
     id: getId(),
     loc,
 });
@@ -36,7 +37,7 @@ export const add = (
     args: TwoOrMore<types.Node>,
     loc?: types.SourceLocation,
 ): types.Add => ({
-    type: "add",
+    type: NodeType.Add,
     id: getId(),
     args,
     loc,
@@ -47,7 +48,7 @@ export const mul = (
     implicit = false,
     loc?: types.SourceLocation,
 ): types.Mul => ({
-    type: "mul",
+    type: NodeType.Mul,
     id: getId(),
     implicit,
     args,
@@ -58,7 +59,7 @@ export const eq = (
     args: TwoOrMore<types.Node>,
     loc?: types.SourceLocation,
 ): types.Eq => ({
-    type: "eq",
+    type: NodeType.Eq,
     id: getId(),
     args,
     loc,
@@ -69,7 +70,7 @@ export const neg = (
     subtraction = false,
     loc?: types.SourceLocation,
 ): types.Neg => ({
-    type: "neg",
+    type: NodeType.Neg,
     id: getId(),
     arg,
     subtraction,
@@ -81,7 +82,7 @@ export const plusminus = (
     arity: "unary" | "binary",
     loc?: types.SourceLocation,
 ): types.PlusMinus => ({
-    type: "plusminus",
+    type: NodeType.PlusMinus,
     id: getId(),
     arg,
     arity,
@@ -93,7 +94,7 @@ export const div = (
     den: types.Node,
     loc?: types.SourceLocation,
 ): types.Div => ({
-    type: "div",
+    type: NodeType.Div,
     id: getId(),
     args: [num, den],
     loc,
@@ -104,7 +105,7 @@ export const pow = (
     exp: types.Node,
     loc?: types.SourceLocation,
 ): types.Pow => ({
-    type: "pow",
+    type: NodeType.Pow,
     id: getId(),
     base,
     exp,
@@ -116,7 +117,7 @@ export const root = (
     index: types.Node,
     loc?: types.SourceLocation,
 ): types.Root => ({
-    type: "root",
+    type: NodeType.Root,
     id: getId(),
     radicand,
     index,
@@ -128,7 +129,7 @@ export const sqrt = (
     radicand: types.Node,
     loc?: types.SourceLocation,
 ): types.Root => ({
-    type: "root",
+    type: NodeType.Root,
     id: getId(),
     radicand,
     index: number("2"),
@@ -140,7 +141,7 @@ export const parens = (
     arg: types.Node,
     loc?: types.SourceLocation,
 ): types.Parens => ({
-    type: "Parens",
+    type: NodeType.Parens,
     id: getId(),
     arg,
     loc,

--- a/packages/parser-factory/src/types.ts
+++ b/packages/parser-factory/src/types.ts
@@ -3,6 +3,16 @@
  * packages/semantic/src/types.ts and then run tools/build-types.js.
  */
 
+import {NodeType} from "@math-blocks/semantic";
+
+export interface Common<T extends NodeType> {
+    readonly type: T;
+    readonly id: number;
+    readonly loc?: SourceLocation;
+    // TODO: rename this to something less ambiguous
+    source?: string; // eslint-disable-line functional/prefer-readonly-type
+}
+
 export type Node = NumericNode | LogicNode | SetNode;
 
 /**
@@ -46,16 +56,14 @@ export type NumericNode =
  * - handle units, e.g. m/s, kg, etc.
  * - add ComplexNumber type
  */
-export type Num = Common & {
-    readonly type: "number";
+export type Num = Common<NodeType.Number> & {
     readonly value: string;
 };
 
 /**
  * Identifier
  */
-export type Identifier = Common & {
-    readonly type: "Identifier";
+export type Identifier = Common<NodeType.Identifier> & {
     readonly name: string;
     readonly subscript?: Node;
 };
@@ -63,16 +71,14 @@ export type Identifier = Common & {
 /**
  * Addition
  */
-export type Add = Common & {
-    readonly type: "add";
+export type Add = Common<NodeType.Add> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Multiplication
  */
-export type Mul = Common & {
-    readonly type: "mul";
+export type Mul = Common<NodeType.Mul> & {
     readonly args: TwoOrMore<Node>;
     readonly implicit: boolean;
 };
@@ -81,20 +87,17 @@ export type Mul = Common & {
  * Negation
  * Can be used to represent negative values as well as subtraction
  */
-export type Neg = Common & {
-    readonly type: "neg";
+export type Neg = Common<NodeType.Neg> & {
     readonly arg: Node;
     readonly subtraction: boolean; // TODO: change this to `arity: "unary" | "binary";`
 };
 
-export type PlusMinus = Common & {
-    readonly type: "plusminus";
+export type PlusMinus = Common<NodeType.PlusMinus> & {
     readonly arg: Node;
     readonly arity: "unary" | "binary";
 };
 
-export type MinusPlus = Common & {
-    readonly type: "minusplus";
+export type MinusPlus = Common<NodeType.MinusPlus> & {
     readonly arg: Node;
     readonly arity: "unary" | "binary";
 };
@@ -102,16 +105,14 @@ export type MinusPlus = Common & {
 /**
  * Division
  */
-export type Div = Common & {
-    readonly type: "div";
+export type Div = Common<NodeType.Div> & {
     readonly args: readonly [Node, Node];
 };
 
 /**
  * Modulus
  */
-export type Mod = Common & {
-    readonly type: "mod";
+export type Mod = Common<NodeType.Mod> & {
     readonly args: readonly [Node, Node];
 };
 
@@ -119,8 +120,7 @@ export type Mod = Common & {
  * Root
  * Can be used for square roots as well nth-degree roots
  */
-export type Root = Common & {
-    readonly type: "root";
+export type Root = Common<NodeType.Root> & {
     readonly radicand: Node;
     readonly index: Node;
     readonly sqrt: boolean; // implies index = 2 and that the index should not be rendered
@@ -129,8 +129,7 @@ export type Root = Common & {
 /**
  * Power
  */
-export type Pow = Common & {
-    readonly type: "pow";
+export type Pow = Common<NodeType.Pow> & {
     readonly base: Node;
     readonly exp: Node;
 };
@@ -138,8 +137,7 @@ export type Pow = Common & {
 /**
  * Logarithm
  */
-export type Log = Common & {
-    readonly type: "log";
+export type Log = Common<NodeType.Log> & {
     readonly base: Node;
     readonly arg: Node;
 };
@@ -148,8 +146,7 @@ export type Log = Common & {
  * Function
  * Can be used to represent function declaration as well as application.
  */
-export type Func = Common & {
-    readonly type: "func";
+export type Func = Common<NodeType.Func> & {
     readonly func: Node;
     readonly args: OneOrMore<Node>;
 };
@@ -157,37 +154,29 @@ export type Func = Common & {
 /**
  * Infinity
  */
-export type Infinity = Common & {
-    readonly type: "infinity";
-};
+export type Infinity = Common<NodeType.Infinity>;
 
 /**
  * pi
  * TODO: Why is pi special?  Maybe we should just use Ident for pi.  What about e?
  */
-export type Pi = Common & {
-    readonly type: "pi";
-};
+export type Pi = Common<NodeType.Pi>;
 
 /**
  * Ellipsis
  */
-export type Ellipsis = Common & {
-    readonly type: "ellipsis";
-};
+export type Ellipsis = Common<NodeType.Ellipsis>;
 
 /**
  * Absolute value
  *
  * e.g. 5! = 1 * 2 * 3 * 4 * 5
  */
-export type Abs = Common & {
-    readonly type: "abs";
+export type Abs = Common<NodeType.Abs> & {
     readonly arg: Node;
 };
 
-export type Parens = Common & {
-    readonly type: "Parens";
+export type Parens = Common<NodeType.Parens> & {
     readonly arg: Node;
 };
 
@@ -208,8 +197,7 @@ type Limits = {
 /**
  * Summation
  */
-export type Sum = Common & {
-    readonly type: "Sum";
+export type Sum = Common<NodeType.Sum> & {
     readonly arg: Node;
     readonly bvar: Identifier; // bound variable, i.e. the variable being summed over
     // TODO: support `condition` and `domainofapplication` as well,
@@ -220,8 +208,7 @@ export type Sum = Common & {
 /**
  * Product
  */
-export type Product = Common & {
-    readonly type: "Product";
+export type Product = Common<NodeType.Product> & {
     readonly arg: Node;
     readonly bvar: Identifier; // bound variable, i.e. the variable being multiplied over
     readonly limits: Limits;
@@ -235,8 +222,7 @@ type TendsTo = {
 /**
  * Limit
  */
-export type Limit = Common & {
-    readonly type: "Limit";
+export type Limit = Common<NodeType.Limit> & {
     readonly arg: Node;
     readonly bvar: Identifier;
     readonly tendsTo: TendsTo;
@@ -245,8 +231,7 @@ export type Limit = Common & {
 /**
  * Derivative
  */
-export type Derivative = Common & {
-    readonly type: "Derivative";
+export type Derivative = Common<NodeType.Derivative> & {
     readonly arg: Node;
     readonly degree?: number; // if no degree is provided this is treated as the first derivative
 };
@@ -254,8 +239,7 @@ export type Derivative = Common & {
 /**
  * Partial derivative
  */
-export type PartialDerivative = Common & {
-    readonly type: "PartialDerivative";
+export type PartialDerivative = Common<NodeType.PartialDerivative> & {
     // TODO: This is insufficient to model high degree partial derivatives
     // https://www.w3.org/TR/MathML3/chapter4.html#contm.partialdiff
     readonly args: readonly [Node, Node];
@@ -264,8 +248,7 @@ export type PartialDerivative = Common & {
 /**
  * Integral
  */
-export type Integral = Common & {
-    readonly type: "Integral";
+export type Integral = Common<NodeType.Integral> & {
     readonly arg: Node;
     readonly bvar: Identifier;
     // TODO: support `domainofapplication`,
@@ -275,30 +258,30 @@ export type Integral = Common & {
 
 type RelationOperator = "eq" | "neq" | "lt" | "lte" | "gt" | "gte";
 
-export type VerticalAdditionToRelation = Common & {
-    readonly type: "VerticalAdditionToRelation";
-    readonly relOp: RelationOperator;
-    readonly originalRelation: {
-        readonly left: readonly (Node | null)[];
-        readonly right: readonly (Node | null)[];
+export type VerticalAdditionToRelation =
+    Common<NodeType.VerticalAdditionToRelation> & {
+        readonly relOp: RelationOperator;
+        readonly originalRelation: {
+            readonly left: readonly (Node | null)[];
+            readonly right: readonly (Node | null)[];
+        };
+        readonly actions: {
+            readonly left: readonly (Node | null)[];
+            readonly right: readonly (Node | null)[];
+        };
+        readonly resultingRelation?: {
+            readonly left: readonly (Node | null)[];
+            readonly right: readonly (Node | null)[];
+        };
     };
-    readonly actions: {
-        readonly left: readonly (Node | null)[];
-        readonly right: readonly (Node | null)[];
-    };
-    readonly resultingRelation?: {
-        readonly left: readonly (Node | null)[];
-        readonly right: readonly (Node | null)[];
-    };
-};
 
 // When complete, the result of this is a logic value
-export type SystemOfRelationsElimination = Common & {
-    readonly type: "SystemOfRelationsElimination";
-    readonly relOp: RelationOperator;
-    // TODO: fill this out
-    // two or three rows
-};
+export type SystemOfRelationsElimination =
+    Common<NodeType.SystemOfRelationsElimination> & {
+        readonly relOp: RelationOperator;
+        // TODO: fill this out
+        // two or three rows
+    };
 
 // Basic Arithmetic Algorithms
 
@@ -308,16 +291,14 @@ type Digit = Num;
 // TODO: extend these types to support decimals
 
 // When complete, the result of this is a numeric value
-export type LongAddition = Common & {
-    readonly type: "LongAddition";
+export type LongAddition = Common<NodeType.LongAddition> & {
     readonly terms: readonly (readonly Digit[])[];
     readonly sum: readonly (Digit | null)[];
     readonly carries: readonly (Digit | null)[];
 };
 
 // When complete, the result of this is a numeric value
-export type LongSubtraction = Common & {
-    readonly type: "LongSubtraction";
+export type LongSubtraction = Common<NodeType.LongSubtraction> & {
     readonly minuend: readonly Digit[];
     readonly subtrahend: readonly (Digit | null)[];
     readonly difference: readonly (Digit | null)[];
@@ -325,8 +306,7 @@ export type LongSubtraction = Common & {
 };
 
 // When complete, the result of this is a numeric value
-export type LongMultiplication = Common & {
-    readonly type: "LongMultiplication";
+export type LongMultiplication = Common<NodeType.LongMultiplication> & {
     readonly factors: readonly (readonly Digit[])[];
     readonly partialProducts: readonly (readonly Digit[])[];
     readonly product: readonly (Digit | null)[];
@@ -334,8 +314,7 @@ export type LongMultiplication = Common & {
 };
 
 // When complete, the result of this is a numeric value
-export type LongDivision = Common & {
-    readonly type: "LongDivision";
+export type LongDivision = Common<NodeType.LongDivision> & {
     readonly dividend: readonly Digit[];
     readonly divisor: readonly (Digit | null)[];
     readonly quotient: readonly (Digit | null)[];
@@ -375,112 +354,95 @@ export type LogicNode =
 /**
  * True
  */
-export type True = Common & {
-    readonly type: "true";
-};
+export type True = Common<NodeType.True>;
 
 /**
  * False
  */
-export type False = Common & {
-    readonly type: "false";
-};
+export type False = Common<NodeType.False>;
 
 /**
  * Logical And (Conjunction)
  */
-export type And = Common & {
-    readonly type: "and";
+export type And = Common<NodeType.And> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Logical Or (Disjunction)
  */
-export type Or = Common & {
-    readonly type: "or";
+export type Or = Common<NodeType.Or> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Logical Not (Inverse)
  */
-export type Not = Common & {
-    readonly type: "not";
+export type Not = Common<NodeType.Not> & {
     readonly arg: Node;
 };
 
 /**
  * Exclusive Or
  */
-export type Xor = Common & {
-    readonly type: "xor";
+export type Xor = Common<NodeType.Xor> & {
     readonly args: TwoOrMore<Node>;
 };
 
-export type Implies = Common & {
-    readonly type: "implies";
+export type Implies = Common<NodeType.Implies> & {
     readonly args: readonly [Node, Node];
 };
 
-export type Iff = Common & {
-    readonly type: "iff";
+export type Iff = Common<NodeType.Iff> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Equals
  */
-export type Eq = Common & {
-    readonly type: "eq";
+export type Eq = Common<NodeType.Eq> & {
     readonly args: TwoOrMore<Node> | TwoOrMore<Node> | TwoOrMore<Node>;
 };
 
 /**
  * Not Equals
  */
-export type Neq = Common & {
-    readonly type: "neq";
+export type Neq = Common<NodeType.Neq> & {
     readonly args: TwoOrMore<Node> | TwoOrMore<Node> | TwoOrMore<Node>;
 };
 
 /**
  * Less Than
  */
-export type Lt = Common & {
-    readonly type: "lt";
+export type Lt = Common<NodeType.Lt> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Less Than or Equal to
  */
-export type Lte = Common & {
-    readonly type: "lte";
+export type Lte = Common<NodeType.Lte> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Greater Than
  */
-export type Gt = Common & {
-    readonly type: "gt";
+export type Gt = Common<NodeType.Gt> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Greater Than or Equal to
  */
-export type Gte = Common & {
-    readonly type: "gte";
+export type Gte = Common<NodeType.Gte> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Element in set
  */
-export type In = Common & {
-    readonly type: "in";
+export type In = Common<NodeType.In> & {
     readonly element: Node;
     readonly set: Node;
 };
@@ -488,8 +450,7 @@ export type In = Common & {
 /**
  * Element is not a set
  */
-export type NotIn = Common & {
-    readonly type: "notin";
+export type NotIn = Common<NodeType.NotIn> & {
     readonly element: Node;
     readonly set: Node;
 };
@@ -497,32 +458,28 @@ export type NotIn = Common & {
 /**
  * Subset
  */
-export type Subset = Common & {
-    readonly type: "subset";
+export type Subset = Common<NodeType.Subset> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Proper Subset
  */
-export type ProperSubset = Common & {
-    readonly type: "prsubset";
+export type ProperSubset = Common<NodeType.ProperSubset> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Not a Subset
  */
-export type NotSubset = Common & {
-    readonly type: "notsubset";
+export type NotSubset = Common<NodeType.NotSubset> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Propert Not a Subset
  */
-export type NotProperSubset = Common & {
-    readonly type: "notprsubset";
+export type NotProperSubset = Common<NodeType.NotProperSubset> & {
     readonly args: TwoOrMore<Node>;
 };
 
@@ -547,8 +504,7 @@ export type SetNode =
 /**
  * Set containing zero or more elements
  */
-export type Set = Common & {
-    readonly type: "set";
+export type Set = Common<NodeType.Set> & {
     // TODO: expand this to include other things like words, shapes, images, etc.
     readonly args: readonly Node[];
 };
@@ -557,39 +513,33 @@ export type Set = Common & {
  * Empty Set
  * A set containing no elements.
  */
-export type EmptySet = Common & {
-    readonly type: "empty";
-};
+export type EmptySet = Common<NodeType.EmptySet>;
 
 /**
  * Union
  */
-export type Union = Common & {
-    readonly type: "union";
+export type Union = Common<NodeType.Union> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Intersection
  */
-export type Intersection = Common & {
-    readonly type: "intersection";
+export type Intersection = Common<NodeType.Intersection> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Set Difference
  */
-export type SetDiff = Common & {
-    readonly type: "setdiff";
+export type SetDiff = Common<NodeType.SetDiff> & {
     readonly args: readonly [Node, Node];
 };
 
 /**
  * Cartesian Product
  */
-export type CartesianProduct = Common & {
-    readonly type: "cartesian_product";
+export type CartesianProduct = Common<NodeType.CartesianProduct> & {
     readonly args: TwoOrMore<Node>;
 };
 
@@ -597,46 +547,29 @@ export type CartesianProduct = Common & {
  * Natural Numbers (counting numbers)
  * e.g. 1, 2, 3, ...
  */
-export type Naturals = Common & {
-    readonly type: "naturals";
-};
+export type Naturals = Common<NodeType.Naturals>;
 
 /**
  * Integers
  * e.g. ..., -2, -1, 0, 1, 2, ...
  */
-export type Integers = Common & {
-    readonly type: "integers";
-};
+export type Integers = Common<NodeType.Integers>;
 
 /**
  * Rationals
  * p / q, where p and q are integers
  */
-export type Rationals = Common & {
-    readonly type: "rationals";
-};
+export type Rationals = Common<NodeType.Rationals>;
 
 /**
  * Real Numbers
  */
-export type Reals = Common & {
-    readonly type: "reals";
-};
+export type Reals = Common<NodeType.Reals>;
 
 /**
  * Complex Numbers
  */
-export type Complexes = Common & {
-    readonly type: "complexes";
-};
-
-export interface Common {
-    readonly id: number;
-    readonly loc?: SourceLocation;
-    // TODO: rename this to something less ambiguous
-    source?: string; // eslint-disable-line functional/prefer-readonly-type
-}
+export type Complexes = Common<NodeType.Complexes>;
 
 // TODO: dedupe with editor-core and parser-factory
 export interface SourceLocation {

--- a/packages/semantic/src/__tests__/traverse.test.ts
+++ b/packages/semantic/src/__tests__/traverse.test.ts
@@ -1,11 +1,12 @@
 import {traverse} from "../util";
 import * as types from "../types";
+import {NodeType} from "../enums";
 
 describe("traverse", () => {
     it("call enter and exit once for a single node", () => {
         const num: types.Num = {
             id: 0,
-            type: "number",
+            type: NodeType.Number,
             value: "123",
         };
         const enter = jest.fn();
@@ -22,16 +23,16 @@ describe("traverse", () => {
     it("should traverse arrays", () => {
         const add: types.Add = {
             id: 0,
-            type: "add",
+            type: NodeType.Add,
             args: [
                 {
                     id: 1,
-                    type: "number",
+                    type: NodeType.Number,
                     value: "123",
                 },
                 {
                     id: 2,
-                    type: "number",
+                    type: NodeType.Number,
                     value: "456",
                 },
             ],
@@ -49,15 +50,15 @@ describe("traverse", () => {
     it("call traverse properties", () => {
         const power: types.Pow = {
             id: 0,
-            type: "pow",
+            type: NodeType.Pow,
             base: {
                 id: 1,
-                type: "Identifier",
+                type: NodeType.Identifier,
                 name: "x",
             },
             exp: {
                 id: 2,
-                type: "number",
+                type: NodeType.Number,
                 value: "3",
             },
         };
@@ -74,7 +75,7 @@ describe("traverse", () => {
     it("should not call cb on location", () => {
         const num: types.Num = {
             id: 0,
-            type: "number",
+            type: NodeType.Number,
             value: "123",
             loc: {
                 path: [],
@@ -93,15 +94,15 @@ describe("traverse", () => {
     it("supports making changes to a node on exit", () => {
         const power: types.Pow = {
             id: 0,
-            type: "pow",
+            type: NodeType.Pow,
             base: {
                 id: 1,
-                type: "Identifier",
+                type: NodeType.Identifier,
                 name: "x",
             },
             exp: {
                 id: 2,
-                type: "number",
+                type: NodeType.Number,
                 value: "3",
             },
         };
@@ -136,16 +137,16 @@ describe("traverse", () => {
     it("supports making changes to an element in an array on exit", () => {
         const sum: types.Add = {
             id: 0,
-            type: "add",
+            type: NodeType.Add,
             args: [
                 {
                     id: 1,
-                    type: "Identifier",
+                    type: NodeType.Identifier,
                     name: "x",
                 },
                 {
                     id: 2,
-                    type: "number",
+                    type: NodeType.Number,
                     value: "3",
                 },
             ],

--- a/packages/semantic/src/builders.ts
+++ b/packages/semantic/src/builders.ts
@@ -1,12 +1,13 @@
 import {getId} from "@math-blocks/core";
 
 import * as types from "./types";
+import {NodeType} from "./enums";
 
 export const identifier = (
     name: string,
     loc?: types.SourceLocation,
 ): types.Identifier => ({
-    type: "Identifier",
+    type: NodeType.Identifier,
     id: getId(),
     name,
     loc,
@@ -21,7 +22,7 @@ export const number = <T extends string>(
         return neg(number(value.slice(1)));
     }
     return {
-        type: "number",
+        type: NodeType.Number,
         id: getId(),
         value: value.replace(/-/g, "\u2212"),
         loc,
@@ -29,7 +30,7 @@ export const number = <T extends string>(
 };
 
 export const ellipsis = (loc?: types.SourceLocation): types.Ellipsis => ({
-    type: "ellipsis",
+    type: NodeType.Ellipsis,
     id: getId(),
     loc,
 });
@@ -45,7 +46,7 @@ export const add = (
             return terms[0]; // TODO: figure out if we should give this node a location
         default:
             return {
-                type: "add",
+                type: NodeType.Add,
                 id: getId(),
                 args: terms as TwoOrMore<types.NumericNode>,
                 loc,
@@ -65,7 +66,7 @@ export const mul = (
             return factors[0]; // TODO: figure out if we should give this node a location
         default:
             return {
-                type: "mul",
+                type: NodeType.Mul,
                 id: getId(),
                 implicit,
                 args: factors as TwoOrMore<types.NumericNode>,
@@ -81,7 +82,7 @@ export const eq = (
         | TwoOrMore<types.SetNode>,
     loc?: types.SourceLocation,
 ): types.Eq => ({
-    type: "eq",
+    type: NodeType.Eq,
     id: getId(),
     args,
     loc,
@@ -92,7 +93,7 @@ export const neg = (
     subtraction = false,
     loc?: types.SourceLocation,
 ): types.Neg => ({
-    type: "neg",
+    type: NodeType.Neg,
     id: getId(),
     arg,
     subtraction,
@@ -104,7 +105,7 @@ export const div = (
     den: types.NumericNode,
     loc?: types.SourceLocation,
 ): types.Div => ({
-    type: "div",
+    type: NodeType.Div,
     id: getId(),
     args: [num, den],
     loc,
@@ -115,7 +116,7 @@ export const pow = (
     exp: types.NumericNode,
     loc?: types.SourceLocation,
 ): types.Pow => ({
-    type: "pow",
+    type: NodeType.Pow,
     id: getId(),
     base,
     exp,
@@ -127,7 +128,7 @@ export const root = (
     index: types.NumericNode,
     loc?: types.SourceLocation,
 ): types.Root => ({
-    type: "root",
+    type: NodeType.Root,
     id: getId(),
     radicand,
     index,
@@ -139,7 +140,7 @@ export const sqrt = (
     radicand: types.NumericNode,
     loc?: types.SourceLocation,
 ): types.Root => ({
-    type: "root",
+    type: NodeType.Root,
     id: getId(),
     radicand,
     index: number("2"),
@@ -151,7 +152,7 @@ export const parens = (
     arg: types.Node,
     loc?: types.SourceLocation,
 ): types.Parens => ({
-    type: "Parens",
+    type: NodeType.Parens,
     id: getId(),
     arg,
     loc,

--- a/packages/semantic/src/enums.ts
+++ b/packages/semantic/src/enums.ts
@@ -1,0 +1,68 @@
+export enum NodeType {
+    // Numeric Node Types
+    Number = "number",
+    Identifier = "Identifier",
+    Add = "add",
+    Mul = "mul",
+    Neg = "neg",
+    PlusMinus = "plusminus",
+    MinusPlus = "minusplus",
+    Div = "div",
+    Mod = "mod",
+    Root = "root",
+    Pow = "pow",
+    Log = "log",
+    Func = "func",
+    Infinity = "infinity",
+    Pi = "pi",
+    Ellipsis = "ellipsis",
+    Abs = "abs",
+    Parens = "Parens",
+    Sum = "Sum",
+    Product = "Product",
+    Limit = "Limit",
+    Derivative = "Derivative",
+    PartialDerivative = "PartialDerivative",
+    Integral = "Integral",
+    VerticalAdditionToRelation = "VerticalAdditionToRelation",
+    SystemOfRelationsElimination = "SystemOfRelationsElimination",
+    LongAddition = "LongAddition",
+    LongSubtraction = "LongSubtraction",
+    LongMultiplication = "LongMultiplication",
+    LongDivision = "LongDivision",
+
+    // Logic Node Types
+    True = "true",
+    False = "false",
+    And = "and", // rename to Conjunction
+    Or = "or", // rename to Disjunction
+    Not = "not", // rename to LogicalInverse
+    Xor = "xor",
+    Implies = "implies",
+    Iff = "iff",
+    Eq = "eq", // Equals
+    Neq = "neq", // NotEquals
+    Lt = "lt", // LessThan
+    Lte = "lte", // LessThanOrEquals
+    Gt = "gt", // GreaterThan
+    Gte = "gte", // GreaterThanOrEquals
+
+    // Set Node Types
+    In = "in",
+    NotIn = "notin",
+    Subset = "subset",
+    ProperSubset = "prsubset",
+    NotSubset = "notsubset",
+    NotProperSubset = "notprsubset",
+    Set = "set",
+    EmptySet = "empty",
+    Union = "union",
+    Intersection = "intersection", // rename to SetIntersection
+    SetDiff = "setdiff", // rename to SetDifference
+    CartesianProduct = "cartesian_product",
+    Naturals = "naturals",
+    Integers = "integers",
+    Rationals = "rationals",
+    Reals = "reals",
+    Complexes = "complexes",
+}

--- a/packages/semantic/src/index.ts
+++ b/packages/semantic/src/index.ts
@@ -1,3 +1,5 @@
+export {NodeType} from "./enums";
+
 import * as types from "./types";
 import * as builders from "./builders";
 import * as util from "./util";

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -1,3 +1,13 @@
+import {NodeType} from "./enums";
+
+export interface Common<T extends NodeType> {
+    readonly type: T;
+    readonly id: number;
+    readonly loc?: SourceLocation;
+    // TODO: rename this to something less ambiguous
+    source?: string; // eslint-disable-line functional/prefer-readonly-type
+}
+
 export type Node = NumericNode | LogicNode | SetNode;
 
 /**
@@ -41,16 +51,14 @@ export type NumericNode =
  * - handle units, e.g. m/s, kg, etc.
  * - add ComplexNumber type
  */
-export type Num = Common & {
-    readonly type: "number";
+export type Num = Common<NodeType.Number> & {
     readonly value: string;
 };
 
 /**
  * Identifier
  */
-export type Identifier = Common & {
-    readonly type: "Identifier";
+export type Identifier = Common<NodeType.Identifier> & {
     readonly name: string;
     readonly subscript?: NumericNode;
 };
@@ -58,16 +66,14 @@ export type Identifier = Common & {
 /**
  * Addition
  */
-export type Add = Common & {
-    readonly type: "add";
+export type Add = Common<NodeType.Add> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Multiplication
  */
-export type Mul = Common & {
-    readonly type: "mul";
+export type Mul = Common<NodeType.Mul> & {
     readonly args: TwoOrMore<NumericNode>;
     readonly implicit: boolean;
 };
@@ -76,20 +82,17 @@ export type Mul = Common & {
  * Negation
  * Can be used to represent negative values as well as subtraction
  */
-export type Neg = Common & {
-    readonly type: "neg";
+export type Neg = Common<NodeType.Neg> & {
     readonly arg: NumericNode;
     readonly subtraction: boolean; // TODO: change this to `arity: "unary" | "binary";`
 };
 
-export type PlusMinus = Common & {
-    readonly type: "plusminus";
+export type PlusMinus = Common<NodeType.PlusMinus> & {
     readonly arg: NumericNode;
     readonly arity: "unary" | "binary";
 };
 
-export type MinusPlus = Common & {
-    readonly type: "minusplus";
+export type MinusPlus = Common<NodeType.MinusPlus> & {
     readonly arg: NumericNode;
     readonly arity: "unary" | "binary";
 };
@@ -97,16 +100,14 @@ export type MinusPlus = Common & {
 /**
  * Division
  */
-export type Div = Common & {
-    readonly type: "div";
+export type Div = Common<NodeType.Div> & {
     readonly args: readonly [NumericNode, NumericNode];
 };
 
 /**
  * Modulus
  */
-export type Mod = Common & {
-    readonly type: "mod";
+export type Mod = Common<NodeType.Mod> & {
     readonly args: readonly [NumericNode, NumericNode];
 };
 
@@ -114,8 +115,7 @@ export type Mod = Common & {
  * Root
  * Can be used for square roots as well nth-degree roots
  */
-export type Root = Common & {
-    readonly type: "root";
+export type Root = Common<NodeType.Root> & {
     readonly radicand: NumericNode;
     readonly index: NumericNode;
     readonly sqrt: boolean; // implies index = 2 and that the index should not be rendered
@@ -124,8 +124,7 @@ export type Root = Common & {
 /**
  * Power
  */
-export type Pow = Common & {
-    readonly type: "pow";
+export type Pow = Common<NodeType.Pow> & {
     readonly base: NumericNode;
     readonly exp: NumericNode;
 };
@@ -133,8 +132,7 @@ export type Pow = Common & {
 /**
  * Logarithm
  */
-export type Log = Common & {
-    readonly type: "log";
+export type Log = Common<NodeType.Log> & {
     readonly base: NumericNode;
     readonly arg: NumericNode;
 };
@@ -143,8 +141,7 @@ export type Log = Common & {
  * Function
  * Can be used to represent function declaration as well as application.
  */
-export type Func = Common & {
-    readonly type: "func";
+export type Func = Common<NodeType.Func> & {
     readonly func: NumericNode;
     readonly args: OneOrMore<NumericNode>;
 };
@@ -152,37 +149,29 @@ export type Func = Common & {
 /**
  * Infinity
  */
-export type Infinity = Common & {
-    readonly type: "infinity";
-};
+export type Infinity = Common<NodeType.Infinity>;
 
 /**
  * pi
  * TODO: Why is pi special?  Maybe we should just use Ident for pi.  What about e?
  */
-export type Pi = Common & {
-    readonly type: "pi";
-};
+export type Pi = Common<NodeType.Pi>;
 
 /**
  * Ellipsis
  */
-export type Ellipsis = Common & {
-    readonly type: "ellipsis";
-};
+export type Ellipsis = Common<NodeType.Ellipsis>;
 
 /**
  * Absolute value
  *
  * e.g. 5! = 1 * 2 * 3 * 4 * 5
  */
-export type Abs = Common & {
-    readonly type: "abs";
+export type Abs = Common<NodeType.Abs> & {
     readonly arg: NumericNode;
 };
 
-export type Parens = Common & {
-    readonly type: "Parens";
+export type Parens = Common<NodeType.Parens> & {
     readonly arg: Node;
 };
 
@@ -203,8 +192,7 @@ type Limits = {
 /**
  * Summation
  */
-export type Sum = Common & {
-    readonly type: "Sum";
+export type Sum = Common<NodeType.Sum> & {
     readonly arg: NumericNode;
     readonly bvar: Identifier; // bound variable, i.e. the variable being summed over
     // TODO: support `condition` and `domainofapplication` as well,
@@ -215,8 +203,7 @@ export type Sum = Common & {
 /**
  * Product
  */
-export type Product = Common & {
-    readonly type: "Product";
+export type Product = Common<NodeType.Product> & {
     readonly arg: NumericNode;
     readonly bvar: Identifier; // bound variable, i.e. the variable being multiplied over
     readonly limits: Limits;
@@ -230,8 +217,7 @@ type TendsTo = {
 /**
  * Limit
  */
-export type Limit = Common & {
-    readonly type: "Limit";
+export type Limit = Common<NodeType.Limit> & {
     readonly arg: NumericNode;
     readonly bvar: Identifier;
     readonly tendsTo: TendsTo;
@@ -240,8 +226,7 @@ export type Limit = Common & {
 /**
  * Derivative
  */
-export type Derivative = Common & {
-    readonly type: "Derivative";
+export type Derivative = Common<NodeType.Derivative> & {
     readonly arg: NumericNode;
     readonly degree?: number; // if no degree is provided this is treated as the first derivative
 };
@@ -249,8 +234,7 @@ export type Derivative = Common & {
 /**
  * Partial derivative
  */
-export type PartialDerivative = Common & {
-    readonly type: "PartialDerivative";
+export type PartialDerivative = Common<NodeType.PartialDerivative> & {
     // TODO: This is insufficient to model high degree partial derivatives
     // https://www.w3.org/TR/MathML3/chapter4.html#contm.partialdiff
     readonly args: readonly [NumericNode, NumericNode];
@@ -259,8 +243,7 @@ export type PartialDerivative = Common & {
 /**
  * Integral
  */
-export type Integral = Common & {
-    readonly type: "Integral";
+export type Integral = Common<NodeType.Integral> & {
     readonly arg: NumericNode;
     readonly bvar: Identifier;
     // TODO: support `domainofapplication`,
@@ -270,30 +253,30 @@ export type Integral = Common & {
 
 type RelationOperator = "eq" | "neq" | "lt" | "lte" | "gt" | "gte";
 
-export type VerticalAdditionToRelation = Common & {
-    readonly type: "VerticalAdditionToRelation";
-    readonly relOp: RelationOperator;
-    readonly originalRelation: {
-        readonly left: readonly (NumericNode | null)[];
-        readonly right: readonly (NumericNode | null)[];
+export type VerticalAdditionToRelation =
+    Common<NodeType.VerticalAdditionToRelation> & {
+        readonly relOp: RelationOperator;
+        readonly originalRelation: {
+            readonly left: readonly (NumericNode | null)[];
+            readonly right: readonly (NumericNode | null)[];
+        };
+        readonly actions: {
+            readonly left: readonly (NumericNode | null)[];
+            readonly right: readonly (NumericNode | null)[];
+        };
+        readonly resultingRelation?: {
+            readonly left: readonly (NumericNode | null)[];
+            readonly right: readonly (NumericNode | null)[];
+        };
     };
-    readonly actions: {
-        readonly left: readonly (NumericNode | null)[];
-        readonly right: readonly (NumericNode | null)[];
-    };
-    readonly resultingRelation?: {
-        readonly left: readonly (NumericNode | null)[];
-        readonly right: readonly (NumericNode | null)[];
-    };
-};
 
 // When complete, the result of this is a logic value
-export type SystemOfRelationsElimination = Common & {
-    readonly type: "SystemOfRelationsElimination";
-    readonly relOp: RelationOperator;
-    // TODO: fill this out
-    // two or three rows
-};
+export type SystemOfRelationsElimination =
+    Common<NodeType.SystemOfRelationsElimination> & {
+        readonly relOp: RelationOperator;
+        // TODO: fill this out
+        // two or three rows
+    };
 
 // Basic Arithmetic Algorithms
 
@@ -303,16 +286,14 @@ type Digit = Num;
 // TODO: extend these types to support decimals
 
 // When complete, the result of this is a numeric value
-export type LongAddition = Common & {
-    readonly type: "LongAddition";
+export type LongAddition = Common<NodeType.LongAddition> & {
     readonly terms: readonly (readonly Digit[])[];
     readonly sum: readonly (Digit | null)[];
     readonly carries: readonly (Digit | null)[];
 };
 
 // When complete, the result of this is a numeric value
-export type LongSubtraction = Common & {
-    readonly type: "LongSubtraction";
+export type LongSubtraction = Common<NodeType.LongSubtraction> & {
     readonly minuend: readonly Digit[];
     readonly subtrahend: readonly (Digit | null)[];
     readonly difference: readonly (Digit | null)[];
@@ -320,8 +301,7 @@ export type LongSubtraction = Common & {
 };
 
 // When complete, the result of this is a numeric value
-export type LongMultiplication = Common & {
-    readonly type: "LongMultiplication";
+export type LongMultiplication = Common<NodeType.LongMultiplication> & {
     readonly factors: readonly (readonly Digit[])[];
     readonly partialProducts: readonly (readonly Digit[])[];
     readonly product: readonly (Digit | null)[];
@@ -329,8 +309,7 @@ export type LongMultiplication = Common & {
 };
 
 // When complete, the result of this is a numeric value
-export type LongDivision = Common & {
-    readonly type: "LongDivision";
+export type LongDivision = Common<NodeType.LongDivision> & {
     readonly dividend: readonly Digit[];
     readonly divisor: readonly (Digit | null)[];
     readonly quotient: readonly (Digit | null)[];
@@ -370,64 +349,53 @@ export type LogicNode =
 /**
  * True
  */
-export type True = Common & {
-    readonly type: "true";
-};
+export type True = Common<NodeType.True>;
 
 /**
  * False
  */
-export type False = Common & {
-    readonly type: "false";
-};
+export type False = Common<NodeType.False>;
 
 /**
  * Logical And (Conjunction)
  */
-export type And = Common & {
-    readonly type: "and";
+export type And = Common<NodeType.And> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
 /**
  * Logical Or (Disjunction)
  */
-export type Or = Common & {
-    readonly type: "or";
+export type Or = Common<NodeType.Or> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
 /**
  * Logical Not (Inverse)
  */
-export type Not = Common & {
-    readonly type: "not";
+export type Not = Common<NodeType.Not> & {
     readonly arg: LogicNode;
 };
 
 /**
  * Exclusive Or
  */
-export type Xor = Common & {
-    readonly type: "xor";
+export type Xor = Common<NodeType.Xor> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
-export type Implies = Common & {
-    readonly type: "implies";
+export type Implies = Common<NodeType.Implies> & {
     readonly args: readonly [LogicNode, LogicNode];
 };
 
-export type Iff = Common & {
-    readonly type: "iff";
+export type Iff = Common<NodeType.Iff> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
 /**
  * Equals
  */
-export type Eq = Common & {
-    readonly type: "eq";
+export type Eq = Common<NodeType.Eq> & {
     readonly args:
         | TwoOrMore<NumericNode>
         | TwoOrMore<LogicNode>
@@ -437,8 +405,7 @@ export type Eq = Common & {
 /**
  * Not Equals
  */
-export type Neq = Common & {
-    readonly type: "neq";
+export type Neq = Common<NodeType.Neq> & {
     readonly args:
         | TwoOrMore<NumericNode>
         | TwoOrMore<LogicNode>
@@ -448,40 +415,35 @@ export type Neq = Common & {
 /**
  * Less Than
  */
-export type Lt = Common & {
-    readonly type: "lt";
+export type Lt = Common<NodeType.Lt> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Less Than or Equal to
  */
-export type Lte = Common & {
-    readonly type: "lte";
+export type Lte = Common<NodeType.Lte> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Greater Than
  */
-export type Gt = Common & {
-    readonly type: "gt";
+export type Gt = Common<NodeType.Gt> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Greater Than or Equal to
  */
-export type Gte = Common & {
-    readonly type: "gte";
+export type Gte = Common<NodeType.Gte> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Element in set
  */
-export type In = Common & {
-    readonly type: "in";
+export type In = Common<NodeType.In> & {
     readonly element: Node;
     readonly set: SetNode;
 };
@@ -489,8 +451,7 @@ export type In = Common & {
 /**
  * Element is not a set
  */
-export type NotIn = Common & {
-    readonly type: "notin";
+export type NotIn = Common<NodeType.NotIn> & {
     readonly element: Node;
     readonly set: SetNode;
 };
@@ -498,32 +459,28 @@ export type NotIn = Common & {
 /**
  * Subset
  */
-export type Subset = Common & {
-    readonly type: "subset";
+export type Subset = Common<NodeType.Subset> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
 /**
  * Proper Subset
  */
-export type ProperSubset = Common & {
-    readonly type: "prsubset";
+export type ProperSubset = Common<NodeType.ProperSubset> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
 /**
  * Not a Subset
  */
-export type NotSubset = Common & {
-    readonly type: "notsubset";
+export type NotSubset = Common<NodeType.NotSubset> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
 /**
  * Propert Not a Subset
  */
-export type NotProperSubset = Common & {
-    readonly type: "notprsubset";
+export type NotProperSubset = Common<NodeType.NotProperSubset> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
@@ -548,8 +505,7 @@ export type SetNode =
 /**
  * Set containing zero or more elements
  */
-export type Set = Common & {
-    readonly type: "set";
+export type Set = Common<NodeType.Set> & {
     // TODO: expand this to include other things like words, shapes, images, etc.
     readonly args: readonly Node[];
 };
@@ -558,39 +514,33 @@ export type Set = Common & {
  * Empty Set
  * A set containing no elements.
  */
-export type EmptySet = Common & {
-    readonly type: "empty";
-};
+export type EmptySet = Common<NodeType.EmptySet>;
 
 /**
  * Union
  */
-export type Union = Common & {
-    readonly type: "union";
+export type Union = Common<NodeType.Union> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
 /**
  * Intersection
  */
-export type Intersection = Common & {
-    readonly type: "intersection";
+export type Intersection = Common<NodeType.Intersection> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
 /**
  * Set Difference
  */
-export type SetDiff = Common & {
-    readonly type: "setdiff";
+export type SetDiff = Common<NodeType.SetDiff> & {
     readonly args: readonly [SetNode, SetNode];
 };
 
 /**
  * Cartesian Product
  */
-export type CartesianProduct = Common & {
-    readonly type: "cartesian_product";
+export type CartesianProduct = Common<NodeType.CartesianProduct> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
@@ -598,46 +548,29 @@ export type CartesianProduct = Common & {
  * Natural Numbers (counting numbers)
  * e.g. 1, 2, 3, ...
  */
-export type Naturals = Common & {
-    readonly type: "naturals";
-};
+export type Naturals = Common<NodeType.Naturals>;
 
 /**
  * Integers
  * e.g. ..., -2, -1, 0, 1, 2, ...
  */
-export type Integers = Common & {
-    readonly type: "integers";
-};
+export type Integers = Common<NodeType.Integers>;
 
 /**
  * Rationals
  * p / q, where p and q are integers
  */
-export type Rationals = Common & {
-    readonly type: "rationals";
-};
+export type Rationals = Common<NodeType.Rationals>;
 
 /**
  * Real Numbers
  */
-export type Reals = Common & {
-    readonly type: "reals";
-};
+export type Reals = Common<NodeType.Reals>;
 
 /**
  * Complex Numbers
  */
-export type Complexes = Common & {
-    readonly type: "complexes";
-};
-
-export interface Common {
-    readonly id: number;
-    readonly loc?: SourceLocation;
-    // TODO: rename this to something less ambiguous
-    source?: string; // eslint-disable-line functional/prefer-readonly-type
-}
+export type Complexes = Common<NodeType.Complexes>;
 
 // TODO: dedupe with editor-core and parser-factory
 export interface SourceLocation {

--- a/packages/semantic/src/util.ts
+++ b/packages/semantic/src/util.ts
@@ -5,6 +5,7 @@
 import Fraction from "fraction.js";
 
 import * as types from "./types";
+import {NodeType} from "./enums";
 
 export const isSubtraction = (node: types.NumericNode): node is types.Neg =>
     node.type === "neg" && node.subtraction;
@@ -44,29 +45,30 @@ export const isNumber = (node: types.Node): boolean => {
 
 // TODO: autogenerate this from the validation schema
 export const isNumeric = (node: types.Node): node is types.NumericNode => {
-    return [
-        "number",
-        "Identifier",
-        "pi",
-        "infinity",
-        "ellipsis",
-        "add",
-        "mul",
-        "func",
-        "div",
-        "mod",
-        "root",
-        "pow",
-        "log",
-        "neg",
-        "abs",
-        "Sum",
-        "Product",
-        "limit",
-        "Derivative",
-        "PartialDerivative",
-        "Integral",
-    ].includes(node.type);
+    const NumericNodeTypes: NodeType[] = [
+        NodeType.Number,
+        NodeType.Identifier,
+        NodeType.Pi,
+        NodeType.Infinity,
+        NodeType.Ellipsis,
+        NodeType.Add,
+        NodeType.Mul,
+        NodeType.Func,
+        NodeType.Div,
+        NodeType.Mod,
+        NodeType.Root,
+        NodeType.Pow,
+        NodeType.Log,
+        NodeType.Neg,
+        NodeType.Abs,
+        NodeType.Sum,
+        NodeType.Product,
+        NodeType.Limit,
+        NodeType.Derivative,
+        NodeType.PartialDerivative,
+        NodeType.Integral,
+    ];
+    return NumericNodeTypes.includes(node.type);
 };
 
 const isObject = (val: unknown): val is Record<string, unknown> => {

--- a/packages/testing/src/__tests__/printer.test.ts
+++ b/packages/testing/src/__tests__/printer.test.ts
@@ -2,6 +2,8 @@ import * as Semantic from "@math-blocks/semantic";
 import {print} from "../printer";
 import {parse} from "../text-parser";
 
+const {NodeType} = Semantic;
+
 describe("printer", () => {
     describe("add/sub", () => {
         test("1 - x", () => {
@@ -86,16 +88,16 @@ describe("printer", () => {
 
         test("leading subtraction", () => {
             const ast: Semantic.types.NumericNode = {
-                type: "add",
+                type: NodeType.Add,
                 id: 0,
                 args: [
                     {
-                        type: "neg",
+                        type: NodeType.Neg,
                         id: 1,
                         subtraction: true,
-                        arg: {type: "Identifier", name: "a", id: 2},
+                        arg: {type: NodeType.Identifier, name: "a", id: 2},
                     },
-                    {type: "Identifier", name: "b", id: 3},
+                    {type: NodeType.Identifier, name: "b", id: 3},
                 ],
             } as const;
 

--- a/packages/testing/src/__tests__/serializer.test.ts
+++ b/packages/testing/src/__tests__/serializer.test.ts
@@ -3,6 +3,8 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {serializer} from "../serializer";
 
+const {NodeType} = Semantic;
+
 expect.addSnapshotSerializer(serializer);
 
 describe("serializer", () => {
@@ -19,11 +21,11 @@ describe("serializer", () => {
     test("identifier with subscript", () => {
         const ast: Semantic.types.NumericNode = {
             id: getId(),
-            type: "Identifier",
+            type: NodeType.Identifier,
             name: "a",
             subscript: {
                 id: getId(),
-                type: "Identifier",
+                type: NodeType.Identifier,
                 name: "n",
             },
         };
@@ -116,7 +118,7 @@ describe("serializer", () => {
         expect(() => {
             const ast: Semantic.types.Node = {
                 id: 0,
-                type: "log",
+                type: NodeType.Log,
                 base: Semantic.builders.number("2"),
                 arg: Semantic.builders.identifier("x"),
             };


### PR DESCRIPTION
This will make it easier to rename semantic nodes and key their `type` property in sync without breaking anything.