### PR TITLE
Rename more enums

### DIFF
--- a/demo/src/solver/solver-page.tsx
+++ b/demo/src/solver/solver-page.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import * as Editor from "@math-blocks/editor-core";
 import {MathEditor, MathRenderer, FontDataContext} from "@math-blocks/react";
-import {builders} from "@math-blocks/semantic";
+import {builders, NodeType} from "@math-blocks/semantic";
 import {simplify, solve} from "@math-blocks/solver";
 import {Step} from "@math-blocks/step-utils";
 import * as Typesetter from "@math-blocks/typesetter";
@@ -56,7 +56,7 @@ const SolverPage: React.FunctionComponent = () => {
     const handleSolve = (): void => {
         console.log("SOLVE");
         const ast = Editor.parse(Editor.zipperToRow(input));
-        if (ast.type === "eq") {
+        if (ast.type === NodeType.Equals) {
             const result = solve(ast, builders.identifier("x"));
             if (result) {
                 console.log(result);

--- a/demo/src/tutor/step.tsx
+++ b/demo/src/tutor/step.tsx
@@ -18,6 +18,8 @@ import {Step as _Step, StepStatus} from "./reducer";
 import {HStack, VStack} from "./layout";
 import {Dispatch} from "./store";
 
+const {NodeType} = Semantic;
+
 type Props = {
     readonly readonly: boolean;
 
@@ -154,8 +156,8 @@ const Step: React.FunctionComponent<Props> = (props) => {
             }
 
             if (
-                parsedNext.type === "eq" &&
-                parsedNext.args[0].type === "Identifier" &&
+                parsedNext.type === NodeType.Equals &&
+                parsedNext.args[0].type === NodeType.Identifier &&
                 Semantic.util.isNumber(parsedNext.args[1])
             ) {
                 dispatch({type: "right", hint});

--- a/packages/editor-core/src/parser/__tests__/parser.test.ts
+++ b/packages/editor-core/src/parser/__tests__/parser.test.ts
@@ -1,4 +1,5 @@
 import * as Testing from "@math-blocks/testing";
+import {NodeType} from "@math-blocks/semantic";
 
 import * as builders from "../../char/builders";
 import * as util from "../../char/util";
@@ -16,7 +17,7 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (eq
+            (Equals
               (mul.imp 2 x)
               10)
         `);
@@ -26,7 +27,7 @@ describe("EditorParser", () => {
             end: 5,
             path: [],
         });
-        if (ast.type === "eq") {
+        if (ast.type === NodeType.Equals) {
             expect(ast.args[0].loc).toEqual({
                 start: 0,
                 end: 2,
@@ -45,7 +46,7 @@ describe("EditorParser", () => {
 
         const ast = parser.parse(input);
 
-        expect(ast).toMatchInlineSnapshot(`(eq x y z)`);
+        expect(ast).toMatchInlineSnapshot(`(Equals x y z)`);
     });
 
     it("should parse binary expressions containing subtraction", () => {
@@ -54,7 +55,7 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
               (neg.sub 2))
         `);
@@ -66,7 +67,7 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
               (neg.sub 2)
               (neg.sub 3))
@@ -79,7 +80,7 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
               (neg.sub (neg 2)))
         `);
@@ -91,7 +92,7 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
               (neg 2)
               3)
@@ -128,22 +129,22 @@ describe("EditorParser", () => {
         const parseTree = parser.parse(input);
 
         expect(parseTree).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
-              (div 1 x))
+              (Div 1 x))
         `);
         expect(parseTree.loc).toEqual({
             start: 0,
             end: 3,
             path: [],
         });
-        if (parseTree.type === "add") {
+        if (parseTree.type === NodeType.Add) {
             expect(parseTree.args[1].loc).toEqual({
                 start: 2,
                 end: 3,
                 path: [],
             });
-            if (parseTree.args[1].type === "div") {
+            if (parseTree.args[1].type === NodeType.Div) {
                 // numerator
                 expect(parseTree.args[1].args[0].loc).toEqual({
                     start: 0,
@@ -165,13 +166,13 @@ describe("EditorParser", () => {
 
         const parseTree = parser.parse(input);
 
-        expect(parseTree).toMatchInlineSnapshot(`(pow :base x :exp 2)`);
+        expect(parseTree).toMatchInlineSnapshot(`(Power :base x :exp 2)`);
         expect(parseTree.loc).toEqual({
             start: 0,
             end: 2,
             path: [],
         });
-        if (parseTree.type === "pow") {
+        if (parseTree.type === NodeType.Power) {
             expect(parseTree.exp.loc).toEqual({
                 start: 0,
                 end: 1,
@@ -189,9 +190,9 @@ describe("EditorParser", () => {
         const parseTree = parser.parse(input);
 
         expect(parseTree).toMatchInlineSnapshot(`
-            (pow
+            (Power
               :base x
-              :exp (pow :base y :exp 2))
+              :exp (Power :base y :exp 2))
         `);
     });
 
@@ -200,14 +201,14 @@ describe("EditorParser", () => {
 
         const parseTree = parser.parse(input);
 
-        expect(parseTree).toMatchInlineSnapshot(`(ident a (add n 1))`);
+        expect(parseTree).toMatchInlineSnapshot(`(ident a (Add n 1))`);
 
         expect(parseTree.loc).toEqual({
             start: 0,
             end: 1,
             path: [],
         });
-        if (parseTree.type === "Identifier") {
+        if (parseTree.type === NodeType.Identifier) {
             if (parseTree.subscript) {
                 expect(parseTree.subscript.loc).toEqual({
                     start: 0,
@@ -224,7 +225,7 @@ describe("EditorParser", () => {
         const parseTree = parser.parse(input);
 
         expect(parseTree).toMatchInlineSnapshot(
-            `(pow :base (ident a (add n 1)) :exp 2)`,
+            `(Power :base (ident a (Add n 1)) :exp 2)`,
         );
     });
 
@@ -258,7 +259,7 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
               ...
               n)
@@ -285,9 +286,9 @@ describe("EditorParser", () => {
         const ast = parser.parse(input);
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               a
-              (add b c))
+              (Add b c))
         `);
     });
 
@@ -311,7 +312,7 @@ describe("EditorParser", () => {
 
         const ast = parser.parse(input);
 
-        expect(ast).toMatchInlineSnapshot(`(Parens (add a b))`);
+        expect(ast).toMatchInlineSnapshot(`(Parens (Add a b))`);
     });
 
     it("negation can be on individual factors when wrapped in parens", () => {
@@ -362,7 +363,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (add b c))
+              (Add b c))
         `);
     });
 
@@ -386,8 +387,8 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (add b c)
-              (add d e))
+              (Add b c)
+              (Add d e))
         `);
     });
 
@@ -409,8 +410,8 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (add b c)
-              (add d e))
+              (Add b c)
+              (Add d e))
         `);
     });
 
@@ -439,8 +440,8 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (add a b)
-              (div 1 2))
+              (Add a b)
+              (Div 1 2))
         `);
     });
 
@@ -451,7 +452,7 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (div 1 2)
+              (Div 1 2)
               b)
         `);
     });
@@ -472,7 +473,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (root :radicand 2 :index b))
+              (Root :radicand 2 :index b))
         `);
 
         expect(ast.loc).toEqual({
@@ -480,7 +481,7 @@ describe("EditorParser", () => {
             end: 2,
             path: [],
         });
-        if (ast.type === "mul") {
+        if (ast.type === NodeType.Mul) {
             expect(ast.args[0].loc).toEqual({
                 start: 0,
                 end: 1,
@@ -491,7 +492,7 @@ describe("EditorParser", () => {
                 end: 2,
                 path: [],
             });
-            if (ast.args[1].type === "root") {
+            if (ast.args[1].type === NodeType.Root) {
                 expect(ast.args[1].radicand.loc).toEqual({
                     start: 0,
                     end: 1,
@@ -518,8 +519,8 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (root :radicand 2 :index b)
-              (root :radicand 3 :index c))
+              (Root :radicand 2 :index b)
+              (Root :radicand 3 :index c))
         `);
     });
 
@@ -530,8 +531,8 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (root :radicand 2 :index b)
-              (root :radicand 3 :index c))
+              (Root :radicand 2 :index b)
+              (Root :radicand 3 :index c))
         `);
     });
 
@@ -542,7 +543,7 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (root :radicand 2 :index 2)
+              (Root :radicand 2 :index 2)
               a)
         `);
     });
@@ -555,7 +556,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               5
-              (root :radicand 2 :index 2))
+              (Root :radicand 2 :index 2))
         `);
     });
 
@@ -566,7 +567,7 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (root :radicand 2 :index 2)
+              (Root :radicand 2 :index 2)
               5)
         `);
     });
@@ -578,8 +579,8 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (root :radicand 2 :index 2)
-              (root :radicand 2 :index 3))
+              (Root :radicand 2 :index 2)
+              (Root :radicand 2 :index 3))
         `);
     });
 
@@ -590,7 +591,7 @@ describe("EditorParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (root :radicand 2 :index 2)
+              (Root :radicand 2 :index 2)
               a)
         `);
     });
@@ -611,7 +612,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (neg (mul.imp
               1
-              (add a b)))
+              (Add a b)))
         `);
     });
 
@@ -634,7 +635,7 @@ describe("EditorParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               (neg 1)
-              (add a b))
+              (Add a b))
         `);
     });
 
@@ -673,7 +674,7 @@ describe("EditorParser", () => {
             const ast = parser.parse(input);
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   1
                   (Parens x))
             `);
@@ -700,7 +701,7 @@ describe("EditorParser", () => {
             expect(ast).toMatchInlineSnapshot(`
                 (mul.imp
                   2
-                  (Parens (add x y)))
+                  (Parens (Add x y)))
             `);
         });
 
@@ -718,7 +719,7 @@ describe("EditorParser", () => {
             const ast = parser.parse(input);
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   1
                   (Parens (mul.imp x y)))
             `);
@@ -738,7 +739,7 @@ describe("EditorParser", () => {
             const ast = parser.parse(input);
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   a
                   (Parens (neg b)))
             `);
@@ -762,7 +763,7 @@ describe("EditorParser", () => {
             const ast = parser.parse(input);
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (Parens (neg a))
                   (Parens (neg b)))
             `);

--- a/packages/editor-core/src/parser/parser.ts
+++ b/packages/editor-core/src/parser/parser.ts
@@ -10,6 +10,8 @@ import {parseVerticalWork} from "./vertical-work";
 import type {CharRow} from "../char/types";
 import type {TokenNode, SourceLocation} from "../token/types";
 
+const {NodeType} = Semantic;
+
 // TODO: fill out this list
 type Operator =
     | "add"
@@ -350,7 +352,7 @@ const getInfixParselet = (
                 op: "mul.imp",
                 parse: (parser, left): Parser.types.Node => {
                     const parselet = parseNaryInfix("mul.imp");
-                    if (left.type === "div") {
+                    if (left.type === NodeType.Div) {
                         throw new Error(
                             "An operator is required between fractions",
                         );
@@ -437,19 +439,25 @@ const removeExcessParens = (node: Semantic.types.Node): Semantic.types.Node => {
             // the parens are necessary or not.
             if (node.type === "Parens") {
                 const {arg} = node;
-                if (parent.type === "Parens") {
+                if (parent.type === NodeType.Parens) {
                     return;
                 }
-                if (parent.type === "mul" && parent.implicit) {
+                if (parent.type === NodeType.Mul && parent.implicit) {
                     return arg;
                 }
-                if (arg.type === "Identifier" || arg.type === "number") {
+                if (
+                    arg.type === NodeType.Identifier ||
+                    arg.type === NodeType.Number
+                ) {
                     return;
                 }
-                if (arg.type === "mul" && parent.type === "add") {
+                if (arg.type === NodeType.Mul && parent.type === NodeType.Add) {
                     return;
                 }
-                if (arg.type === "neg" && parent.type !== "pow") {
+                if (
+                    arg.type === NodeType.Neg &&
+                    parent.type !== NodeType.Power
+                ) {
                     return;
                 }
                 return arg;

--- a/packages/grader/src/__tests__/util.test.ts
+++ b/packages/grader/src/__tests__/util.test.ts
@@ -78,7 +78,7 @@ describe("replaceNode", () => {
 
         replaceNodeWithId(root, two.id, three);
 
-        expect(root).toMatchInlineSnapshot(`(add 1 3)`);
+        expect(root).toMatchInlineSnapshot(`(Add 1 3)`);
     });
 
     test("finds a node in named property", () => {
@@ -89,7 +89,7 @@ describe("replaceNode", () => {
 
         replaceNodeWithId(root, two.id, three);
 
-        expect(root).toMatchInlineSnapshot(`(pow :base x :exp 3)`);
+        expect(root).toMatchInlineSnapshot(`(Power :base x :exp 3)`);
     });
 });
 

--- a/packages/grader/src/checks/__tests__/axiom-checks.test.ts
+++ b/packages/grader/src/checks/__tests__/axiom-checks.test.ts
@@ -734,50 +734,50 @@ describe("Axiom checks", () => {
 
             expect(result.steps[0].before).toMatchInlineSnapshot(`
                 (mul.exp
-                  (add a b)
-                  (add x y))
+                  (Add a b)
+                  (Add x y))
             `);
 
             expect(result.steps[0].after).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (mul.exp
                     a
-                    (add x y))
+                    (Add x y))
                   (mul.exp
                     b
-                    (add x y)))
+                    (Add x y)))
             `);
 
             expect(result.steps[1].before).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (mul.exp
                     a
-                    (add x y))
+                    (Add x y))
                   (mul.exp
                     b
-                    (add x y)))
+                    (Add x y)))
             `);
 
             expect(result.steps[1].after).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (mul.exp a x)
                   (mul.exp a y)
                   (mul.exp
                     b
-                    (add x y)))
+                    (Add x y)))
             `);
 
             expect(result.steps[2].before).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (mul.exp a x)
                   (mul.exp a y)
                   (mul.exp
                     b
-                    (add x y)))
+                    (Add x y)))
             `);
 
             expect(result.steps[2].after).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (mul.exp a x)
                   (mul.exp a y)
                   (mul.exp b x)

--- a/packages/grader/src/checks/__tests__/integer-checks.test.ts
+++ b/packages/grader/src/checks/__tests__/integer-checks.test.ts
@@ -70,7 +70,7 @@ describe("Integer checks", () => {
 
         expect(result.steps[0].before).toMatchInlineSnapshot(`0`);
         expect(result.steps[0].after).toMatchInlineSnapshot(`
-            (add
+            (Add
               a
               (neg a))
         `);

--- a/packages/grader/src/checks/axiom-checks.ts
+++ b/packages/grader/src/checks/axiom-checks.ts
@@ -7,8 +7,10 @@ import {MistakeId} from "../enums";
 import {exactMatch, checkArgs} from "./basic-checks";
 import {zip, correctResult} from "./util";
 
+const {NodeType} = Semantic;
+
 export const addZero: Check = (prev, next, context) => {
-    if (next.type !== "add") {
+    if (next.type !== NodeType.Add) {
         return;
     }
 
@@ -118,7 +120,7 @@ export const mulOne: Check = (prev, next, context) => {
     // This is going in the direction of (a)(1) -> a
     // so if we have -a we can go from (-a)(1) -> a
     // TODO: figure out how we can drop this without running into recursion limits
-    if (next.type !== "mul") {
+    if (next.type !== NodeType.Mul) {
         return;
     }
 
@@ -231,7 +233,7 @@ mulOne.symmetric = true;
 export const mulByZero: Check = (prev, next, context) => {
     const {checker} = context;
 
-    if (prev.type !== "mul") {
+    if (prev.type !== NodeType.Mul) {
         return;
     }
 
@@ -271,8 +273,8 @@ export const commuteAddition: Check = (prev, next, context) => {
     const {checker} = context;
 
     if (
-        prev.type === "add" &&
-        next.type === "add" &&
+        prev.type === NodeType.Add &&
+        next.type === NodeType.Add &&
         prev.args.length === next.args.length
     ) {
         const pairs = zip(prev.args, next.args);
@@ -332,8 +334,8 @@ export const commuteMultiplication: Check = (prev, next, context) => {
     const {checker} = context;
 
     if (
-        prev.type === "mul" &&
-        next.type === "mul" &&
+        prev.type === NodeType.Mul &&
+        next.type === NodeType.Mul &&
         prev.args.length === next.args.length
     ) {
         const pairs = zip(prev.args, next.args);
@@ -392,8 +394,8 @@ export const symmetricProperty: Check = (
     }
 
     if (
-        prev.type === "eq" &&
-        next.type === "eq" &&
+        prev.type === NodeType.Equals &&
+        next.type === NodeType.Equals &&
         prev.args.length === next.args.length
     ) {
         // TODO: actually check that this is the case
@@ -467,13 +469,13 @@ symmetricProperty.symmetric = true;
 // multiplication, but rather can "mul" nodes that are args of a parent "mul"
 // node be removed (or added).
 export const associativeMul: Check = (prev, next, context) => {
-    if (prev.type !== "mul") {
+    if (prev.type !== NodeType.Mul) {
         return;
     }
 
     const {checker} = context;
 
-    if (prev.args.some((arg) => arg.type === "mul")) {
+    if (prev.args.some((arg) => arg.type === NodeType.Mul)) {
         // for (const arg of prev.args) {
         //     console.log(arg);
         // }
@@ -506,13 +508,13 @@ associativeMul.symmetric = true;
 // but rather can parens be removed (or added) for "add" nodes that are args of
 // a parent "add" node.
 export const associativeAdd: Check = (prev, next, context) => {
-    if (prev.type !== "add") {
+    if (prev.type !== NodeType.Add) {
         return;
     }
 
     const {checker} = context;
 
-    if (prev.args.some((arg) => arg.type === "add")) {
+    if (prev.args.some((arg) => arg.type === NodeType.Add)) {
         const terms: Semantic.types.NumericNode[] = [];
         for (const arg of prev.args) {
             terms.push(...Semantic.util.getTerms(arg));

--- a/packages/grader/src/checks/basic-checks.ts
+++ b/packages/grader/src/checks/basic-checks.ts
@@ -3,10 +3,12 @@ import type {Step} from "@math-blocks/step-utils";
 
 import type {Check, Result, Mistake, Context} from "../types";
 
+const {NodeType} = Semantic;
+
 export const numberCheck: Check = (prev, next, context): Result | undefined => {
     if (
-        prev.type === "number" &&
-        next.type === "number" &&
+        prev.type === NodeType.Number &&
+        next.type === NodeType.Number &&
         prev.value === next.value
     ) {
         return {
@@ -22,8 +24,8 @@ export const identifierCheck: Check = (
     context,
 ): Result | undefined => {
     if (
-        prev.type === "Identifier" &&
-        next.type === "Identifier" &&
+        prev.type === NodeType.Identifier &&
+        next.type === NodeType.Identifier &&
         prev.name === next.name
     ) {
         return {
@@ -110,12 +112,12 @@ export const checkArgs: Check = (prev, next, context): Result | undefined => {
         return {
             steps: steps,
         };
-    } else if (prev.type === "neg" && next.type === "neg") {
+    } else if (prev.type === NodeType.Neg && next.type === NodeType.Neg) {
         const result = checker.checkStep(prev.arg, next.arg, context);
         if (result && prev.subtraction === next.subtraction) {
             return result;
         }
-    } else if (prev.type === "pow" && next.type === "pow") {
+    } else if (prev.type === NodeType.Power && next.type === NodeType.Power) {
         const baseResult = checker.checkStep(prev.base, next.base, context);
         const expResult = checker.checkStep(prev.exp, next.exp, context);
 

--- a/packages/grader/src/checks/distribution-check.ts
+++ b/packages/grader/src/checks/distribution-check.ts
@@ -4,6 +4,8 @@ import type {Result, Check} from "../types";
 
 import {correctResult} from "./util";
 
+const {NodeType} = Semantic;
+
 const replaceItem = <T>(
     items: readonly T[] | TwoOrMore<T>,
     newItem: T,
@@ -18,7 +20,10 @@ export const checkDistribution: Check = (prev, next, context) => {
     // not look at the `next` node.  In this case we make an exception to avoid
     // infinite loops.  We might be able to lift this restriction in the future
     // by setting `.source` on new nodes created by this check.
-    if ((prev.type === "add" || prev.type === "mul") && next.type === "add") {
+    if (
+        (prev.type === NodeType.Add || prev.type === NodeType.Mul) &&
+        next.type === NodeType.Add
+    ) {
         const results: Result[] = [];
 
         const terms = Semantic.util.getTerms(prev);
@@ -31,10 +36,10 @@ export const checkDistribution: Check = (prev, next, context) => {
             const potentialResults: Result[] = [];
             const potentialNewPrevs = [];
 
-            if (mul.type === "mul") {
+            if (mul.type === NodeType.Mul) {
                 for (let j = 0; j < mul.args.length; j++) {
                     const factor = mul.args[j];
-                    if (factor.type !== "add") {
+                    if (factor.type !== NodeType.Add) {
                         continue;
                     }
 

--- a/packages/grader/src/checks/equation-checks.ts
+++ b/packages/grader/src/checks/equation-checks.ts
@@ -5,6 +5,8 @@ import type {Check, Result} from "../types";
 
 import {correctResult} from "./util";
 
+const {NodeType} = Semantic;
+
 // TODO: create sub-steps that includes the opposite operation when reversed is true
 // TODO: include which nodes were added/removed in each reason
 // TODO: handle square rooting both sides
@@ -14,7 +16,7 @@ const NUMERATOR = 0;
 const DENOMINATOR = 1;
 
 export const checkAddSub: Check = (prev, next, context): Result | undefined => {
-    if (prev.type !== "eq" || next.type !== "eq") {
+    if (prev.type !== NodeType.Equals || next.type !== NodeType.Equals) {
         return;
     }
 
@@ -34,7 +36,7 @@ export const checkAddSub: Check = (prev, next, context): Result | undefined => {
 
     // TODO: take into account LHS and RHS being swapped
     // e.g. y = x -> x + 10 = y + 10
-    if (nextLHS.type === "add" || nextRHS.type === "add") {
+    if (nextLHS.type === NodeType.Add || nextRHS.type === NodeType.Add) {
         const prevTermsLHS = Semantic.util.getTerms(prevLHS);
         const prevTermsRHS = Semantic.util.getTerms(prevRHS);
         const nextTermsLHS = Semantic.util.getTerms(nextLHS);
@@ -132,7 +134,7 @@ export const checkAddSub: Check = (prev, next, context): Result | undefined => {
 checkAddSub.symmetric = true;
 
 export const checkMul: Check = (prev, next, context): Result | undefined => {
-    if (prev.type !== "eq" || next.type !== "eq") {
+    if (prev.type !== NodeType.Equals || next.type !== NodeType.Equals) {
         return;
     }
 
@@ -143,7 +145,7 @@ export const checkMul: Check = (prev, next, context): Result | undefined => {
 
     // TODO: take into account LHS and RHS being swapped
     // e.g. y = x -> x * 10 = y * 10
-    if (nextLHS.type === "mul" || nextRHS.type === "mul") {
+    if (nextLHS.type === NodeType.Mul || nextRHS.type === NodeType.Mul) {
         if (
             !Semantic.util.isNumeric(prevLHS) ||
             !Semantic.util.isNumeric(prevRHS) ||
@@ -246,7 +248,7 @@ export const checkMul: Check = (prev, next, context): Result | undefined => {
 checkMul.symmetric = true;
 
 export const checkDiv: Check = (prev, next, context): Result | undefined => {
-    if (prev.type !== "eq" || next.type !== "eq") {
+    if (prev.type !== NodeType.Equals || next.type !== NodeType.Equals) {
         return;
     }
 
@@ -262,7 +264,7 @@ export const checkDiv: Check = (prev, next, context): Result | undefined => {
         return;
     }
 
-    if (nextLHS.type === "div" && nextRHS.type === "div") {
+    if (nextLHS.type === NodeType.Div && nextRHS.type === NodeType.Div) {
         if (
             checker.checkStep(prevLHS, nextLHS.args[NUMERATOR], context) &&
             checker.checkStep(prevRHS, nextRHS.args[NUMERATOR], context)

--- a/packages/grader/src/checks/eval-checks.ts
+++ b/packages/grader/src/checks/eval-checks.ts
@@ -5,6 +5,8 @@ import type {Check, Correction, Result} from "../types";
 
 import {correctResult} from "./util";
 
+const {NodeType} = Semantic;
+
 // TODO: when evaluating 5 - 5 or 5 + -5 then we may want to include substeps,
 // e.g. "adding inverse" and "addition with identity"
 export const evalAdd: Check = (prev, next, context): Result | undefined => {
@@ -13,7 +15,7 @@ export const evalAdd: Check = (prev, next, context): Result | undefined => {
     }
 
     // If neither are sums then we can stop early
-    if (prev.type !== "add" && next.type !== "add") {
+    if (prev.type !== NodeType.Add && next.type !== NodeType.Add) {
         return;
     }
 
@@ -153,7 +155,7 @@ export const evalMul: Check = (prev, next, context): Result | undefined => {
     }
 
     // If neither are products then we can stop early
-    if (prev.type !== "mul" && next.type !== "mul") {
+    if (prev.type !== NodeType.Mul && next.type !== NodeType.Mul) {
         return;
     }
 

--- a/packages/grader/src/checks/polynomial-checks.ts
+++ b/packages/grader/src/checks/polynomial-checks.ts
@@ -6,13 +6,15 @@ import type {Check, Result} from "../types";
 import {correctResult} from "./util";
 import {exactMatch} from "./basic-checks";
 
+const {NodeType} = Semantic;
+
 // 2x + 3x -> 5x
 export const collectLikeTerms: Check = (
     prev,
     next,
     context,
 ): Result | undefined => {
-    if (prev.type !== "add") {
+    if (prev.type !== NodeType.Add) {
         return;
     }
 
@@ -52,7 +54,10 @@ export const collectLikeTerms: Check = (
             // If there's a single number factor then it's the coefficient
             if (numericFactors.length === 1) {
                 coeff = numericFactors[0];
-                if (coeff.type === "add" || coeff.type === "mul") {
+                if (
+                    coeff.type === NodeType.Add ||
+                    coeff.type === NodeType.Mul
+                ) {
                     const originalCoeff = coeff;
                     coeff = Semantic.builders.number(
                         Semantic.util

--- a/packages/grader/src/checks/power-checks.ts
+++ b/packages/grader/src/checks/power-checks.ts
@@ -6,8 +6,10 @@ import type {Check, Result} from "../types";
 import {correctResult} from "./util";
 import {exactMatch} from "./basic-checks";
 
+const {NodeType} = Semantic;
+
 const isPower = (node: Semantic.types.Node): node is Semantic.types.Pow => {
-    return node.type === "pow";
+    return node.type === NodeType.Power;
 };
 
 // a*a*...*a -> a^n
@@ -24,7 +26,7 @@ export const powDef: Check = (prev, next, context): Result | undefined => {
         return;
     }
 
-    if (prev.type === "mul") {
+    if (prev.type === NodeType.Mul) {
         // TODO: memoize helpers like getFactors, getTerms, difference, intersection, etc.
         const prevFactors = Semantic.util.getFactors(prev);
         const nextFactors = Semantic.util.getFactors(next);
@@ -48,7 +50,7 @@ export const powDef: Check = (prev, next, context): Result | undefined => {
         const exps = uniqueNextFactors.filter(isPower);
 
         const expsWithNumberExp = exps.filter(
-            (exp) => exp.exp.type === "number",
+            (exp) => exp.exp.type === NodeType.Number,
         );
 
         if (expsWithNumberExp.length === 0) {
@@ -118,7 +120,7 @@ export const powDefReverse: Check = (
     next,
     context,
 ): Result | undefined => {
-    if (prev.type !== "pow") {
+    if (prev.type !== NodeType.Power) {
         return undefined;
     }
 
@@ -136,7 +138,7 @@ export const powDefReverse: Check = (
     const {checker} = context;
 
     // TODO: evaluate the exponent if necessary
-    if (exp.type === "number") {
+    if (exp.type === NodeType.Number) {
         const factors: Semantic.types.NumericNode[] = [];
         const count = Number.parseInt(exp.value);
         if (count <= 1) {
@@ -174,7 +176,7 @@ export const mulPowsSameBase: Check = (
 ): Result | undefined => {
     const {checker} = context;
 
-    if (prev.type !== "mul") {
+    if (prev.type !== NodeType.Mul) {
         return;
     }
 
@@ -197,7 +199,7 @@ export const mulPowsSameBase: Check = (
     for (const factor of factors) {
         // TODO: should we clone base and exp?
         const {base, exp} =
-            factor.type === "pow"
+            factor.type === NodeType.Power
                 ? factor
                 : // TODO: track when we add "1" as an exponent so that we don't add
                   // it below when it wasn't par of the original expression.
@@ -362,7 +364,7 @@ export const divPowsSameBase: Check = (
     next,
     context,
 ): Result | undefined => {
-    if (prev.type !== "div") {
+    if (prev.type !== NodeType.Div) {
         return;
     }
 
@@ -512,7 +514,7 @@ export const oneOverPowToNegPow: Check = (
     next,
     context,
 ): Result | undefined => {
-    if (prev.type !== "div") {
+    if (prev.type !== NodeType.Div) {
         return undefined;
     }
 
@@ -596,7 +598,7 @@ powOfPow.symmetric = true;
 
 // (xy)^n -> (x^n)(y^n)
 export const powOfMul: Check = (prev, next, context): Result | undefined => {
-    if (!(prev.type === "pow" && prev.base.type === "mul")) {
+    if (!(prev.type === NodeType.Power && prev.base.type === NodeType.Mul)) {
         return;
     }
 
@@ -637,11 +639,11 @@ export const mulPowsSameExp: Check = (
     next,
     context,
 ): Result | undefined => {
-    if (prev.type !== "mul") {
+    if (prev.type !== NodeType.Mul) {
         return undefined;
     }
 
-    if (!prev.args.every((arg) => arg.type === "pow")) {
+    if (!prev.args.every((arg) => arg.type === NodeType.Power)) {
         return undefined;
     }
 
@@ -685,7 +687,7 @@ mulPowsSameExp.symmetric = true;
 
 // (x/y)^n -> x^n / y^n
 export const powOfDiv: Check = (prev, next, context): Result | undefined => {
-    if (!(prev.type === "pow" && prev.base.type === "div")) {
+    if (!(prev.type === NodeType.Power && prev.base.type === NodeType.Div)) {
         return;
     }
 
@@ -729,11 +731,11 @@ export const divOfPowsSameExp: Check = (
     next,
     context,
 ): Result | undefined => {
-    if (prev.type !== "div") {
+    if (prev.type !== NodeType.Div) {
         return undefined;
     }
 
-    if (!prev.args.every((arg) => arg.type === "pow")) {
+    if (!prev.args.every((arg) => arg.type === NodeType.Power)) {
         return undefined;
     }
 
@@ -774,7 +776,7 @@ divOfPowsSameExp.symmetric = true;
 // x^0 -> 1
 // NOTE: 0^0 is defined as 1 for convenience
 export const powToZero: Check = (prev, next, context): Result | undefined => {
-    if (prev.type !== "pow") {
+    if (prev.type !== NodeType.Power) {
         return;
     }
 
@@ -804,7 +806,7 @@ powToZero.symmetric = true;
 
 // x^1 -> x
 export const powToOne: Check = (prev, next, context): Result | undefined => {
-    if (prev.type !== "pow") {
+    if (prev.type !== NodeType.Power) {
         return;
     }
 
@@ -836,7 +838,7 @@ powToOne.symmetric = true;
 
 // 1^x -> 1
 export const powOfOne: Check = (prev, next, context) => {
-    if (prev.type !== "pow") {
+    if (prev.type !== NodeType.Power) {
         return;
     }
 
@@ -866,7 +868,7 @@ powOfOne.symmetric = true;
 
 // 0^x -> 0
 export const powOfZero: Check = (prev, next, context): Result | undefined => {
-    if (prev.type !== "pow") {
+    if (prev.type !== NodeType.Power) {
         return;
     }
 

--- a/packages/grader/src/checks/util.ts
+++ b/packages/grader/src/checks/util.ts
@@ -3,6 +3,8 @@ import {Step, applySteps} from "@math-blocks/step-utils";
 
 import type {Context, Result} from "../types";
 
+const {NodeType} = Semantic;
+
 // TODO: handle negative numbers
 export const primeDecomp = (n: number): readonly number[] => {
     if (!Number.isInteger(n)) {
@@ -40,7 +42,7 @@ export const decomposeFactors = (
 ): readonly Semantic.types.NumericNode[] => {
     return factors.reduce((result: Semantic.types.NumericNode[], factor) => {
         // TODO: add decomposition of powers
-        if (factor.type === "number") {
+        if (factor.type === NodeType.Number) {
             return [
                 ...result,
                 ...primeDecomp(parseInt(factor.value)).map((value) =>

--- a/packages/parser-factory/src/builders.ts
+++ b/packages/parser-factory/src/builders.ts
@@ -59,7 +59,7 @@ export const eq = (
     args: TwoOrMore<types.Node>,
     loc?: types.SourceLocation,
 ): types.Eq => ({
-    type: NodeType.Eq,
+    type: NodeType.Equals,
     id: getId(),
     args,
     loc,
@@ -105,7 +105,7 @@ export const pow = (
     exp: types.Node,
     loc?: types.SourceLocation,
 ): types.Pow => ({
-    type: NodeType.Pow,
+    type: NodeType.Power,
     id: getId(),
     base,
     exp,

--- a/packages/parser-factory/src/types.ts
+++ b/packages/parser-factory/src/types.ts
@@ -112,7 +112,7 @@ export type Div = Common<NodeType.Div> & {
 /**
  * Modulus
  */
-export type Mod = Common<NodeType.Mod> & {
+export type Mod = Common<NodeType.Modulo> & {
     readonly args: readonly [Node, Node];
 };
 
@@ -129,7 +129,7 @@ export type Root = Common<NodeType.Root> & {
 /**
  * Power
  */
-export type Pow = Common<NodeType.Pow> & {
+export type Pow = Common<NodeType.Power> & {
     readonly base: Node;
     readonly exp: Node;
 };
@@ -172,7 +172,7 @@ export type Ellipsis = Common<NodeType.Ellipsis>;
  *
  * e.g. 5! = 1 * 2 * 3 * 4 * 5
  */
-export type Abs = Common<NodeType.Abs> & {
+export type Abs = Common<NodeType.AbsoluteValue> & {
     readonly arg: Node;
 };
 
@@ -197,7 +197,7 @@ type Limits = {
 /**
  * Summation
  */
-export type Sum = Common<NodeType.Sum> & {
+export type Sum = Common<NodeType.Summation> & {
     readonly arg: Node;
     readonly bvar: Identifier; // bound variable, i.e. the variable being summed over
     // TODO: support `condition` and `domainofapplication` as well,
@@ -364,85 +364,85 @@ export type False = Common<NodeType.False>;
 /**
  * Logical And (Conjunction)
  */
-export type And = Common<NodeType.And> & {
+export type And = Common<NodeType.LogicalAnd> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Logical Or (Disjunction)
  */
-export type Or = Common<NodeType.Or> & {
+export type Or = Common<NodeType.LogicalOr> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Logical Not (Inverse)
  */
-export type Not = Common<NodeType.Not> & {
+export type Not = Common<NodeType.LogicalNot> & {
     readonly arg: Node;
 };
 
 /**
  * Exclusive Or
  */
-export type Xor = Common<NodeType.Xor> & {
+export type Xor = Common<NodeType.ExclusiveOr> & {
     readonly args: TwoOrMore<Node>;
 };
 
-export type Implies = Common<NodeType.Implies> & {
+export type Implies = Common<NodeType.Conditional> & {
     readonly args: readonly [Node, Node];
 };
 
-export type Iff = Common<NodeType.Iff> & {
+export type Iff = Common<NodeType.Biconditional> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Equals
  */
-export type Eq = Common<NodeType.Eq> & {
+export type Eq = Common<NodeType.Equals> & {
     readonly args: TwoOrMore<Node> | TwoOrMore<Node> | TwoOrMore<Node>;
 };
 
 /**
  * Not Equals
  */
-export type Neq = Common<NodeType.Neq> & {
+export type Neq = Common<NodeType.NotEquals> & {
     readonly args: TwoOrMore<Node> | TwoOrMore<Node> | TwoOrMore<Node>;
 };
 
 /**
  * Less Than
  */
-export type Lt = Common<NodeType.Lt> & {
+export type Lt = Common<NodeType.LessThan> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Less Than or Equal to
  */
-export type Lte = Common<NodeType.Lte> & {
+export type Lte = Common<NodeType.LessThanOrEquals> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Greater Than
  */
-export type Gt = Common<NodeType.Gt> & {
+export type Gt = Common<NodeType.GreaterThan> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Greater Than or Equal to
  */
-export type Gte = Common<NodeType.Gte> & {
+export type Gte = Common<NodeType.GreaterThanOrEquals> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Element in set
  */
-export type In = Common<NodeType.In> & {
+export type In = Common<NodeType.ElementOf> & {
     readonly element: Node;
     readonly set: Node;
 };
@@ -450,7 +450,7 @@ export type In = Common<NodeType.In> & {
 /**
  * Element is not a set
  */
-export type NotIn = Common<NodeType.NotIn> & {
+export type NotIn = Common<NodeType.NotElementOf> & {
     readonly element: Node;
     readonly set: Node;
 };
@@ -525,14 +525,14 @@ export type Union = Common<NodeType.Union> & {
 /**
  * Intersection
  */
-export type Intersection = Common<NodeType.Intersection> & {
+export type Intersection = Common<NodeType.SetIntersection> & {
     readonly args: TwoOrMore<Node>;
 };
 
 /**
  * Set Difference
  */
-export type SetDiff = Common<NodeType.SetDiff> & {
+export type SetDiff = Common<NodeType.SetDifference> & {
     readonly args: readonly [Node, Node];
 };
 

--- a/packages/react/src/mathml-renderer.tsx
+++ b/packages/react/src/mathml-renderer.tsx
@@ -2,20 +2,25 @@ import * as React from "react";
 
 import * as Semantic from "@math-blocks/semantic";
 
+const {NodeType} = Semantic;
+
 // pipelines:
 // Semantic -> HAST(MathML) -> React/Vue/etc.
 // Editor -> HAST(SVG) -> React/Vue/etc.
 
 const print = (math: Semantic.types.Node): React.ReactElement | null => {
     switch (math.type) {
-        case "add": {
+        case NodeType.Add: {
             // TODO: handle adding parens when necessary (this is kind of link printers we have)
             const children: React.ReactNode[] = [];
             // TODO: give each child a key
             for (const arg of math.args) {
-                if (arg.type === "neg" && arg.subtraction) {
+                if (arg.type === NodeType.Neg && arg.subtraction) {
                     children.push(<mo>-</mo>);
-                } else if (arg.type === "plusminus" && arg.arity === "binary") {
+                } else if (
+                    arg.type === NodeType.PlusMinus &&
+                    arg.arity === "binary"
+                ) {
                     children.push(<mo>±</mo>);
                 } else {
                     children.push(<mo>+</mo>);
@@ -25,12 +30,12 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
             children.shift(); // removes the leading operator
             return <mrow>{children}</mrow>;
         }
-        case "mul": {
+        case NodeType.Mul: {
             const children: React.ReactNode[] = [];
             // TODO: give each child a key
             for (const arg of math.args) {
                 const child = print(arg);
-                if (arg.type === "add") {
+                if (arg.type === NodeType.Add) {
                     children.push(
                         <mrow>
                             <mo>(</mo>
@@ -50,10 +55,10 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
             children.pop(); // removes the trailing operator
             return <mrow>{children}</mrow>;
         }
-        case "number": {
+        case NodeType.Number: {
             return <mn>{math.value}</mn>;
         }
-        case "Identifier": {
+        case NodeType.Identifier: {
             if (math.subscript) {
                 return (
                     <msub>
@@ -65,7 +70,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
                 return <mi>{math.name}</mi>;
             }
         }
-        case "neg": {
+        case NodeType.Neg: {
             const arg = print(math.arg);
             return math.subtraction ? (
                 arg
@@ -76,7 +81,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
                 </mrow>
             );
         }
-        case "plusminus": {
+        case NodeType.PlusMinus: {
             const arg = print(math.arg);
             return math.arity === "binary" ? (
                 arg
@@ -87,7 +92,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
                 </mrow>
             );
         }
-        case "eq": {
+        case NodeType.Equals: {
             const children: React.ReactNode[] = [];
             // TODO: give each child a key
             for (const arg of math.args) {
@@ -97,7 +102,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
             children.pop(); // removes the trailing &equals;
             return <mrow>{children}</mrow>;
         }
-        case "div": {
+        case NodeType.Div: {
             // TODO: fraction from division using the division operator
             // TODO: remove <mrow> wrapper on children
             return (
@@ -107,7 +112,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
                 </mfrac>
             );
         }
-        case "pow": {
+        case NodeType.Power: {
             // TODO: check if math.base is an identifier with a subscript and
             // use msubsup in that situation
             return (
@@ -117,7 +122,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
                 </msup>
             );
         }
-        case "root": {
+        case NodeType.Root: {
             if (math.sqrt) {
                 // TODO: remove extra <mrow>
                 return <msqrt>{print(math.radicand)}</msqrt>;

--- a/packages/semantic/src/__tests__/traverse.test.ts
+++ b/packages/semantic/src/__tests__/traverse.test.ts
@@ -50,7 +50,7 @@ describe("traverse", () => {
     it("call traverse properties", () => {
         const power: types.Pow = {
             id: 0,
-            type: NodeType.Pow,
+            type: NodeType.Power,
             base: {
                 id: 1,
                 type: NodeType.Identifier,
@@ -94,7 +94,7 @@ describe("traverse", () => {
     it("supports making changes to a node on exit", () => {
         const power: types.Pow = {
             id: 0,
-            type: NodeType.Pow,
+            type: NodeType.Power,
             base: {
                 id: 1,
                 type: NodeType.Identifier,
@@ -109,7 +109,7 @@ describe("traverse", () => {
 
         traverse(power, {
             exit: (node) => {
-                if (node.type === "Identifier" && node.name === "x") {
+                if (node.type === NodeType.Identifier && node.name === "x") {
                     return {
                         ...node,
                         name: "y",
@@ -120,15 +120,15 @@ describe("traverse", () => {
 
         expect(power).toEqual({
             id: 0,
-            type: "pow",
+            type: NodeType.Power,
             base: {
                 id: 1,
-                type: "Identifier",
+                type: NodeType.Identifier,
                 name: "y",
             },
             exp: {
                 id: 2,
-                type: "number",
+                type: NodeType.Number,
                 value: "3",
             },
         });
@@ -154,7 +154,7 @@ describe("traverse", () => {
 
         traverse(sum, {
             exit: (node) => {
-                if (node.type === "Identifier" && node.name === "x") {
+                if (node.type === NodeType.Identifier && node.name === "x") {
                     return {
                         ...node,
                         name: "y",
@@ -165,16 +165,16 @@ describe("traverse", () => {
 
         expect(sum).toEqual({
             id: 0,
-            type: "add",
+            type: NodeType.Add,
             args: [
                 {
                     id: 1,
-                    type: "Identifier",
+                    type: NodeType.Identifier,
                     name: "y",
                 },
                 {
                     id: 2,
-                    type: "number",
+                    type: NodeType.Number,
                     value: "3",
                 },
             ],

--- a/packages/semantic/src/builders.ts
+++ b/packages/semantic/src/builders.ts
@@ -82,7 +82,7 @@ export const eq = (
         | TwoOrMore<types.SetNode>,
     loc?: types.SourceLocation,
 ): types.Eq => ({
-    type: NodeType.Eq,
+    type: NodeType.Equals,
     id: getId(),
     args,
     loc,
@@ -116,7 +116,7 @@ export const pow = (
     exp: types.NumericNode,
     loc?: types.SourceLocation,
 ): types.Pow => ({
-    type: NodeType.Pow,
+    type: NodeType.Power,
     id: getId(),
     base,
     exp,

--- a/packages/semantic/src/enums.ts
+++ b/packages/semantic/src/enums.ts
@@ -1,65 +1,89 @@
 export enum NodeType {
     // Numeric Node Types
-    Number = "number",
+    Number = "Number",
     Identifier = "Identifier",
-    Add = "add",
-    Mul = "mul",
-    Neg = "neg",
+
+    // Basic Operators
+    Add = "Add",
+    Mul = "Mul",
+    Neg = "Neg",
+    Div = "Div",
+    Modulo = "Modulo",
+    Root = "Root",
+    Power = "Power",
+    Log = "Log",
+
     PlusMinus = "plusminus",
     MinusPlus = "minusplus",
-    Div = "div",
-    Mod = "mod",
-    Root = "root",
-    Pow = "pow",
-    Log = "log",
-    Func = "func",
-    Infinity = "infinity",
-    Pi = "pi",
-    Ellipsis = "ellipsis",
-    Abs = "abs",
+
+    Func = "Func", // TODO: split into FunctionDefinition and FunctionEvaluation
+    Ellipsis = "Ellipsis",
     Parens = "Parens",
-    Sum = "Sum",
+
+    // Important Numeric Values
+    Pi = "Pi",
+    Infinity = "Infinity",
+
+    // Pre-calculus
+    AbsoluteValue = "AbsoluteValue",
+    Summation = "Summation",
     Product = "Product",
+
+    // Calculus
     Limit = "Limit",
     Derivative = "Derivative",
     PartialDerivative = "PartialDerivative",
     Integral = "Integral",
+
+    // Equations
     VerticalAdditionToRelation = "VerticalAdditionToRelation",
     SystemOfRelationsElimination = "SystemOfRelationsElimination",
+
+    // Elementary Arithmetic Algorithms
     LongAddition = "LongAddition",
     LongSubtraction = "LongSubtraction",
     LongMultiplication = "LongMultiplication",
     LongDivision = "LongDivision",
 
-    // Logic Node Types
-    True = "true",
-    False = "false",
-    And = "and", // rename to Conjunction
-    Or = "or", // rename to Disjunction
-    Not = "not", // rename to LogicalInverse
-    Xor = "xor",
-    Implies = "implies",
-    Iff = "iff",
-    Eq = "eq", // Equals
-    Neq = "neq", // NotEquals
-    Lt = "lt", // LessThan
-    Lte = "lte", // LessThanOrEquals
-    Gt = "gt", // GreaterThan
-    Gte = "gte", // GreaterThanOrEquals
+    // Logic Values
+    True = "True",
+    False = "False",
 
-    // Set Node Types
-    In = "in",
-    NotIn = "notin",
-    Subset = "subset",
-    ProperSubset = "prsubset",
-    NotSubset = "notsubset",
-    NotProperSubset = "notprsubset",
-    Set = "set",
-    EmptySet = "empty",
-    Union = "union",
-    Intersection = "intersection", // rename to SetIntersection
-    SetDiff = "setdiff", // rename to SetDifference
-    CartesianProduct = "cartesian_product",
+    // Logic Operators
+    LogicalAnd = "LogicalAnd",
+    LogicalOr = "LogicalOr",
+    LogicalNot = "LogicalNot",
+    ExclusiveOr = "ExclusiveOr",
+    Conditional = "Conditional",
+    Biconditional = "Biconditional",
+
+    // Relation Operators (Logic Result)
+    Equals = "Equals",
+    NotEquals = "NotEquals",
+    LessThan = "LessThan",
+    LessThanOrEquals = "LessThanOrEquals",
+    GreaterThan = "GreaterThan",
+    GreaterThanOrEquals = "GreaterThanOrEquals",
+
+    // Set Operations
+    ElementOf = "ElementOf",
+    NotElementOf = "NotElementOf",
+    Union = "Union",
+    SetIntersection = "SetIntersection",
+    SetDifference = "SetDifference",
+    CartesianProduct = "CartesianProduct",
+
+    // Set Relations
+    Subset = "Subset",
+    ProperSubset = "ProperSubset",
+    NotSubset = "NotSubset",
+    NotProperSubset = "NotProperSubset",
+
+    // Set Values
+    Set = "Set",
+    EmptySet = "EmptySet",
+
+    // Well-Kwown Number Theory Sets
     Naturals = "naturals",
     Integers = "integers",
     Rationals = "rationals",

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -107,7 +107,7 @@ export type Div = Common<NodeType.Div> & {
 /**
  * Modulus
  */
-export type Mod = Common<NodeType.Mod> & {
+export type Mod = Common<NodeType.Modulo> & {
     readonly args: readonly [NumericNode, NumericNode];
 };
 
@@ -124,7 +124,7 @@ export type Root = Common<NodeType.Root> & {
 /**
  * Power
  */
-export type Pow = Common<NodeType.Pow> & {
+export type Pow = Common<NodeType.Power> & {
     readonly base: NumericNode;
     readonly exp: NumericNode;
 };
@@ -140,6 +140,7 @@ export type Log = Common<NodeType.Log> & {
 /**
  * Function
  * Can be used to represent function declaration as well as application.
+ * TODO: split this into separate nodes for function declaration vs function evaluation
  */
 export type Func = Common<NodeType.Func> & {
     readonly func: NumericNode;
@@ -167,7 +168,7 @@ export type Ellipsis = Common<NodeType.Ellipsis>;
  *
  * e.g. 5! = 1 * 2 * 3 * 4 * 5
  */
-export type Abs = Common<NodeType.Abs> & {
+export type Abs = Common<NodeType.AbsoluteValue> & {
     readonly arg: NumericNode;
 };
 
@@ -192,7 +193,7 @@ type Limits = {
 /**
  * Summation
  */
-export type Sum = Common<NodeType.Sum> & {
+export type Sum = Common<NodeType.Summation> & {
     readonly arg: NumericNode;
     readonly bvar: Identifier; // bound variable, i.e. the variable being summed over
     // TODO: support `condition` and `domainofapplication` as well,
@@ -326,8 +327,8 @@ export type LogicNode =
     | Identifier
     | True
     | False
-    | And
-    | Or
+    | Conjunction
+    | Disjunction
     | Not
     | Xor
     | Implies
@@ -357,45 +358,45 @@ export type True = Common<NodeType.True>;
 export type False = Common<NodeType.False>;
 
 /**
- * Logical And (Conjunction)
+ * Conjunction
  */
-export type And = Common<NodeType.And> & {
+export type Conjunction = Common<NodeType.LogicalAnd> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
 /**
- * Logical Or (Disjunction)
+ * Disjunction
  */
-export type Or = Common<NodeType.Or> & {
+export type Disjunction = Common<NodeType.LogicalOr> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
 /**
  * Logical Not (Inverse)
  */
-export type Not = Common<NodeType.Not> & {
+export type Not = Common<NodeType.LogicalNot> & {
     readonly arg: LogicNode;
 };
 
 /**
  * Exclusive Or
  */
-export type Xor = Common<NodeType.Xor> & {
+export type Xor = Common<NodeType.ExclusiveOr> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
-export type Implies = Common<NodeType.Implies> & {
+export type Implies = Common<NodeType.Conditional> & {
     readonly args: readonly [LogicNode, LogicNode];
 };
 
-export type Iff = Common<NodeType.Iff> & {
+export type Iff = Common<NodeType.Biconditional> & {
     readonly args: TwoOrMore<LogicNode>;
 };
 
 /**
  * Equals
  */
-export type Eq = Common<NodeType.Eq> & {
+export type Eq = Common<NodeType.Equals> & {
     readonly args:
         | TwoOrMore<NumericNode>
         | TwoOrMore<LogicNode>
@@ -405,7 +406,7 @@ export type Eq = Common<NodeType.Eq> & {
 /**
  * Not Equals
  */
-export type Neq = Common<NodeType.Neq> & {
+export type Neq = Common<NodeType.NotEquals> & {
     readonly args:
         | TwoOrMore<NumericNode>
         | TwoOrMore<LogicNode>
@@ -415,35 +416,35 @@ export type Neq = Common<NodeType.Neq> & {
 /**
  * Less Than
  */
-export type Lt = Common<NodeType.Lt> & {
+export type Lt = Common<NodeType.LessThan> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Less Than or Equal to
  */
-export type Lte = Common<NodeType.Lte> & {
+export type Lte = Common<NodeType.LessThanOrEquals> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Greater Than
  */
-export type Gt = Common<NodeType.Gt> & {
+export type Gt = Common<NodeType.GreaterThan> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Greater Than or Equal to
  */
-export type Gte = Common<NodeType.Gte> & {
+export type Gte = Common<NodeType.GreaterThanOrEquals> & {
     readonly args: TwoOrMore<NumericNode>;
 };
 
 /**
  * Element in set
  */
-export type In = Common<NodeType.In> & {
+export type In = Common<NodeType.ElementOf> & {
     readonly element: Node;
     readonly set: SetNode;
 };
@@ -451,7 +452,7 @@ export type In = Common<NodeType.In> & {
 /**
  * Element is not a set
  */
-export type NotIn = Common<NodeType.NotIn> & {
+export type NotIn = Common<NodeType.NotElementOf> & {
     readonly element: Node;
     readonly set: SetNode;
 };
@@ -526,14 +527,14 @@ export type Union = Common<NodeType.Union> & {
 /**
  * Intersection
  */
-export type Intersection = Common<NodeType.Intersection> & {
+export type Intersection = Common<NodeType.SetIntersection> & {
     readonly args: TwoOrMore<SetNode>;
 };
 
 /**
  * Set Difference
  */
-export type SetDiff = Common<NodeType.SetDiff> & {
+export type SetDiff = Common<NodeType.SetDifference> & {
     readonly args: readonly [SetNode, SetNode];
 };
 

--- a/packages/semantic/src/util.ts
+++ b/packages/semantic/src/util.ts
@@ -8,35 +8,37 @@ import * as types from "./types";
 import {NodeType} from "./enums";
 
 export const isSubtraction = (node: types.NumericNode): node is types.Neg =>
-    node.type === "neg" && node.subtraction;
+    node.type === NodeType.Neg && node.subtraction;
 
 export const isNegative = (node: types.NumericNode): node is types.Neg =>
-    node.type === "neg" && !node.subtraction;
+    node.type === NodeType.Neg && !node.subtraction;
 
 export const getFactors = (
     node: types.NumericNode,
-): OneOrMore<types.NumericNode> => (node.type === "mul" ? node.args : [node]);
+): OneOrMore<types.NumericNode> =>
+    node.type === NodeType.Mul ? node.args : [node];
 
 export const getTerms = (
     node: types.NumericNode,
-): OneOrMore<types.NumericNode> => (node.type === "add" ? node.args : [node]);
+): OneOrMore<types.NumericNode> =>
+    node.type === NodeType.Add ? node.args : [node];
 
 // TODO: create a function to check if an answer is simplified or not
 // TODO: rename this to canBeEvaluated()
 export const isNumber = (node: types.Node): boolean => {
-    if (node.type === "number") {
+    if (node.type === NodeType.Number) {
         return true;
-    } else if (node.type === "neg") {
+    } else if (node.type === NodeType.Neg) {
         return isNumber(node.arg);
-    } else if (node.type === "div") {
+    } else if (node.type === NodeType.Div) {
         return node.args.every(isNumber);
-    } else if (node.type === "mul") {
+    } else if (node.type === NodeType.Mul) {
         return node.args.every(isNumber);
-    } else if (node.type === "add") {
+    } else if (node.type === NodeType.Add) {
         return node.args.every(isNumber);
-    } else if (node.type === "root") {
+    } else if (node.type === NodeType.Root) {
         return isNumber(node.radicand) && isNumber(node.index);
-    } else if (node.type === "pow") {
+    } else if (node.type === NodeType.Power) {
         return isNumber(node.base) && isNumber(node.exp);
     } else {
         return false;
@@ -55,13 +57,13 @@ export const isNumeric = (node: types.Node): node is types.NumericNode => {
         NodeType.Mul,
         NodeType.Func,
         NodeType.Div,
-        NodeType.Mod,
+        NodeType.Modulo,
         NodeType.Root,
-        NodeType.Pow,
+        NodeType.Power,
         NodeType.Log,
         NodeType.Neg,
-        NodeType.Abs,
-        NodeType.Sum,
+        NodeType.AbsoluteValue,
+        NodeType.Summation,
         NodeType.Product,
         NodeType.Limit,
         NodeType.Derivative,
@@ -156,15 +158,15 @@ export type HasArgs =
     | types.Div;
 
 export const hasArgs = (a: types.Node): a is HasArgs =>
-    a.type === "add" ||
-    a.type === "mul" ||
-    a.type === "eq" ||
-    a.type === "neq" ||
-    a.type === "lt" ||
-    a.type === "lte" ||
-    a.type === "gt" ||
-    a.type === "gte" ||
-    a.type === "div";
+    a.type === NodeType.Add ||
+    a.type === NodeType.Mul ||
+    a.type === NodeType.Equals ||
+    a.type === NodeType.NotEquals ||
+    a.type === NodeType.LessThan ||
+    a.type === NodeType.LessThanOrEquals ||
+    a.type === NodeType.GreaterThan ||
+    a.type === NodeType.GreaterThanOrEquals ||
+    a.type === NodeType.Div;
 
 // TODO: dedupe with grader package
 type Options = {
@@ -180,21 +182,21 @@ export const evalNode = (
         evalFractions: true,
     },
 ): Fraction => {
-    if (node.type === "number") {
+    if (node.type === NodeType.Number) {
         return new Fraction(node.value);
-    } else if (node.type === "neg") {
+    } else if (node.type === NodeType.Neg) {
         return evalNode(node.arg, options).mul(new Fraction("-1"));
-    } else if (node.type === "div" && options.evalFractions) {
+    } else if (node.type === NodeType.Div && options.evalFractions) {
         // TODO: add a recursive option as well
         return evalNode(node.args[0], options).div(
             evalNode(node.args[1], options),
         );
-    } else if (node.type === "add") {
+    } else if (node.type === NodeType.Add) {
         return node.args.reduce(
             (sum, term) => sum.add(evalNode(term, options)),
             new Fraction("0"),
         );
-    } else if (node.type === "mul") {
+    } else if (node.type === NodeType.Mul) {
         return node.args.reduce(
             (sum, factor) => sum.mul(evalNode(factor, options)),
             new Fraction("1"),

--- a/packages/solver/src/simplify/transforms/add-neg-to-sub.ts
+++ b/packages/solver/src/simplify/transforms/add-neg-to-sub.ts
@@ -2,6 +2,8 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {Transform} from "../types";
 
+const {NodeType} = Semantic;
+
 export const addNegToSub: Transform = (node) => {
     if (!Semantic.util.isNumeric(node)) {
         return;
@@ -9,7 +11,7 @@ export const addNegToSub: Transform = (node) => {
     const terms = Semantic.util.getTerms(node);
     let changed = false;
     const newTerms = terms.map((term, index) => {
-        if (index > 0 && term.type === "neg" && !term.subtraction) {
+        if (index > 0 && term.type === NodeType.Neg && !term.subtraction) {
             changed = true;
             return Semantic.builders.neg(term.arg, true);
         } else {

--- a/packages/solver/src/simplify/transforms/distribute-div.ts
+++ b/packages/solver/src/simplify/transforms/distribute-div.ts
@@ -3,36 +3,41 @@ import {Step} from "@math-blocks/step-utils";
 
 import {Transform} from "../types";
 
+const {NodeType} = Semantic;
+
 // (a + b) / c -> a/c + b/c
 export const distributeDiv: Transform = (node, path): Step | undefined => {
-    if (node.type !== "div") {
+    if (node.type !== NodeType.Div) {
         return undefined;
     }
 
     const [numerator, denominator] = node.args;
 
-    if (numerator.type !== "add") {
+    if (numerator.type !== NodeType.Add) {
         return undefined;
     }
 
     const after = Semantic.builders.add(
         numerator.args.map((term, index) => {
             // TODO: clone denominator
-            if (term.type === "neg" && denominator.type === "neg") {
+            if (
+                term.type === NodeType.Neg &&
+                denominator.type === NodeType.Neg
+            ) {
                 // TODO: add a substep going from -a / -b -> a / b
                 // We don't need the whole proof for each of these substeps, but
                 // we should be able to link to a proof if a student needs more
                 // info.  How do we should contextual help without moving to a
                 // different page?
                 return Semantic.builders.div(term.arg, denominator.arg);
-            } else if (term.type === "neg") {
+            } else if (term.type === NodeType.Neg) {
                 // TODO: add substeps for converting subtraction to adding the
                 // negative and back again.
                 return Semantic.builders.neg(
                     Semantic.builders.div(term.arg, denominator),
                     term.subtraction,
                 );
-            } else if (denominator.type === "neg") {
+            } else if (denominator.type === NodeType.Neg) {
                 // TODO: add substeps for converting subtraction to adding the
                 // negative and back again.
                 return Semantic.builders.neg(

--- a/packages/solver/src/simplify/transforms/drop-add-identity.ts
+++ b/packages/solver/src/simplify/transforms/drop-add-identity.ts
@@ -2,10 +2,12 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {Transform} from "../types";
 
+const {NodeType} = Semantic;
+
 const isZero = (node: Semantic.types.Node): boolean => {
-    if (node.type === "number" && node.value === "0") {
+    if (node.type === NodeType.Number && node.value === "0") {
         return true;
-    } else if (node.type === "neg") {
+    } else if (node.type === NodeType.Neg) {
         return isZero(node.arg);
     } else {
         return false;
@@ -13,7 +15,7 @@ const isZero = (node: Semantic.types.Node): boolean => {
 };
 
 export const dropAddIdentity: Transform = (node) => {
-    if (node.type !== "add") {
+    if (node.type !== NodeType.Add) {
         return;
     }
     const terms = Semantic.util.getTerms(node);

--- a/packages/solver/src/simplify/transforms/drop-parens.ts
+++ b/packages/solver/src/simplify/transforms/drop-parens.ts
@@ -2,6 +2,8 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {Transform} from "../types";
 
+const {NodeType} = Semantic;
+
 export const dropParens: Transform = (node) => {
     if (!Semantic.util.isNumeric(node)) {
         return;
@@ -9,7 +11,7 @@ export const dropParens: Transform = (node) => {
     const terms = Semantic.util.getTerms(node);
     let changed = false;
     const newTerms = terms.flatMap((term) => {
-        if (term.type === "add") {
+        if (term.type === NodeType.Add) {
             changed = true;
             return term.args;
         } else {

--- a/packages/solver/src/simplify/transforms/eval.ts
+++ b/packages/solver/src/simplify/transforms/eval.ts
@@ -2,6 +2,8 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {Transform} from "../types";
 
+const {NodeType} = Semantic;
+
 // TODO: backport this to @math-blocks/semantic
 const evalNode = (
     node: Semantic.types.NumericNode,
@@ -85,7 +87,7 @@ export const evalAdd: Transform = (node) => {
 // TODO: if the fraction is in lowest terms or otherwise can't be modified, don't
 // process it.
 export const evalDiv: Transform = (node) => {
-    if (node.type !== "div") {
+    if (node.type !== NodeType.Div) {
         return;
     }
 

--- a/packages/solver/src/simplify/transforms/mul-fraction.ts
+++ b/packages/solver/src/simplify/transforms/mul-fraction.ts
@@ -2,16 +2,18 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {Transform} from "../types";
 
+const {NodeType} = Semantic;
+
 export const mulFraction: Transform = (before) => {
     if (
-        before.type === "mul" &&
-        before.args.some((arg) => arg.type === "div")
+        before.type === NodeType.Mul &&
+        before.args.some((arg) => arg.type === NodeType.Div)
     ) {
         const numFactors: Semantic.types.NumericNode[] = [];
         const denFactors: Semantic.types.NumericNode[] = [];
 
         for (const factor of before.args) {
-            if (factor.type === "div") {
+            if (factor.type === NodeType.Div) {
                 const [num, den] = factor.args;
                 numFactors.push(...Semantic.util.getFactors(num));
                 denFactors.push(...Semantic.util.getFactors(den));

--- a/packages/solver/src/simplify/transforms/reduce-fraction.ts
+++ b/packages/solver/src/simplify/transforms/reduce-fraction.ts
@@ -3,11 +3,13 @@ import * as Semantic from "@math-blocks/semantic";
 import {Transform} from "../types";
 import {isNegative} from "../util";
 
+const {NodeType} = Semantic;
+
 // TODO:
 // - powers
 // - negative factors
 export const reduceFraction: Transform = (node) => {
-    if (node.type !== "div") {
+    if (node.type !== NodeType.Div) {
         return undefined;
     }
 
@@ -16,11 +18,11 @@ export const reduceFraction: Transform = (node) => {
     }
 
     const numFactors =
-        node.args[0].type === "neg"
+        node.args[0].type === NodeType.Neg
             ? Semantic.util.getFactors(node.args[0].arg)
             : Semantic.util.getFactors(node.args[0]);
     const denFactors =
-        node.args[1].type === "neg"
+        node.args[1].type === NodeType.Neg
             ? Semantic.util.getFactors(node.args[1].arg)
             : Semantic.util.getFactors(node.args[1]);
 
@@ -60,7 +62,7 @@ export const reduceFraction: Transform = (node) => {
         }
     }
 
-    if (resultIsNegative && after.type !== "div") {
+    if (resultIsNegative && after.type !== NodeType.Div) {
         after = Semantic.builders.neg(after);
     }
 

--- a/packages/solver/src/simplify/transforms/simplify-mul.ts
+++ b/packages/solver/src/simplify/transforms/simplify-mul.ts
@@ -4,6 +4,8 @@ import {Step} from "@math-blocks/step-utils";
 import {Transform} from "../types";
 import {isNegative} from "../util";
 
+const {NodeType} = Semantic;
+
 // This transform should go at the top of the simplify stack so that other
 // transforms that work with `mul` nodes don't have to handle as many cases.
 //
@@ -18,26 +20,26 @@ import {isNegative} from "../util";
 // 1x -> x
 // -1x -> -x
 export const simplifyMul: Transform = (before, path): Step | undefined => {
-    if (before.type !== "mul") {
+    if (before.type !== NodeType.Mul) {
         return undefined;
     }
 
     let changed = false;
     for (const arg of before.args) {
-        if (arg.type === "neg") {
+        if (arg.type === NodeType.Neg) {
             changed = true;
             break;
         }
     }
 
     // This seems like a weird exception to have on this function
-    if (before.args.some((f) => f.type === "add")) {
+    if (before.args.some((f) => f.type === NodeType.Add)) {
         return undefined;
     }
 
     const factors = Semantic.util
         .getFactors(before)
-        .map((f) => (f.type === "neg" ? f.arg : f));
+        .map((f) => (f.type === NodeType.Neg ? f.arg : f));
 
     const one = Semantic.builders.number("1");
     const newFactors = factors.filter((f) => !Semantic.util.deepEquals(one, f));

--- a/packages/solver/src/simplify/util.ts
+++ b/packages/solver/src/simplify/util.ts
@@ -1,16 +1,18 @@
 import * as Semantic from "@math-blocks/semantic";
 import {Step} from "@math-blocks/step-utils";
 
+const {NodeType} = Semantic;
+
 // TODO: backport the change to @math-blocks/semantic
 // We want three checks:
 // - is it negative
 // - is it subtraction
 // - is it negative and not subtraction
 export const isNegative = (node: Semantic.types.NumericNode): boolean => {
-    if (node.type === "neg") {
+    if (node.type === NodeType.Neg) {
         return !isNegative(node.arg);
     }
-    if (node.type === "mul") {
+    if (node.type === NodeType.Mul) {
         let count = 0;
         for (const factor of node.args) {
             if (isNegative(factor)) {
@@ -30,15 +32,15 @@ export const simplifyMul = (
 
     // if a and b are monomials
     const aFactors =
-        a.type === "neg"
+        a.type === NodeType.Neg
             ? Semantic.util.getFactors(a.arg)
             : Semantic.util.getFactors(a);
     const bFactors =
-        b.type === "neg"
+        b.type === NodeType.Neg
             ? Semantic.util.getFactors(b.arg)
             : Semantic.util.getFactors(b);
 
-    const resultIsNeg = (a.type === "neg") !== (b.type === "neg");
+    const resultIsNeg = (a.type === NodeType.Neg) !== (b.type === NodeType.Neg);
 
     let after: Semantic.types.NumericNode;
 
@@ -80,7 +82,7 @@ export const simplifyMul = (
     }
 
     const factors =
-        after.type === "neg"
+        after.type === NodeType.Neg
             ? Semantic.util.getFactors(after.arg)
             : Semantic.util.getFactors(after);
 
@@ -98,7 +100,7 @@ export const simplifyMul = (
     }
 
     let message: string;
-    if (a.type === "neg" && b.type === "neg") {
+    if (a.type === NodeType.Neg && b.type === NodeType.Neg) {
         message = "multiplying two negatives is a positive";
     } else if (resultIsNeg) {
         message = "multiplying a negative by a positive is negative";

--- a/packages/solver/src/solve/solve.ts
+++ b/packages/solver/src/solve/solve.ts
@@ -7,6 +7,8 @@ import {moveTermsToOneSide} from "./transforms/move-terms-to-one-side";
 import {simplifyBothSides} from "./transforms/simplify-both-sides";
 import type {Transform} from "./types";
 
+const {NodeType} = Semantic;
+
 /**
  * Solve an equation for a given variable.
  *
@@ -21,7 +23,7 @@ import type {Transform} from "./types";
  * @param ident the variable being solved for
  */
 export const solve: Transform = (node, ident) => {
-    if (node.type !== "eq") {
+    if (node.type !== NodeType.Equals) {
         return undefined;
     }
 
@@ -59,7 +61,7 @@ export const solve: Transform = (node, ident) => {
 
     const after = current;
 
-    if (after.type === "eq") {
+    if (after.type === NodeType.Equals) {
         const [left, right] = after.args;
         if (
             Semantic.util.deepEquals(left, ident) ||

--- a/packages/solver/src/solve/transforms/div-both-sides.ts
+++ b/packages/solver/src/solve/transforms/div-both-sides.ts
@@ -3,6 +3,8 @@ import * as Semantic from "@math-blocks/semantic";
 import {Transform} from "../types";
 import {getCoeff, isTermOfIdent} from "../util";
 
+const {NodeType} = Semantic;
+
 export const divBothSides: Transform = (before, ident) => {
     const [left, right] = before.args as readonly Semantic.types.NumericNode[];
 
@@ -29,7 +31,7 @@ export const divBothSides: Transform = (before, ident) => {
 
     if (leftIdentTerms.length === 1 && leftNonIdentTerms.length === 0) {
         const coeff = getCoeff(leftIdentTerms[0]);
-        if (coeff.type === "div") {
+        if (coeff.type === NodeType.Div) {
             return undefined;
         }
 
@@ -41,14 +43,14 @@ export const divBothSides: Transform = (before, ident) => {
         const args = before.args as TwoOrMore<Semantic.types.NumericNode>;
 
         const after = Semantic.builders.eq(
-            (args.map((arg) => {
+            args.map((arg) => {
                 const result = Semantic.builders.div(
                     arg as Semantic.types.NumericNode,
                     coeff,
                 );
                 result.source = "divBothSides";
                 return result;
-            }) as unknown) as TwoOrMore<Semantic.types.NumericNode>,
+            }) as unknown as TwoOrMore<Semantic.types.NumericNode>,
         );
 
         return {
@@ -61,7 +63,7 @@ export const divBothSides: Transform = (before, ident) => {
 
     if (rightIdentTerms.length === 1 && rightNonIdentTerms.length === 0) {
         const coeff = getCoeff(rightIdentTerms[0]);
-        if (coeff.type === "div") {
+        if (coeff.type === NodeType.Div) {
             return undefined;
         }
 
@@ -73,14 +75,14 @@ export const divBothSides: Transform = (before, ident) => {
         const args = before.args as TwoOrMore<Semantic.types.NumericNode>;
 
         const after = Semantic.builders.eq(
-            (args.map((arg) => {
+            args.map((arg) => {
                 const result = Semantic.builders.div(
                     arg as Semantic.types.NumericNode,
                     coeff,
                 );
                 result.source = "divBothSides";
                 return result;
-            }) as unknown) as TwoOrMore<Semantic.types.NumericNode>,
+            }) as unknown as TwoOrMore<Semantic.types.NumericNode>,
         );
 
         return {

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -3,6 +3,8 @@ import * as Semantic from "@math-blocks/semantic";
 import {Transform} from "../types";
 import {isTermOfIdent, flipSign, convertSubTermToNeg} from "../util";
 
+const {NodeType} = Semantic;
+
 /**
  * Moves all terms matching `ident` to one side and those that don't to the
  * other side.
@@ -47,7 +49,7 @@ export const moveTermsToOneSide: Transform = (before, ident) => {
         // TODO: create two sub-steps for each of these moves
         // Move identifiers to the left
         const left =
-            leftIdentTerms[0].type === "neg"
+            leftIdentTerms[0].type === NodeType.Neg
                 ? Semantic.builders.add([
                       convertSubTermToNeg(leftIdentTerms[0]),
                       ...leftIdentTerms.slice(1),
@@ -85,7 +87,7 @@ export const moveTermsToOneSide: Transform = (before, ident) => {
         ]);
 
         // TODO: run this check on leftIdentTerms[0]
-        if (left.type === "neg") {
+        if (left.type === NodeType.Neg) {
             left = convertSubTermToNeg(left);
         }
 
@@ -116,7 +118,7 @@ export const moveTermsToOneSide: Transform = (before, ident) => {
         ]);
 
         let right = rightIdentTerms[0];
-        if (right.type === "neg") {
+        if (right.type === NodeType.Neg) {
             right = convertSubTermToNeg(right);
         }
 

--- a/packages/solver/src/solve/transforms/mul-both-sides.ts
+++ b/packages/solver/src/solve/transforms/mul-both-sides.ts
@@ -3,6 +3,8 @@ import * as Semantic from "@math-blocks/semantic";
 import {Transform} from "../types";
 import {isTermOfIdent} from "../util";
 
+const {NodeType} = Semantic;
+
 export const mulBothSides: Transform = (before, ident) => {
     const [left, right] = before.args as readonly Semantic.types.NumericNode[];
 
@@ -12,7 +14,7 @@ export const mulBothSides: Transform = (before, ident) => {
 
     const leftTerms = Semantic.util.getTerms(left);
 
-    if (leftTerms.length === 1 && leftTerms[0].type === "div") {
+    if (leftTerms.length === 1 && leftTerms[0].type === NodeType.Div) {
         const [num, den] = leftTerms[0].args;
         if (isTermOfIdent(num, ident) && Semantic.util.isNumber(den)) {
             const newLeft = Semantic.builders.mul([leftTerms[0], den]);
@@ -34,7 +36,7 @@ export const mulBothSides: Transform = (before, ident) => {
 
     const rightTerms = Semantic.util.getTerms(right);
 
-    if (rightTerms.length === 1 && rightTerms[0].type === "div") {
+    if (rightTerms.length === 1 && rightTerms[0].type === NodeType.Div) {
         const [num, den] = rightTerms[0].args;
         if (isTermOfIdent(num, ident) && Semantic.util.isNumber(den)) {
             const newLeft = Semantic.builders.mul([left, den]);

--- a/packages/solver/src/solve/util.ts
+++ b/packages/solver/src/solve/util.ts
@@ -1,13 +1,15 @@
 import * as Semantic from "@math-blocks/semantic";
 
+const {NodeType} = Semantic;
+
 // TODO: handle non-canonicalized terms
 export const getCoeff = (
     node: Semantic.types.NumericNode,
 ): Semantic.types.NumericNode => {
-    if (node.type === "neg") {
+    if (node.type === NodeType.Neg) {
         return Semantic.builders.neg(getCoeff(node.arg));
     }
-    if (node.type === "div") {
+    if (node.type === NodeType.Div) {
         return Semantic.builders.div(getCoeff(node.args[0]), node.args[1]);
     }
     const factors = Semantic.util.getFactors(node);
@@ -23,7 +25,7 @@ export const isTermOfIdent = (
 ): boolean => {
     if (Semantic.util.deepEquals(ident, term)) {
         return true;
-    } else if (term.type === "mul" && term.args.length === 2) {
+    } else if (term.type === NodeType.Mul && term.args.length === 2) {
         const [coeff, varFact] = term.args;
         if (
             Semantic.util.isNumber(coeff) &&
@@ -31,9 +33,9 @@ export const isTermOfIdent = (
         ) {
             return true;
         }
-    } else if (term.type === "neg") {
+    } else if (term.type === NodeType.Neg) {
         return isTermOfIdent(term.arg, ident);
-    } else if (term.type === "div") {
+    } else if (term.type === NodeType.Div) {
         const [num, den] = term.args;
         if (Semantic.util.isNumber(den)) {
             return isTermOfIdent(num, ident);
@@ -45,7 +47,7 @@ export const isTermOfIdent = (
 export const flipSign = (
     node: Semantic.types.NumericNode,
 ): Semantic.types.NumericNode => {
-    if (node.type === "neg") {
+    if (node.type === NodeType.Neg) {
         return node.arg;
     } else {
         return Semantic.builders.neg(node, true);
@@ -55,7 +57,7 @@ export const flipSign = (
 export const convertSubTermToNeg = (
     node: Semantic.types.NumericNode,
 ): Semantic.types.NumericNode => {
-    if (node.type === "neg" && node.subtraction) {
+    if (node.type === NodeType.Neg && node.subtraction) {
         const factors = Semantic.util.getFactors(node.arg);
         const numericFactors = factors.filter(Semantic.util.isNumber);
         const nonNumericFactors = factors.filter(

--- a/packages/step-utils/src/apply.ts
+++ b/packages/step-utils/src/apply.ts
@@ -2,6 +2,8 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {Step} from "./types";
 
+const {NodeType} = Semantic;
+
 export const applyStep = (
     node: Semantic.types.Node,
     step: Step,
@@ -22,9 +24,9 @@ export const applyStep = (
             const newNode = step.after;
 
             if (
-                newNode.type === "add" &&
-                node.type !== "add" &&
-                parent?.type === "add"
+                newNode.type === NodeType.Add &&
+                node.type !== NodeType.Add &&
+                parent?.type === NodeType.Add
             ) {
                 // let the parent handle the application
                 return;
@@ -32,7 +34,7 @@ export const applyStep = (
             if (node.id === oldNode.id) {
                 return newNode;
             }
-            if (newNode.type === "add" && node.type === "add") {
+            if (newNode.type === NodeType.Add && node.type === NodeType.Add) {
                 const index = node.args.findIndex(
                     (arg: Semantic.types.NumericNode) => arg.id === oldNode.id,
                 );

--- a/packages/testing/src/__tests__/serializer.test.ts
+++ b/packages/testing/src/__tests__/serializer.test.ts
@@ -43,18 +43,19 @@ describe("serializer", () => {
             Semantic.builders.neg(Semantic.builders.number("5"), true),
         ]);
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               x
               (neg.sub 5))
         `);
     });
 
     test("not", () => {
-        const ast = {
-            type: "not",
+        const ast: Semantic.types.LogicNode = {
+            id: getId(),
+            type: NodeType.LogicalNot,
             arg: Semantic.builders.identifier("A"),
         };
-        expect(ast).toMatchInlineSnapshot(`(not A)`);
+        expect(ast).toMatchInlineSnapshot(`(LogicalNot A)`);
     });
 
     test("mul (explicit)", () => {
@@ -78,12 +79,12 @@ describe("serializer", () => {
             Semantic.builders.identifier("x"),
             Semantic.builders.number("5"),
         ]);
-        expect(ast).toMatchInlineSnapshot(`(add x 5)`);
+        expect(ast).toMatchInlineSnapshot(`(Add x 5)`);
     });
 
     test("root", () => {
         const ast = Semantic.builders.sqrt(Semantic.builders.identifier("x"));
-        expect(ast).toMatchInlineSnapshot(`(root :radicand x :index 2)`);
+        expect(ast).toMatchInlineSnapshot(`(Root :radicand x :index 2)`);
     });
 
     test("pow", () => {
@@ -91,7 +92,7 @@ describe("serializer", () => {
             Semantic.builders.identifier("x"),
             Semantic.builders.number("2"),
         );
-        expect(ast).toMatchInlineSnapshot(`(pow :base x :exp 2)`);
+        expect(ast).toMatchInlineSnapshot(`(Power :base x :exp 2)`);
     });
 
     test("pow (with grandchildren)", () => {
@@ -103,14 +104,17 @@ describe("serializer", () => {
             Semantic.builders.number("2"),
         );
         expect(ast).toMatchInlineSnapshot(`
-            (pow
-              :base (add x 1)
+            (Power
+              :base (Add x 1)
               :exp 2)
         `);
     });
 
     test("infinity", () => {
-        const ast = {type: "infinity"};
+        const ast: Semantic.types.NumericNode = {
+            type: NodeType.Infinity,
+            id: getId(),
+        };
         expect(ast).toMatchInlineSnapshot(`\u221e`);
     });
 
@@ -128,7 +132,7 @@ describe("serializer", () => {
                 () => "",
             );
         }).toThrowErrorMatchingInlineSnapshot(
-            `"we don't handle serializing 'log' nodes yet"`,
+            `"we don't handle serializing 'Log' nodes yet"`,
         );
     });
 });

--- a/packages/testing/src/__tests__/text-parser.test.ts
+++ b/packages/testing/src/__tests__/text-parser.test.ts
@@ -7,20 +7,20 @@ describe("TextParser", () => {
     it("parse addition", () => {
         const ast = parse("1 + 2");
 
-        expect(ast).toMatchInlineSnapshot(`(add 1 2)`);
+        expect(ast).toMatchInlineSnapshot(`(Add 1 2)`);
     });
 
     it("parse n-ary addition", () => {
         const ast = parse("1 + 2 + a");
 
-        expect(ast).toMatchInlineSnapshot(`(add 1 2 a)`);
+        expect(ast).toMatchInlineSnapshot(`(Add 1 2 a)`);
     });
 
     it("parses minus", () => {
         const ast = parse("a - b");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               a
               (neg.sub b))
         `);
@@ -30,7 +30,7 @@ describe("TextParser", () => {
         const ast = parse("a + b - c + d");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               a
               b
               (neg.sub c)
@@ -42,7 +42,7 @@ describe("TextParser", () => {
         const ast = parse("1 + 2 * 3 - 4");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               1
               (mul.exp 2 3)
               (neg.sub 4))
@@ -59,7 +59,7 @@ describe("TextParser", () => {
         const ast = parse("a + -a");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               a
               (neg a))
         `);
@@ -75,7 +75,7 @@ describe("TextParser", () => {
         const ast = parse("a - -b");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               a
               (neg.sub (neg b)))
         `);
@@ -97,7 +97,7 @@ describe("TextParser", () => {
         const ast = parse("-a / b");
 
         expect(ast).toMatchInlineSnapshot(`
-            (div
+            (Div
               (neg a)
               b)
         `);
@@ -106,7 +106,7 @@ describe("TextParser", () => {
     it("negation is higher precedence than division (w/ parens)", () => {
         const ast = parse("-(a / b)");
 
-        expect(ast).toMatchInlineSnapshot(`(neg (div a b))`);
+        expect(ast).toMatchInlineSnapshot(`(neg (Div a b))`);
     });
 
     // TODO: document this in the semantic README.md
@@ -114,7 +114,7 @@ describe("TextParser", () => {
         const ast = parse("7x - 5x");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               (mul.imp 7 x)
               (neg.sub (mul.imp 5 x)))
         `);
@@ -125,7 +125,7 @@ describe("TextParser", () => {
         const ast = parse("7x + -5x");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               (mul.imp 7 x)
               (neg (mul.imp 5 x)))
         `);
@@ -155,7 +155,7 @@ describe("TextParser", () => {
         const ast = parse("ab + cd");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
+            (Add
               (mul.imp a b)
               (mul.imp c d))
         `);
@@ -188,8 +188,8 @@ describe("TextParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.exp
-              (div a b)
-              (div c d))
+              (Div a b)
+              (Div c d))
         `);
     });
 
@@ -198,10 +198,10 @@ describe("TextParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.exp
-              (div
+              (Div
                 (mul.imp a b)
                 (mul.imp c d))
-              (div
+              (Div
                 (mul.imp u v)
                 (mul.imp x y)))
         `);
@@ -210,7 +210,7 @@ describe("TextParser", () => {
     it("parses parenthesis", () => {
         const ast = parse("(x + y)");
 
-        expect(ast).toMatchInlineSnapshot(`(Parens (add x y))`);
+        expect(ast).toMatchInlineSnapshot(`(Parens (Add x y))`);
     });
 
     it("throws if lparen is missing", () => {
@@ -237,7 +237,7 @@ describe("TextParser", () => {
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
               a
-              (add x y))
+              (Add x y))
         `);
     });
 
@@ -245,9 +245,9 @@ describe("TextParser", () => {
         const ast = parse("(a + b) + (x + y)");
 
         expect(ast).toMatchInlineSnapshot(`
-            (add
-              (add a b)
-              (add x y))
+            (Add
+              (Add a b)
+              (Add x y))
         `);
     });
 
@@ -256,8 +256,8 @@ describe("TextParser", () => {
 
         expect(ast).toMatchInlineSnapshot(`
             (mul.imp
-              (add a b)
-              (add x y))
+              (Add a b)
+              (Add x y))
         `);
     });
 
@@ -270,15 +270,15 @@ describe("TextParser", () => {
     it("parses division", () => {
         const ast = parse("x / y");
 
-        expect(ast).toMatchInlineSnapshot(`(div x y)`);
+        expect(ast).toMatchInlineSnapshot(`(Div x y)`);
     });
 
     it("parses nested division", () => {
         const ast = parse("x / y / z");
 
         expect(ast).toMatchInlineSnapshot(`
-            (div
-              (div x y)
+            (Div
+              (Div x y)
               z)
         `);
     });
@@ -286,16 +286,16 @@ describe("TextParser", () => {
     it("parses exponents", () => {
         const ast = parse("x^2");
 
-        expect(ast).toMatchInlineSnapshot(`(pow :base x :exp 2)`);
+        expect(ast).toMatchInlineSnapshot(`(Power :base x :exp 2)`);
     });
 
     it("parses nested exponents", () => {
         const ast = parse("2^3^4");
 
         expect(ast).toMatchInlineSnapshot(`
-            (pow
+            (Power
               :base 2
-              :exp (pow :base 3 :exp 4))
+              :exp (Power :base 3 :exp 4))
         `);
     });
 
@@ -303,16 +303,16 @@ describe("TextParser", () => {
         const ast = parse("y = x + 1");
 
         expect(ast).toMatchInlineSnapshot(`
-            (eq
+            (Equals
               y
-              (add x 1))
+              (Add x 1))
         `);
     });
 
     it("parses n-ary equations", () => {
         const ast = parse("x = y = z");
 
-        expect(ast).toMatchInlineSnapshot(`(eq x y z)`);
+        expect(ast).toMatchInlineSnapshot(`(Equals x y z)`);
     });
 
     it("parses (5)2 as (mul 5 2)", () => {
@@ -325,14 +325,14 @@ describe("TextParser", () => {
         it("excess parens 1", () => {
             const ast = parse("(x + y)");
 
-            expect(ast).toMatchInlineSnapshot(`(Parens (add x y))`);
+            expect(ast).toMatchInlineSnapshot(`(Parens (Add x y))`);
         });
 
         it("excess parens 2", () => {
             const ast = parse("(x) + (y)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (Parens x)
                   (Parens y))
             `);
@@ -342,7 +342,7 @@ describe("TextParser", () => {
             const ast = parse("(a * b) + (c * d)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   (Parens (mul.exp a b))
                   (Parens (mul.exp c d)))
             `);
@@ -353,7 +353,7 @@ describe("TextParser", () => {
 
             expect(ast).toMatchInlineSnapshot(`
                 (mul.imp
-                  (Parens (add a b))
+                  (Parens (Add a b))
                   (Parens c))
             `);
         });
@@ -364,7 +364,7 @@ describe("TextParser", () => {
             const ast = parse("a + (-b)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   a
                   (Parens (neg b)))
             `);
@@ -374,7 +374,7 @@ describe("TextParser", () => {
             const ast = parse("(a) / (b)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (div
+                (Div
                   (Parens a)
                   (Parens b))
             `);
@@ -383,7 +383,7 @@ describe("TextParser", () => {
         it("fractions 2", () => {
             const ast = parse("(a/b)");
 
-            expect(ast).toMatchInlineSnapshot(`(Parens (div a b))`);
+            expect(ast).toMatchInlineSnapshot(`(Parens (Div a b))`);
         });
 
         it("fractions 3", () => {
@@ -391,8 +391,8 @@ describe("TextParser", () => {
 
             expect(ast).toMatchInlineSnapshot(`
                 (mul.imp
-                  (div 1 a)
-                  (div 1 b))
+                  (Div 1 a)
+                  (Div 1 b))
             `);
         });
 
@@ -400,7 +400,7 @@ describe("TextParser", () => {
             const ast = parse("a^(2)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (pow
+                (Power
                   :base a
                   :exp (Parens 2))
             `);
@@ -410,9 +410,9 @@ describe("TextParser", () => {
             const ast = parse("e^(x + y)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (pow
+                (Power
                   :base e
-                  :exp (add x y))
+                  :exp (Add x y))
             `);
         });
 
@@ -432,9 +432,9 @@ describe("TextParser", () => {
             const ast = parse("1 + (x + y)");
 
             expect(ast).toMatchInlineSnapshot(`
-                (add
+                (Add
                   1
-                  (add x y))
+                  (Add x y))
             `);
         });
     });

--- a/packages/testing/src/printer.ts
+++ b/packages/testing/src/printer.ts
@@ -3,6 +3,8 @@
  */
 import * as Semantic from "@math-blocks/semantic";
 
+const {NodeType} = Semantic;
+
 // TODO: Use the operator precedence numbers from text-parser to determine when
 // to add parens (or not).
 
@@ -10,19 +12,19 @@ import * as Semantic from "@math-blocks/semantic";
 
 export const print = (expr: Semantic.types.Node, oneToOne = false): string => {
     switch (expr.type) {
-        case "Identifier": {
+        case NodeType.Identifier: {
             // TODO: handle multi-character identifiers, e.g. sin, cos, etc.
             // TODO: handle subscripts
 
             return expr.name;
         }
-        case "number": {
+        case NodeType.Number: {
             // How do we avoid creating a bunch of ids that we immediately
             // throw away because this number is part of a larger expression
             // and thus contained within a larger row?
             return expr.value;
         }
-        case "add": {
+        case NodeType.Add: {
             let result = "";
 
             for (let i = 0; i < expr.args.length; i++) {
@@ -41,22 +43,22 @@ export const print = (expr: Semantic.types.Node, oneToOne = false): string => {
                 }
 
                 if (
-                    arg.type === "number" ||
-                    arg.type === "Identifier" ||
-                    arg.type === "mul" ||
-                    arg.type === "div" ||
-                    arg.type === "pow" ||
-                    (arg.type === "neg" && !arg.subtraction)
+                    arg.type === NodeType.Number ||
+                    arg.type === NodeType.Identifier ||
+                    arg.type === NodeType.Mul ||
+                    arg.type === NodeType.Div ||
+                    arg.type === NodeType.Power ||
+                    (arg.type === NodeType.Neg && !arg.subtraction)
                 ) {
                     result += print(arg, oneToOne);
                 } else if (Semantic.util.isSubtraction(arg)) {
                     if (
-                        arg.arg.type === "number" ||
-                        arg.arg.type === "Identifier" ||
-                        arg.arg.type === "mul" ||
-                        arg.arg.type === "div" ||
-                        arg.arg.type === "pow" ||
-                        (arg.arg.type === "neg" && !arg.arg.subtraction)
+                        arg.arg.type === NodeType.Number ||
+                        arg.arg.type === NodeType.Identifier ||
+                        arg.arg.type === NodeType.Mul ||
+                        arg.arg.type === NodeType.Div ||
+                        arg.arg.type === NodeType.Power ||
+                        (arg.arg.type === NodeType.Neg && !arg.arg.subtraction)
                     ) {
                         result += print(arg.arg, oneToOne);
                     } else {
@@ -69,17 +71,17 @@ export const print = (expr: Semantic.types.Node, oneToOne = false): string => {
 
             return result;
         }
-        case "mul": {
+        case NodeType.Mul: {
             let result = "";
 
             const wrapAll = expr.args.some((arg, index) => {
-                if (arg.type === "number" && index > 0) {
+                if (arg.type === NodeType.Number && index > 0) {
                     return true;
                 }
-                if (arg.type === "neg" && (index > 0 || oneToOne)) {
+                if (arg.type === NodeType.Neg && (index > 0 || oneToOne)) {
                     return true;
                 }
-                if (arg.type === "div") {
+                if (arg.type === NodeType.Div) {
                     return true;
                 }
                 return false;
@@ -93,9 +95,11 @@ export const print = (expr: Semantic.types.Node, oneToOne = false): string => {
 
                 const wrap =
                     (wrapAll && expr.implicit) ||
-                    arg.type === "add" ||
-                    (arg.type === "mul" && !arg.implicit) ||
-                    (expr.implicit && arg.type === "mul" && arg.implicit);
+                    arg.type === NodeType.Add ||
+                    (arg.type === NodeType.Mul && !arg.implicit) ||
+                    (expr.implicit &&
+                        arg.type === NodeType.Mul &&
+                        arg.implicit);
                 const node = print(arg, oneToOne);
 
                 if (wrap) {
@@ -107,54 +111,65 @@ export const print = (expr: Semantic.types.Node, oneToOne = false): string => {
 
             return result;
         }
-        case "neg": {
+        case NodeType.Neg: {
             const node = print(expr.arg, oneToOne);
             if (
-                expr.arg.type === "number" ||
-                expr.arg.type === "Identifier" ||
-                (expr.arg.type === "neg" && !expr.arg.subtraction) ||
-                (expr.arg.type === "mul" && expr.arg.implicit) ||
-                expr.arg.type === "pow" // pow has a higher precedence
+                expr.arg.type === NodeType.Number ||
+                expr.arg.type === NodeType.Identifier ||
+                (expr.arg.type === NodeType.Neg && !expr.arg.subtraction) ||
+                (expr.arg.type === NodeType.Mul && expr.arg.implicit) ||
+                expr.arg.type === NodeType.Power // pow has a higher precedence
             ) {
                 return `-${node}`;
             } else {
                 return `-(${node})`;
             }
         }
-        case "div": {
+        case NodeType.Div: {
             const numerator =
-                expr.args[0].type === "add" ||
-                (expr.args[0].type === "mul" && !expr.args[0].implicit) ||
-                expr.args[0].type === "div"
+                expr.args[0].type === NodeType.Add ||
+                (expr.args[0].type === NodeType.Mul &&
+                    !expr.args[0].implicit) ||
+                expr.args[0].type === NodeType.Div
                     ? `(${print(expr.args[0], oneToOne)})`
                     : print(expr.args[0], oneToOne);
             const denominator =
-                expr.args[1].type === "add" ||
-                (expr.args[1].type === "mul" && !expr.args[1].implicit) ||
-                expr.args[1].type === "div"
+                expr.args[1].type === NodeType.Add ||
+                (expr.args[1].type === NodeType.Mul &&
+                    !expr.args[1].implicit) ||
+                expr.args[1].type === NodeType.Div
                     ? `(${print(expr.args[1], oneToOne)})`
                     : print(expr.args[1], oneToOne);
 
             // TODO: change the spacing depending on the parent.
             return `${numerator} / ${denominator}`;
         }
-        case "eq": {
+        case NodeType.Equals: {
             // TODO: add a check to make sure this is true
             const args = expr.args as TwoOrMore<Semantic.types.NumericNode>;
             return args.map((arg) => print(arg, oneToOne)).join(" = ");
         }
-        case "pow": {
+        case NodeType.Power: {
             const {base, exp} = expr;
 
             // 'number' nodes are never negative so this is okay
-            if (base.type === "Identifier" || base.type === "number") {
-                if (exp.type === "Identifier" || exp.type === "number") {
+            if (
+                base.type === NodeType.Identifier ||
+                base.type === NodeType.Number
+            ) {
+                if (
+                    exp.type === NodeType.Identifier ||
+                    exp.type === NodeType.Number
+                ) {
                     return `${print(base, oneToOne)}^${print(exp, oneToOne)}`;
                 } else {
                     return `${print(base, oneToOne)}^(${print(exp, oneToOne)})`;
                 }
             } else {
-                if (exp.type === "Identifier" || exp.type === "number") {
+                if (
+                    exp.type === NodeType.Identifier ||
+                    exp.type === NodeType.Number
+                ) {
                     return `(${print(base, oneToOne)})^${print(exp, oneToOne)}`;
                 } else {
                     return `(${print(base, oneToOne)})^(${print(
@@ -164,7 +179,7 @@ export const print = (expr: Semantic.types.Node, oneToOne = false): string => {
                 }
             }
         }
-        case "Parens": {
+        case NodeType.Parens: {
             return `(${print(expr.arg)})`;
         }
         default: {

--- a/packages/testing/src/serializer.ts
+++ b/packages/testing/src/serializer.ts
@@ -1,6 +1,8 @@
 // import {UnreachableCaseError} from "@math-blocks/core";
 import * as Semantic from "@math-blocks/semantic";
 
+const {NodeType} = Semantic;
+
 const printArgs = (
     type: string,
     args: readonly Semantic.types.Node[],
@@ -9,7 +11,7 @@ const printArgs = (
 ): string => {
     const hasGrandchildren = args.some(
         (arg: Semantic.types.Node) =>
-            arg.type !== "Identifier" && arg.type !== "number",
+            arg.type !== NodeType.Identifier && arg.type !== NodeType.Number,
     );
 
     if (hasGrandchildren) {
@@ -26,16 +28,16 @@ const printArgs = (
 };
 
 const symbols = {
-    infinity: "\u221e",
-    pi: "\u03c0",
-    ellipsis: "...", // TODO: replace with \u2026 or \u22ef
-    true: "T",
-    false: "F",
-    naturals: "\u2115",
-    integers: "\u2124",
-    rationals: "\u221a",
-    reals: "\u221d",
-    complexes: "\u2102",
+    [NodeType.Infinity]: "\u221e",
+    [NodeType.Pi]: "\u03c0",
+    [NodeType.Ellipsis]: "...", // TODO: replace with \u2026 or \u22ef
+    [NodeType.True]: "T",
+    [NodeType.False]: "F",
+    [NodeType.Naturals]: "\u2115",
+    [NodeType.Integers]: "\u2124",
+    [NodeType.Rationals]: "\u221a",
+    [NodeType.Reals]: "\u221d",
+    [NodeType.Complexes]: "\u2102",
 };
 
 type WorkRow = {
@@ -76,10 +78,10 @@ const print = (
         return "null";
     }
     switch (ast.type) {
-        case "number": {
+        case NodeType.Number: {
             return `${ast.value}`;
         }
-        case "Identifier": {
+        case NodeType.Identifier: {
             if (ast.subscript) {
                 return `(ident ${ast.name} ${print(
                     ast.subscript,
@@ -90,52 +92,53 @@ const print = (
                 return `${ast.name}`;
             }
         }
-        case "neg": {
+        case NodeType.Neg: {
             const type = ast.subtraction ? "neg.sub" : "neg";
             return `(${type} ${print(ast.arg, serialize, indent)})`;
         }
-        case "not":
-        case "abs":
-        case "Parens":
+        case NodeType.LogicalNot:
+        case NodeType.AbsoluteValue:
+        case NodeType.Parens:
             return `(${ast.type} ${print(ast.arg, serialize, indent)})`;
-        case "mul": {
+        case NodeType.Mul: {
             const type = ast.implicit ? "mul.imp" : "mul.exp";
             return printArgs(type, ast.args, serialize, indent);
         }
-        case "add":
-        case "div":
-        case "mod":
-        case "and":
-        case "or":
-        case "xor":
-        case "implies":
-        case "iff":
-        case "eq":
-        case "neq":
-        case "lt":
-        case "lte":
-        case "gt":
-        case "gte":
-        case "set":
-        case "union":
-        case "intersection":
-        case "setdiff":
-        case "cartesian_product":
-        case "subset":
-        case "prsubset":
-        case "notsubset":
-        case "notprsubset":
+        case NodeType.Add:
+        case NodeType.Div:
+        case NodeType.Modulo:
+        case NodeType.LogicalAnd:
+        case NodeType.LogicalOr:
+        case NodeType.ExclusiveOr:
+        case NodeType.Conditional:
+        case NodeType.Biconditional:
+        case NodeType.Equals:
+        case NodeType.NotEquals:
+        case NodeType.LessThan:
+        case NodeType.LessThanOrEquals:
+        case NodeType.GreaterThan:
+        case NodeType.GreaterThanOrEquals:
+        case NodeType.Set:
+        case NodeType.Union:
+        case NodeType.SetIntersection:
+        case NodeType.SetDifference:
+        case NodeType.CartesianProduct:
+        case NodeType.Subset:
+        case NodeType.ProperSubset:
+        case NodeType.NotSubset:
+        case NodeType.NotProperSubset:
             return printArgs(ast.type, ast.args, serialize, indent);
-        case "root": {
+        case NodeType.Root: {
             const radicand = print(ast.radicand, serialize, indent);
             const index = print(ast.index, serialize, indent);
             return `(${ast.type} :radicand ${radicand} :index ${index})`;
         }
-        case "pow": {
+        case NodeType.Power: {
             const hasGrandchildren =
-                (ast.base.type !== "Identifier" &&
-                    ast.base.type !== "number") ||
-                (ast.exp.type !== "Identifier" && ast.exp.type !== "number");
+                (ast.base.type !== NodeType.Identifier &&
+                    ast.base.type !== NodeType.Number) ||
+                (ast.exp.type !== NodeType.Identifier &&
+                    ast.exp.type !== NodeType.Number);
             const base = print(ast.base, serialize, indent);
             const exp = print(ast.exp, serialize, indent);
             return hasGrandchildren
@@ -144,18 +147,18 @@ const print = (
                   )})`
                 : `(${ast.type} :base ${base} :exp ${exp})`;
         }
-        case "infinity":
-        case "pi":
-        case "ellipsis":
-        case "true":
-        case "false":
-        case "naturals":
-        case "integers":
-        case "rationals":
-        case "reals":
-        case "complexes":
+        case NodeType.Infinity:
+        case NodeType.Pi:
+        case NodeType.Ellipsis:
+        case NodeType.True:
+        case NodeType.False:
+        case NodeType.Naturals:
+        case NodeType.Integers:
+        case NodeType.Rationals:
+        case NodeType.Reals:
+        case NodeType.Complexes:
             return symbols[ast.type];
-        case "VerticalAdditionToRelation": {
+        case NodeType.VerticalAdditionToRelation: {
             const relOp = ast.relOp;
             const originalRelation = printWorkRow(
                 ast.originalRelation,

--- a/packages/testing/src/text-parser.ts
+++ b/packages/testing/src/text-parser.ts
@@ -5,6 +5,8 @@ import {lex} from "./text-lexer";
 
 import type {Token} from "./text-lexer";
 
+const {NodeType} = Semantic;
+
 // TODO: fill out this list
 type Operator =
     | "add"
@@ -270,21 +272,27 @@ const removeExcessParens = (node: Semantic.types.Node): Semantic.types.Node => {
 
             // TODO: use the precedence of the operators to determine whether
             // the parens are necessary or not.
-            if (node.type === "Parens") {
+            if (node.type === NodeType.Parens) {
                 const {arg} = node;
-                if (parent.type === "Parens") {
+                if (parent.type === NodeType.Parens) {
                     return;
                 }
-                if (parent.type === "mul" && parent.implicit) {
+                if (parent.type === NodeType.Mul && parent.implicit) {
                     return arg;
                 }
-                if (arg.type === "Identifier" || arg.type === "number") {
+                if (
+                    arg.type === NodeType.Identifier ||
+                    arg.type === NodeType.Number
+                ) {
                     return;
                 }
-                if (arg.type === "mul" && parent.type === "add") {
+                if (arg.type === NodeType.Mul && parent.type === NodeType.Add) {
                     return;
                 }
-                if (arg.type === "neg" && parent.type !== "pow") {
+                if (
+                    arg.type === NodeType.Neg &&
+                    parent.type !== NodeType.Power
+                ) {
                     return;
                 }
                 return arg;


### PR DESCRIPTION
The goal of this work it to make the `type` enums for the semantic tree more descriptive and more consistent.  This PR also updates a number of places where we were still using string literals instead of the enums.