### PR TITLE
Fix 'correct mistake for me'

### DIFF
--- a/demo/src/tutor/reducer.ts
+++ b/demo/src/tutor/reducer.ts
@@ -136,7 +136,6 @@ export const reducer = (state: State = initialState, action: Action): State => {
                     ...state.steps.slice(0, -1),
                     {
                         ...state.steps[state.steps.length - 1],
-                        status: StepStatus.Pending,
                         value: action.value,
                     },
                 ],

--- a/demo/src/tutor/step.tsx
+++ b/demo/src/tutor/step.tsx
@@ -379,6 +379,8 @@ const Step: React.FunctionComponent<Props> = (props) => {
                     type: "update",
                     value: zipper,
                 });
+                dispatch({type: "set_pending"});
+                setZipper(zipper); // update this value so that we can submit the new answer
             }
         }
     };


### PR DESCRIPTION
We were setting the step status to `Pending` when updating the value of the step upon submission.  This PR fixes it by separating value updates from status updates.