### PR TITLE
reorganize layout of tutor so that on-screen keyboards don't overlap steps

### DIFF
--- a/demo/src/tutor/tutor.tsx
+++ b/demo/src/tutor/tutor.tsx
@@ -29,8 +29,59 @@ const Tutor: React.FunctionComponent = () => {
     const zipper: Editor.Zipper = state.steps[0].value;
 
     return (
-        <div style={{margin: "auto"}}>
-            <VStack style={{marginLeft: 242}}>
+        <HStack style={{margin: "auto"}}>
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    width: 300,
+                    marginRight: 32,
+                }}
+            >
+                {mode === "solve" && (
+                    <button
+                        style={{height: 48, fontSize: 24}}
+                        onClick={() => {
+                            setMode("edit");
+                            dispatch({
+                                type: "set",
+                                steps: [state.steps[0]],
+                            });
+                        }}
+                    >
+                        Edit Question
+                    </button>
+                )}
+                {mode === "edit" && (
+                    <button
+                        style={{height: 48, fontSize: 24}}
+                        onClick={() => {
+                            setMode("solve");
+                            // get the ball rolling
+                            dispatch({type: "duplicate"});
+                        }}
+                    >
+                        Solve Question
+                    </button>
+                )}
+                <MathKeypad />
+                <div style={{position: "fixed", bottom: 0, left: 0, margin: 4}}>
+                    <div>
+                        Icons made by{" "}
+                        <a
+                            href="https://www.flaticon.com/authors/pixel-perfect"
+                            title="Pixel perfect"
+                        >
+                            Pixel perfect
+                        </a>{" "}
+                        from{" "}
+                        <a href="https://www.flaticon.com/" title="Flaticon">
+                            www.flaticon.com
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <VStack style={{flexGrow: 1, height: "100vh", overflowY: "scroll"}}>
                 <HStack>
                     <MathEditor
                         key={`question`}
@@ -69,63 +120,11 @@ const Tutor: React.FunctionComponent = () => {
                         />
                     );
                 })}
+                {isComplete && (
+                    <h1 style={{fontFamily: "sans-serif"}}>Good work!</h1>
+                )}
             </VStack>
-            {isComplete && (
-                <h1 style={{fontFamily: "sans-serif"}}>Good work!</h1>
-            )}
-            <div
-                style={{
-                    position: "fixed",
-                    bottom: 0,
-                    left: 0,
-                    display: "flex",
-                    flexDirection: "column",
-                }}
-            >
-                {mode === "solve" && (
-                    <button
-                        style={{height: 48, fontSize: 24}}
-                        onClick={() => {
-                            setMode("edit");
-                            dispatch({
-                                type: "set",
-                                steps: [state.steps[0]],
-                            });
-                        }}
-                    >
-                        Edit Question
-                    </button>
-                )}
-                {mode === "edit" && (
-                    <button
-                        style={{height: 48, fontSize: 24}}
-                        onClick={() => {
-                            setMode("solve");
-                            // get the ball rolling
-                            dispatch({type: "duplicate"});
-                        }}
-                    >
-                        Solve Question
-                    </button>
-                )}
-                <MathKeypad />
-            </div>
-            <div style={{position: "fixed", bottom: 0, right: 0, margin: 4}}>
-                <div>
-                    Icons made by{" "}
-                    <a
-                        href="https://www.flaticon.com/authors/pixel-perfect"
-                        title="Pixel perfect"
-                    >
-                        Pixel perfect
-                    </a>{" "}
-                    from{" "}
-                    <a href="https://www.flaticon.com/" title="Flaticon">
-                        www.flaticon.com
-                    </a>
-                </div>
-            </div>
-        </div>
+        </HStack>
     );
 };
 

--- a/packages/react/src/__tests__/math-keypad.test.tsx
+++ b/packages/react/src/__tests__/math-keypad.test.tsx
@@ -134,14 +134,14 @@ describe("MathKeypad", () => {
         expect(editMock).toHaveBeenCalledWith({type: "AddRow", side: "below"});
     });
 
-    test("'+ column left' should trigger 'AddColumn' editing event", () => {
+    test("'+ col left' should trigger 'AddColumn' editing event", () => {
         // Arrange
         const editMock = jest.fn();
         render(<TestComp editMock={editMock} />);
 
         // Act
         screen.getByRole("textbox").focus();
-        userEvent.click(screen.getByText("+ column left"));
+        userEvent.click(screen.getByText("+ col left"));
 
         // Assert
         expect(editMock).toHaveBeenCalledWith({
@@ -150,14 +150,14 @@ describe("MathKeypad", () => {
         });
     });
 
-    test("'+ column right' should trigger 'AddColumn' editing event", () => {
+    test("'+ col right' should trigger 'AddColumn' editing event", () => {
         // Arrange
         const editMock = jest.fn();
         render(<TestComp editMock={editMock} />);
 
         // Act
         screen.getByRole("textbox").focus();
-        userEvent.click(screen.getByText("+ column right"));
+        userEvent.click(screen.getByText("+ col right"));
 
         // Assert
         expect(editMock).toHaveBeenCalledWith({
@@ -181,14 +181,14 @@ describe("MathKeypad", () => {
         });
     });
 
-    test("'- column' should trigger 'DeleteColumn' editing event", () => {
+    test("'- col' should trigger 'DeleteColumn' editing event", () => {
         // Arrange
         const editMock = jest.fn();
         render(<TestComp editMock={editMock} />);
 
         // Act
         screen.getByRole("textbox").focus();
-        userEvent.click(screen.getByText("- column"));
+        userEvent.click(screen.getByText("- col"));
 
         // Assert
         expect(editMock).toHaveBeenCalledWith({

--- a/packages/react/src/keypad.module.css
+++ b/packages/react/src/keypad.module.css
@@ -9,11 +9,12 @@
     background-color: #e0e0e0;
     border: solid 1px #e0e0e0;
     width: 240px;
+    margin-top: 32px;
 }
 
 .container2 {
     display: grid;
-    grid-template-columns: auto auto auto;
+    grid-template-columns: auto auto;
     grid-auto-rows: 60px;
     font-family: comic sans ms;
     font-size: 28px;
@@ -21,7 +22,7 @@
     grid-row-gap: 1px;
     background-color: #e0e0e0;
     border: solid 1px #e0e0e0;
-    margin-left: 32px;
+    margin-top: 32px;
 }
 
 .item {

--- a/packages/react/src/math-keypad.tsx
+++ b/packages/react/src/math-keypad.tsx
@@ -73,7 +73,7 @@ const MathKeypad: React.FunctionComponent<EmptyProps> = () => {
     };
 
     return (
-        <div style={{display: "flex", flexDirection: "row"}}>
+        <div style={{display: "flex", flexDirection: "column"}}>
             <div className={styles.container}>
                 {buttons.map((button) => (
                     <div
@@ -111,7 +111,6 @@ const MathKeypad: React.FunctionComponent<EmptyProps> = () => {
                 >
                     + pmatrix
                 </div>
-                <div></div>
                 <div
                     className={styles.item2}
                     onMouseDown={(e) => e.preventDefault()}
@@ -125,10 +124,28 @@ const MathKeypad: React.FunctionComponent<EmptyProps> = () => {
                     className={styles.item2}
                     onMouseDown={(e) => e.preventDefault()}
                     onClick={() =>
+                        handleMatrixClick({type: "AddColumn", side: "left"})
+                    }
+                >
+                    + col left
+                </div>
+                <div
+                    className={styles.item2}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() =>
                         handleMatrixClick({type: "AddRow", side: "below"})
                     }
                 >
                     + row below
+                </div>
+                <div
+                    className={styles.item2}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() =>
+                        handleMatrixClick({type: "AddColumn", side: "right"})
+                    }
+                >
+                    + col right
                 </div>
                 <div
                     className={styles.item2}
@@ -140,27 +157,9 @@ const MathKeypad: React.FunctionComponent<EmptyProps> = () => {
                 <div
                     className={styles.item2}
                     onMouseDown={(e) => e.preventDefault()}
-                    onClick={() =>
-                        handleMatrixClick({type: "AddColumn", side: "left"})
-                    }
-                >
-                    + column left
-                </div>
-                <div
-                    className={styles.item2}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() =>
-                        handleMatrixClick({type: "AddColumn", side: "right"})
-                    }
-                >
-                    + column right
-                </div>
-                <div
-                    className={styles.item2}
-                    onMouseDown={(e) => e.preventDefault()}
                     onClick={() => handleMatrixClick({type: "DeleteColumn"})}
                 >
-                    - column
+                    - col
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This places the on-screen keyboards along the left side of the page and make the right side where the steps are scrollable.