### PR TITLE
Revert "Use useReducer for MathEditor as well"

### DIFF
--- a/demo/src/editor/editor-page.tsx
+++ b/demo/src/editor/editor-page.tsx
@@ -140,125 +140,107 @@ const EditorPage: React.FunctionComponent = () => {
 
     return (
         <FontDataContext.Provider value={fontData}>
-            <div style={{display: "flex", flexDirection: "row"}}>
-                <div
+            <MathEditor
+                fontSize={fontSize}
+                readonly={false}
+                zipper={zipper}
+                radicalDegreeAlgorithm={radicalDegreeAlgorithm}
+                showHitboxes={showHitboxes}
+            />
+            <br />
+            <br />
+            <div style={{fontFamily: "Bonum-Math", fontSize: fontSize}}></div>
+            <div style={{display: "flex", alignItems: "center"}}>
+                <span style={{fontFamily: "sans-serif", paddingRight: 8}}>
+                    Example:{" "}
+                </span>
+                <select
+                    onChange={(e) => {
+                        const index = parseInt(e.target.value);
+                        const example = examples[index];
+                        const zipper: Editor.Zipper = {
+                            breadcrumbs: [],
+                            row: {
+                                id: example.id,
+                                type: "zrow",
+                                left: [],
+                                selection: [],
+                                right: example.children,
+                                style: {},
+                            },
+                        };
+                        setZipper(zipper);
+                    }}
+                    defaultValue={initialExample}
+                >
+                    <option value={0}>Simple Equation</option>
+                    <option value={1}>Adding Fractions</option>
+                    <option value={2}>All Node Types</option>
+                    <option value={3}>Tall Delimiters</option>
+                    <option value={4}>Nested Fractions</option>
+                    <option value={5}>Matrix</option>
+                </select>
+                <span
                     style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        marginRight: 32,
+                        fontFamily: "sans-serif",
+                        paddingRight: 8,
+                        marginLeft: 32,
                     }}
                 >
-                    <FormattingPalette />
-                    {/* <EditingPanel /> */}
-                    <div style={{height: 8}} />
-                    <MathKeypad />
-                </div>
-                <div style={{display: "flex", flexDirection: "column"}}>
-                    <MathEditor
-                        fontSize={fontSize}
-                        readonly={false}
-                        zipper={zipper}
-                        radicalDegreeAlgorithm={radicalDegreeAlgorithm}
-                        showHitboxes={showHitboxes}
-                    />
-                    <br />
-                    <br />
-                    <div
-                        style={{fontFamily: "Bonum-Math", fontSize: fontSize}}
-                    ></div>
-                    <div style={{display: "flex", alignItems: "center"}}>
-                        <span
-                            style={{fontFamily: "sans-serif", paddingRight: 8}}
-                        >
-                            Example:{" "}
-                        </span>
-                        <select
-                            onChange={(e) => {
-                                const index = parseInt(e.target.value);
-                                const example = examples[index];
-                                const zipper: Editor.Zipper = {
-                                    breadcrumbs: [],
-                                    row: {
-                                        id: example.id,
-                                        type: "zrow",
-                                        left: [],
-                                        selection: [],
-                                        right: example.children,
-                                        style: {},
-                                    },
-                                };
-                                setZipper(zipper);
-                            }}
-                            defaultValue={initialExample}
-                        >
-                            <option value={0}>Simple Equation</option>
-                            <option value={1}>Adding Fractions</option>
-                            <option value={2}>All Node Types</option>
-                            <option value={3}>Tall Delimiters</option>
-                            <option value={4}>Nested Fractions</option>
-                            <option value={5}>Matrix</option>
-                        </select>
-                        <span
-                            style={{
-                                fontFamily: "sans-serif",
-                                paddingRight: 8,
-                                marginLeft: 32,
-                            }}
-                        >
-                            Font:{" "}
-                        </span>
-                        <select
-                            onChange={(e) =>
-                                setFontIndex(parseInt(e.target.value))
-                            }
-                            defaultValue={fontIndex}
-                        >
-                            <option value={0}>STIX2</option>
-                            <option value={1}>Latin Modern</option>
-                            <option value={2}>Gyre Bonum</option>
-                            <option value={3}>Gyre Pagella</option>
-                            <option value={4}>Gyre Schola</option>
-                            <option value={5}>Gyre Termes</option>
-                        </select>
-                        <span
-                            style={{
-                                fontFamily: "sans-serif",
-                                paddingRight: 8,
-                                marginLeft: 32,
-                            }}
-                        >
-                            Radical Degree Algorithm:{" "}
-                        </span>
-                        <select
-                            onChange={(e) =>
-                                setRadicalDegreeAlgorithm(
-                                    parseInt(e.target.value),
-                                )
-                            }
-                            defaultValue={RadicalDegreeAlgorithm.OpenType}
-                        >
-                            <option value={RadicalDegreeAlgorithm.OpenType}>
-                                OpenType
-                            </option>
-                            <option value={RadicalDegreeAlgorithm.MathML}>
-                                MathML/Word
-                            </option>
-                        </select>
-                        <span
-                            style={{
-                                fontFamily: "sans-serif",
-                                paddingRight: 8,
-                                marginLeft: 32,
-                            }}
-                        >
-                            Show Hitboxes
-                        </span>
-                        <input
-                            type="checkbox"
-                            onChange={(e) => setShowHitboxes(e.target.checked)}
-                        ></input>
-                    </div>
-                </div>
+                    Font:{" "}
+                </span>
+                <select
+                    onChange={(e) => setFontIndex(parseInt(e.target.value))}
+                    defaultValue={fontIndex}
+                >
+                    <option value={0}>STIX2</option>
+                    <option value={1}>Latin Modern</option>
+                    <option value={2}>Gyre Bonum</option>
+                    <option value={3}>Gyre Pagella</option>
+                    <option value={4}>Gyre Schola</option>
+                    <option value={5}>Gyre Termes</option>
+                </select>
+                <span
+                    style={{
+                        fontFamily: "sans-serif",
+                        paddingRight: 8,
+                        marginLeft: 32,
+                    }}
+                >
+                    Radical Degree Algorithm:{" "}
+                </span>
+                <select
+                    onChange={(e) =>
+                        setRadicalDegreeAlgorithm(parseInt(e.target.value))
+                    }
+                    defaultValue={RadicalDegreeAlgorithm.OpenType}
+                >
+                    <option value={RadicalDegreeAlgorithm.OpenType}>
+                        OpenType
+                    </option>
+                    <option value={RadicalDegreeAlgorithm.MathML}>
+                        MathML/Word
+                    </option>
+                </select>
+                <span
+                    style={{
+                        fontFamily: "sans-serif",
+                        paddingRight: 8,
+                        marginLeft: 32,
+                    }}
+                >
+                    Show Hitboxes
+                </span>
+                <input
+                    type="checkbox"
+                    onChange={(e) => setShowHitboxes(e.target.checked)}
+                ></input>
+            </div>
+            <div style={{position: "fixed", bottom: 0, left: 0}}>
+                <FormattingPalette />
+                {/* <EditingPanel /> */}
+                <div style={{height: 8}} />
+                <MathKeypad />
             </div>
         </FontDataContext.Provider>
     );

--- a/demo/src/tutor/step.tsx
+++ b/demo/src/tutor/step.tsx
@@ -306,12 +306,10 @@ const Step: React.FunctionComponent<Props> = (props) => {
         }
     };
 
-    const handleChange = React.useCallback(
-        (zipper: Editor.Zipper): void => {
-            onChange(zipper);
-        },
-        [onChange],
-    );
+    const handleChange = (zipper: Editor.Zipper): void => {
+        setZipper(zipper);
+        onChange(zipper);
+    };
 
     let buttonsOrIcon = (
         <HStack>

--- a/demo/src/tutor/tutor.tsx
+++ b/demo/src/tutor/tutor.tsx
@@ -3,13 +3,15 @@ import * as React from "react";
 
 import {MathKeypad, MathEditor} from "@math-blocks/react";
 import * as Editor from "@math-blocks/editor";
-import {reducer, ProblemStatus} from "@math-blocks/tutor";
+import {reducer, ProblemStatus, StepStatus} from "@math-blocks/tutor";
 
 // TODO: rename Step to StepChecker and StepCheckerPage to Grader
 import Step from "./step";
 import {getPairs} from "./util";
 import {initialState} from "./store";
 import {HStack, VStack} from "./layout";
+
+const {useState} = React;
 
 // TODO: Create two modes: immediate and delayed
 // - Immediate feedback will show whether the current step is
@@ -18,7 +20,7 @@ import {HStack, VStack} from "./layout";
 // - Delayed feedback will conceal the correctness of each step
 //   until the user submits their answer.
 const Tutor: React.FunctionComponent = () => {
-    // const [mode, setMode] = React.useState<"edit" | "solve">("solve");
+    const [mode, setMode] = useState<"edit" | "solve">("solve");
     const [state, dispatch] = React.useReducer(reducer, initialState);
 
     const isComplete = state.status === ProblemStatus.Complete;
@@ -32,11 +34,11 @@ const Tutor: React.FunctionComponent = () => {
                 style={{
                     display: "flex",
                     flexDirection: "column",
-                    width: 320,
+                    width: 300,
                     marginRight: 32,
                 }}
             >
-                {/* {mode === "solve" && (
+                {mode === "solve" && (
                     <button
                         style={{height: 48, fontSize: 24}}
                         onClick={() => {
@@ -61,7 +63,7 @@ const Tutor: React.FunctionComponent = () => {
                     >
                         Solve Question
                     </button>
-                )} */}
+                )}
                 <MathKeypad />
                 <div style={{position: "fixed", bottom: 0, left: 0, margin: 4}}>
                     <div>
@@ -86,7 +88,20 @@ const Tutor: React.FunctionComponent = () => {
                         readonly={false}
                         zipper={zipper}
                         stepChecker={true}
+                        // focus={mode === "edit"}
                         style={{marginTop: 8, flexGrow: 1}}
+                        onChange={(zipper: Editor.Zipper) => {
+                            dispatch({
+                                type: "set",
+                                steps: [
+                                    {
+                                        status: StepStatus.Correct,
+                                        value: zipper,
+                                        hint: "none",
+                                    },
+                                ],
+                            });
+                        }}
                     />
                     <div style={{width: 200, marginLeft: 8}} />
                 </HStack>

--- a/packages/editor/src/reducer/action-types.ts
+++ b/packages/editor/src/reducer/action-types.ts
@@ -59,8 +59,4 @@ export type Action =
     | {
           readonly type: "Uncancel";
       }
-    | MatrixActions
-    | {
-          readonly type: "Update";
-          readonly value: Zipper;
-      };
+    | MatrixActions;

--- a/packages/editor/src/reducer/reducer.ts
+++ b/packages/editor/src/reducer/reducer.ts
@@ -86,13 +86,6 @@ export const reducer = (state: State = initialState, action: Action): State => {
         case "DeleteRow":
         case "DeleteColumn":
             return matrix(state, action);
-        case "Update":
-            return {
-                startZipper: action.value,
-                endZipper: action.value,
-                zipper: action.value,
-                selecting: false,
-            };
         default:
             throw new UnreachableCaseError(action);
     }

--- a/packages/react/src/keypad.module.css
+++ b/packages/react/src/keypad.module.css
@@ -9,7 +9,7 @@
     background-color: #e0e0e0;
     border: solid 1px #e0e0e0;
     width: 240px;
-    margin-bottom: 32px;
+    margin-top: 32px;
 }
 
 .container2 {
@@ -22,7 +22,7 @@
     grid-row-gap: 1px;
     background-color: #e0e0e0;
     border: solid 1px #e0e0e0;
-    margin-bottom: 32px;
+    margin-top: 32px;
 }
 
 .item {

--- a/packages/react/src/math-editor.tsx
+++ b/packages/react/src/math-editor.tsx
@@ -92,7 +92,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
         [props.zipper],
     );
 
-    const [state, dispatch] = React.useReducer(Editor.reducer, memoizedState);
+    const [state, setState] = useState<Editor.State>(memoizedState);
     const [active, setActive] = useState<boolean>(false);
     const [mouseDown, setMouseDown] = useState<boolean>(false);
 
@@ -101,15 +101,6 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const svgRef = useRef<SVGSVGElement>(null);
-
-    // Call onChange whenever state changes
-    const {onChange} = props;
-    useEffect(() => {
-        if (onChange) {
-            console.log(state.zipper);
-            onChange(state.zipper);
-        }
-    }, [onChange, state]);
 
     const handleKeydown = useCallback(
         (e: KeyboardEvent): void => {
@@ -121,7 +112,17 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
                 }
 
                 if (action) {
-                    dispatch(action);
+                    const newState = Editor.reducer(state, action);
+                    setState(newState);
+
+                    // We always call on change even when the user is moving the
+                    // cursor.  The underlying content doesn't change, but how
+                    // it's represented in memory is.  If we don't do this, when
+                    // the tutor tries to highlight mistakes it will be doing so
+                    // with a stale value.
+                    if (props.onChange) {
+                        props.onChange(newState.zipper);
+                    }
                 }
 
                 // Prevent StoryBook from capturing '/' and shifting focus to
@@ -137,11 +138,11 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
             if (active && !props.readonly) {
                 const action = keyupToAction(e.key);
                 if (action) {
-                    dispatch(action);
+                    setState(Editor.reducer(state, action));
                 }
             }
         },
-        [props, dispatch, active],
+        [props, state, active],
     );
 
     useEventListener("keydown", handleKeydown);
@@ -166,17 +167,20 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
             }
             const {detail} = e;
             if (detail.type === "color") {
-                dispatch({
+                const newState = Editor.reducer(state, {
                     type: "Color",
                     color: detail.value,
                 });
+                setState(newState);
             } else if (detail.type === "cancel") {
-                dispatch({type: "Cancel"});
+                const newState = Editor.reducer(state, {type: "Cancel"});
+                setState(newState);
             } else if (detail.type === "uncancel") {
-                dispatch({type: "Uncancel"});
+                const newState = Editor.reducer(state, {type: "Uncancel"});
+                setState(newState);
             }
         },
-        [dispatch, active, props.readonly],
+        [state, active, props.readonly],
     ) as EventListener;
 
     // TODO: don't add event listener to window otherwise this event will
@@ -195,13 +199,16 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
     );
 
     const handleEditing = useCallback(
-        ({detail}: CustomEvent<EditingEvent>): void => {
+        (e: CustomEvent<EditingEvent>): void => {
             if (!active || props.readonly) {
                 return;
             }
-            dispatch(detail);
+            const {detail} = e;
+            console.log(detail);
+            const newState = Editor.reducer(state, detail);
+            setState(newState);
         },
-        [dispatch, active, props.readonly],
+        [state, active, props.readonly],
     ) as EventListener;
 
     // TODO: don't add event listener to window otherwise this event will
@@ -235,20 +242,22 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
         const cursorZipper = Editor.rowToZipper(row, intersections);
 
         if (cursorZipper) {
-            dispatch(
-                select ? {type: "StartSelecting"} : {type: "StopSelecting"},
+            const newState = select
+                ? Editor.reducer(state, {type: "StartSelecting"})
+                : Editor.reducer(state, {type: "StopSelecting"});
+            setState(
+                Editor.reducer(newState, {
+                    type: "PositionCursor",
+                    cursor: cursorZipper,
+                }),
             );
-            dispatch({
-                type: "PositionCursor",
-                cursor: cursorZipper,
-            });
         }
     };
 
     // We need to update the state.zipper when props.zipper changes otherwise
     // it looks like fast-refresh is broken.
     React.useEffect(() => {
-        dispatch({type: "Update", value: props.zipper});
+        setState(Editor.stateFromZipper(props.zipper));
     }, [props.zipper]);
 
     const {style, fontSize, showHitboxes} = props;
@@ -286,7 +295,7 @@ export const MathEditor: React.FunctionComponent<Props> = (props: Props) => {
             }}
             onMouseUp={(e) => {
                 setMouseDown(false);
-                dispatch({type: "StopSelecting"});
+                setState(Editor.reducer(state, {type: "StopSelecting"}));
             }}
             className={cx({[styles.container]: true, [styles.focus]: active})}
             style={style}

--- a/packages/tutor/src/__tests__/reducer.test.ts
+++ b/packages/tutor/src/__tests__/reducer.test.ts
@@ -37,186 +37,111 @@ describe("reducer", () => {
         });
     });
 
-    describe("action: {type: 'right'}", () => {
-        it("should mark the last step as correct if it isn't already", () => {
-            const step: Step = {
-                status: StepStatus.Incorrect,
-                value: zipper,
-                mistakes: [],
-            };
+    it("should mark the last step as correct", () => {
+        const step: Step = {
+            status: StepStatus.Incorrect,
+            value: zipper,
+            mistakes: [],
+        };
 
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
+        const state: State = {
+            steps: [step],
+            status: ProblemStatus.Incomplete,
+        };
 
-            const result = reducer(state, {type: "right", hint: "none"});
+        const result = reducer(state, {type: "right", hint: "none"});
 
-            expect(result).toEqual({
-                steps: [
-                    {
-                        value: step.value,
-                        status: StepStatus.Correct,
-                        hint: "none",
-                    },
-                ],
-                status: ProblemStatus.Incomplete,
-            });
-        });
-
-        it("should return the same object if the last step is already correct", () => {
-            const step: Step = {
-                status: StepStatus.Correct,
-                value: zipper,
-                hint: "none",
-            };
-
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
-
-            const result = reducer(state, {type: "right", hint: "none"});
-
-            expect(result).toBe(state);
+        expect(result).toEqual({
+            steps: [
+                {
+                    value: step.value,
+                    status: StepStatus.Correct,
+                    hint: "none",
+                },
+            ],
+            status: ProblemStatus.Incomplete,
         });
     });
 
-    describe("action: {type: 'wrong'}", () => {
-        it("should mark the last step as incorrect", () => {
-            const step: Step = {
-                status: StepStatus.Correct,
-                value: zipper,
-                hint: "none",
-            };
+    it("should mark the last step as incorrect", () => {
+        const step: Step = {
+            status: StepStatus.Incorrect,
+            value: zipper,
+            mistakes: [],
+        };
 
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
+        const state: State = {
+            steps: [step],
+            status: ProblemStatus.Incomplete,
+        };
 
-            const result = reducer(state, {type: "wrong", mistakes: []});
+        const result = reducer(state, {type: "wrong", mistakes: []});
 
-            expect(result).toEqual({
-                steps: [
-                    {
-                        value: step.value,
-                        status: StepStatus.Incorrect,
-                        mistakes: [],
-                    },
-                ],
-                status: ProblemStatus.Incomplete,
-            });
-        });
-
-        it("should not return a new object if the last step is incorrect", () => {
-            const step: Step = {
-                status: StepStatus.Incorrect,
-                value: zipper,
-                mistakes: [],
-            };
-
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
-
-            const result = reducer(state, {type: "wrong", mistakes: []});
-
-            expect(result).toBe(state);
+        expect(result).toEqual({
+            steps: [
+                {
+                    value: step.value,
+                    status: StepStatus.Incorrect,
+                    mistakes: [],
+                },
+            ],
+            status: ProblemStatus.Incomplete,
         });
     });
 
-    describe("action: {type: 'set_pending'}", () => {
-        it("should change the status of the last step to Pending", () => {
-            const step: Step = {
-                status: StepStatus.Incorrect,
-                value: zipper,
-                mistakes: [],
-            };
+    it("should change the status of the last step to Pending", () => {
+        const step: Step = {
+            status: StepStatus.Incorrect,
+            value: zipper,
+            mistakes: [],
+        };
 
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
+        const state: State = {
+            steps: [step],
+            status: ProblemStatus.Incomplete,
+        };
 
-            const result = reducer(state, {type: "set_pending"});
+        const result = reducer(state, {type: "set_pending"});
 
-            expect(result).toEqual({
-                steps: [
-                    {
-                        value: step.value,
-                        status: StepStatus.Pending,
-                    },
-                ],
-                status: ProblemStatus.Incomplete,
-            });
-        });
-
-        it("should return the same object if the last item is already pending", () => {
-            const step: Step = {
-                status: StepStatus.Pending,
-                value: zipper,
-            };
-
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
-
-            const result = reducer(state, {type: "set_pending"});
-
-            expect(result).toBe(state);
+        expect(result).toEqual({
+            steps: [
+                {
+                    value: step.value,
+                    status: StepStatus.Pending,
+                },
+            ],
+            status: ProblemStatus.Incomplete,
         });
     });
 
-    describe("action: {type: 'update'}", () => {
-        it("should update the value of the last step if the value is different", () => {
-            const step: Step = {
-                status: StepStatus.Incorrect,
-                value: zipper,
-                mistakes: [],
-            };
+    it("should update the value of the last step", () => {
+        const step: Step = {
+            status: StepStatus.Incorrect,
+            value: zipper,
+            mistakes: [],
+        };
 
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
+        const state: State = {
+            steps: [step],
+            status: ProblemStatus.Incomplete,
+        };
 
-            const newCharRow: Editor.types.CharRow = Editor.util.row("2x=5");
-            const newZipper = Editor.rowToZipper(newCharRow, []);
-            if (!newZipper) {
-                throw new Error("Couldn't create zipper");
-            }
+        const newCharRow: Editor.types.CharRow = Editor.util.row("2x=5");
+        const newZipper = Editor.rowToZipper(newCharRow, []);
+        if (!newZipper) {
+            throw new Error("Couldn't create zipper");
+        }
 
-            const result = reducer(state, {type: "update", value: newZipper});
+        const result = reducer(state, {type: "update", value: newZipper});
 
-            expect(result).toEqual({
-                steps: [
-                    {
-                        ...step,
-                        value: newZipper,
-                    },
-                ],
-                status: ProblemStatus.Incomplete,
-            });
-        });
-
-        it("should return the same object if the value is the same object", () => {
-            const step: Step = {
-                status: StepStatus.Incorrect,
-                value: zipper,
-                mistakes: [],
-            };
-
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
-
-            const result = reducer(state, {type: "update", value: zipper});
-
-            expect(result).toBe(state);
+        expect(result).toEqual({
+            steps: [
+                {
+                    ...step,
+                    value: newZipper,
+                },
+            ],
+            status: ProblemStatus.Incomplete,
         });
     });
 
@@ -252,42 +177,23 @@ describe("reducer", () => {
         });
     });
 
-    describe("action: {type: 'complete'}", () => {
-        it("should complete the problem", () => {
-            const step: Step = {
-                status: StepStatus.Incorrect,
-                value: zipper,
-                mistakes: [],
-            };
+    it("should complete the problem", () => {
+        const step: Step = {
+            status: StepStatus.Incorrect,
+            value: zipper,
+            mistakes: [],
+        };
 
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Incomplete,
-            };
+        const state: State = {
+            steps: [step],
+            status: ProblemStatus.Incomplete,
+        };
 
-            const result = reducer(state, {type: "complete"});
+        const result = reducer(state, {type: "complete"});
 
-            expect(result).toEqual({
-                steps: state.steps,
-                status: ProblemStatus.Complete,
-            });
-        });
-
-        it("should return the same object if already complete", () => {
-            const step: Step = {
-                status: StepStatus.Correct,
-                value: zipper,
-                hint: "none",
-            };
-
-            const state: State = {
-                steps: [step],
-                status: ProblemStatus.Complete,
-            };
-
-            const result = reducer(state, {type: "complete"});
-
-            expect(result).toBe(state);
+        expect(result).toEqual({
+            steps: state.steps,
+            status: ProblemStatus.Complete,
         });
     });
 

--- a/packages/tutor/src/reducer.ts
+++ b/packages/tutor/src/reducer.ts
@@ -79,10 +79,7 @@ const initialState: State = {
 export const reducer = (state: State = initialState, action: Action): State => {
     switch (action.type) {
         case "right": {
-            const {value, status} = state.steps[state.steps.length - 1];
-            if (status === StepStatus.Correct) {
-                return state;
-            }
+            const {value} = state.steps[state.steps.length - 1];
             return {
                 ...state,
                 steps: [
@@ -96,10 +93,7 @@ export const reducer = (state: State = initialState, action: Action): State => {
             };
         }
         case "wrong": {
-            const {value, status} = state.steps[state.steps.length - 1];
-            if (status === StepStatus.Incorrect) {
-                return state;
-            }
+            const {value} = state.steps[state.steps.length - 1];
             return {
                 ...state,
                 steps: [
@@ -138,10 +132,6 @@ export const reducer = (state: State = initialState, action: Action): State => {
             };
         }
         case "update": {
-            const {value} = state.steps[state.steps.length - 1];
-            if (action.value === value) {
-                return state;
-            }
             return {
                 ...state,
                 steps: [
@@ -160,12 +150,7 @@ export const reducer = (state: State = initialState, action: Action): State => {
             };
         }
         case "set_pending": {
-            // It's important that the reducer only returns a new object when
-            // there's a change in the state object.
-            const {value, status} = state.steps[state.steps.length - 1];
-            if (status === StepStatus.Pending) {
-                return state;
-            }
+            const {value} = state.steps[state.steps.length - 1];
             return {
                 ...state,
                 steps: [
@@ -178,9 +163,6 @@ export const reducer = (state: State = initialState, action: Action): State => {
             };
         }
         case "complete": {
-            if (state.status === ProblemStatus.Complete) {
-                return state;
-            }
             return {
                 ...state,
                 status: ProblemStatus.Complete,


### PR DESCRIPTION
Reverts math-blocks/math-blocks#483

The problem is that we need to call `onChange` only in response to keyboard events as opposed to all changes to MathEditor's state.