### PR TITLE
Make `Step` generic, drop `Transform` types

### DIFF
--- a/demo/src/solver/solver-page.tsx
+++ b/demo/src/solver/solver-page.tsx
@@ -40,7 +40,10 @@ const SolverPage: React.FunctionComponent = () => {
     const handleSimplify = (): void => {
         console.log("SIMPLIFY");
         const ast = Editor.parse(Editor.zipperToRow(input));
-        const result = Solver.simplify(ast, []);
+        if (!Semantic.util.isNumeric(ast)) {
+            throw new Error("ast is not a NumericNode");
+        }
+        const result = Solver.simplify(ast);
         if (result) {
             console.log(result);
             const solution = Editor.print(result.after);

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -37,12 +37,7 @@ export type NumericNode =
     | Limit
     | Derivative
     | PartialDerivative
-    | Integral
-    | VerticalAdditionToRelation
-    | LongAddition
-    | LongSubtraction
-    | LongMultiplication
-    | LongDivision;
+    | Integral;
 
 /**
  * Number
@@ -338,6 +333,11 @@ export type LogicNode =
     | (Common<NodeType.Equals> & {
           readonly args: TwoOrMore<Node>;
       })
+    | VerticalAdditionToRelation
+    | LongAddition
+    | LongSubtraction
+    | LongMultiplication
+    | LongDivision
     | Neq
     | Lt
     | Lte

--- a/packages/solver/src/simplify/__tests__/simplify.test.ts
+++ b/packages/solver/src/simplify/__tests__/simplify.test.ts
@@ -10,7 +10,10 @@ import {toHaveFullStepsLike} from "../../test-util";
 expect.extend({toHaveFullStepsLike});
 
 const simplify = (node: Semantic.types.Node): Step => {
-    const result = _simplify(node, []);
+    if (!Semantic.util.isNumeric(node)) {
+        throw new Error("node is not a NumericNode");
+    }
+    const result = _simplify(node);
     if (!result) {
         throw new Error("no step returned");
     }

--- a/packages/solver/src/simplify/transforms/__tests__/collect-like-terms.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/collect-like-terms.test.ts
@@ -10,7 +10,10 @@ import {toHaveSubstepsLike, toHaveFullStepsLike} from "../../../test-util";
 expect.extend({toHaveSubstepsLike, toHaveFullStepsLike});
 
 const collectLikeTerms = (node: Semantic.types.Node): Step => {
-    const result = _collectLikeTerms(node, []);
+    if (!Semantic.util.isNumeric(node)) {
+        throw new Error("node is not a NumericNode");
+    }
+    const result = _collectLikeTerms(node);
     if (!result) {
         throw new Error("no step returned");
     }

--- a/packages/solver/src/simplify/transforms/__tests__/distribute-div.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/distribute-div.test.ts
@@ -5,7 +5,10 @@ import type {Step} from "../../../types";
 import {distributeDiv as _distributeDiv} from "../distribute-div";
 
 const distributeDiv = (node: Semantic.types.Node): Step => {
-    const result = _distributeDiv(node, []);
+    if (!Semantic.util.isNumeric(node)) {
+        throw new Error("node is not a NumericNode");
+    }
+    const result = _distributeDiv(node);
     if (!result) {
         throw new Error("no step returned");
     }

--- a/packages/solver/src/simplify/transforms/__tests__/distribute.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/distribute.test.ts
@@ -10,6 +10,9 @@ import {toHaveSubstepsLike, toHaveFullStepsLike} from "../../../test-util";
 expect.extend({toHaveSubstepsLike, toHaveFullStepsLike});
 
 const distribute = (node: Semantic.types.Node): Step => {
+    if (!Semantic.util.isNumeric(node)) {
+        throw new Error("node is not a NumericNode");
+    }
     const result = _distribute(node, []);
     if (!result) {
         throw new Error("no step returned");

--- a/packages/solver/src/simplify/transforms/add-neg-to-sub.ts
+++ b/packages/solver/src/simplify/transforms/add-neg-to-sub.ts
@@ -1,13 +1,12 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
-export const addNegToSub: Transform = (node) => {
-    if (!Semantic.util.isNumeric(node)) {
-        return;
-    }
+export function addNegToSub(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     const terms = Semantic.util.getTerms(node);
     let changed = false;
     const newTerms = terms.map((term, index) => {
@@ -27,4 +26,4 @@ export const addNegToSub: Transform = (node) => {
         after: Semantic.builders.add(newTerms),
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/collect-like-terms.ts
+++ b/packages/solver/src/simplify/transforms/collect-like-terms.ts
@@ -1,7 +1,6 @@
 import * as Semantic from "@math-blocks/semantic";
 import * as Testing from "@math-blocks/testing";
 
-import {Transform} from "../types";
 import {simplifyMul} from "../util";
 import {getCoeff} from "../../solve/util";
 
@@ -9,12 +8,14 @@ import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
-export const collectLikeTerms: Transform = (node): Step | undefined => {
+export function collectLikeTerms(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (node.type !== NodeType.Add) {
         return;
     }
 
-    const substeps: Step[] = [];
+    const substeps: Step<Semantic.types.NumericNode>[] = [];
 
     const newSum = subToAddNeg(node, substeps);
     const groups = getGroups(newSum.args);
@@ -35,7 +36,7 @@ export const collectLikeTerms: Transform = (node): Step | undefined => {
         after: newNode,
         substeps,
     };
-};
+}
 
 type Groups = ReadonlyMap<
     Semantic.types.NumericNode | null,

--- a/packages/solver/src/simplify/transforms/distribute-div.ts
+++ b/packages/solver/src/simplify/transforms/distribute-div.ts
@@ -1,12 +1,13 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
 import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
 // (a + b) / c -> a/c + b/c
-export const distributeDiv: Transform = (node, path): Step | undefined => {
+export function distributeDiv(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (node.type !== NodeType.Div) {
         return undefined;
     }
@@ -56,4 +57,4 @@ export const distributeDiv: Transform = (node, path): Step | undefined => {
         after,
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/distribute.ts
+++ b/packages/solver/src/simplify/transforms/distribute.ts
@@ -4,14 +4,13 @@ import type {Mutable} from "utility-types";
 import {simplifyMul} from "../util";
 
 import type {Step} from "../../types";
-import type {Transform} from "../types";
 
 const {NodeType} = Semantic;
 
 // a - (b + c) -> a + -1(b + c)
 const distSub = (
     node: Semantic.types.Neg,
-    substeps: Step[], // eslint-disable-line functional/prefer-readonly-type
+    substeps: Step<Semantic.types.NumericNode>[], // eslint-disable-line functional/prefer-readonly-type
 ): readonly Semantic.types.NumericNode[] | undefined => {
     const add = node.arg;
     const mulNegOne = Semantic.builders.mul(
@@ -31,7 +30,7 @@ const distSub = (
 // a - b -> a + -b
 const subToNeg = (
     before: Semantic.types.NumericNode,
-    substeps: Step[], // eslint-disable-line functional/prefer-readonly-type
+    substeps: Step<Semantic.types.NumericNode>[], // eslint-disable-line functional/prefer-readonly-type
 ): Semantic.types.NumericNode => {
     if (Semantic.util.isSubtraction(before)) {
         const after = Semantic.builders.neg(before.arg, false);
@@ -70,7 +69,7 @@ const negToSub = (
 // a(b + c) -> ab + bc
 const distMul = (
     node: Semantic.types.Mul,
-    substeps: Step[], // eslint-disable-line functional/prefer-readonly-type
+    substeps: Step<Semantic.types.NumericNode>[], // eslint-disable-line functional/prefer-readonly-type
 ): readonly Semantic.types.NumericNode[] | undefined => {
     // TODO: handle distribution of more than two polynomials
     if (node.args.length === 2) {
@@ -202,7 +201,10 @@ const distMul = (
  * @param path An array of nodes that were traversed to get to `node`.
  * @return {Step | undefined}
  */
-export const distribute: Transform = (node, path): Step | undefined => {
+export function distribute(
+    node: Semantic.types.NumericNode,
+    path: readonly Semantic.types.NumericNode[],
+): Step<Semantic.types.NumericNode> | void {
     if (!Semantic.util.isNumeric(node)) {
         return;
     }
@@ -223,7 +225,7 @@ export const distribute: Transform = (node, path): Step | undefined => {
         return undefined;
     }
 
-    const substeps: Step[] = [];
+    const substeps: Step<Semantic.types.NumericNode>[] = [];
     const nodes = Semantic.util.getTerms(node);
     let changed = false;
     const newNodes = nodes.flatMap((node, outerIndex) => {
@@ -262,4 +264,4 @@ export const distribute: Transform = (node, path): Step | undefined => {
         after,
         substeps,
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/drop-add-identity.ts
+++ b/packages/solver/src/simplify/transforms/drop-add-identity.ts
@@ -1,6 +1,6 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
@@ -14,7 +14,9 @@ const isZero = (node: Semantic.types.Node): boolean => {
     }
 };
 
-export const dropAddIdentity: Transform = (node) => {
+export function dropAddIdentity(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (node.type !== NodeType.Add) {
         return;
     }
@@ -36,4 +38,4 @@ export const dropAddIdentity: Transform = (node) => {
         after: Semantic.builders.add(newTerms),
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/drop-parens.ts
+++ b/packages/solver/src/simplify/transforms/drop-parens.ts
@@ -1,10 +1,12 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
-export const dropParens: Transform = (node) => {
+export function dropParens(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (!Semantic.util.isNumeric(node)) {
         return;
     }
@@ -27,4 +29,4 @@ export const dropParens: Transform = (node) => {
         after: Semantic.builders.add(newTerms),
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/eval.ts
+++ b/packages/solver/src/simplify/transforms/eval.ts
@@ -1,6 +1,6 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
@@ -38,7 +38,9 @@ const evalNode = (
 // but won't touch any non-number terms, e.g.
 // (2)(x)(3)(y) -> 6xy
 // TODO: figure out why using our local version of getFactors breaks things.
-export const evalMul: Transform = (node) => {
+export function evalMul(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (!Semantic.util.isNumeric(node)) {
         return;
     }
@@ -59,9 +61,11 @@ export const evalMul: Transform = (node) => {
     }
 
     return undefined;
-};
+}
 
-export const evalAdd: Transform = (node) => {
+export function evalAdd(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (!Semantic.util.isNumeric(node)) {
         return;
     }
@@ -82,11 +86,13 @@ export const evalAdd: Transform = (node) => {
     }
 
     return undefined;
-};
+}
 
 // TODO: if the fraction is in lowest terms or otherwise can't be modified, don't
 // process it.
-export const evalDiv: Transform = (node) => {
+export function evalDiv(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (node.type !== NodeType.Div) {
         return;
     }
@@ -147,4 +153,4 @@ export const evalDiv: Transform = (node) => {
         after,
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/mul-fraction.ts
+++ b/packages/solver/src/simplify/transforms/mul-fraction.ts
@@ -1,18 +1,20 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
-export const mulFraction: Transform = (before) => {
+export function mulFraction(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (
-        before.type === NodeType.Mul &&
-        before.args.some((arg) => arg.type === NodeType.Div)
+        node.type === NodeType.Mul &&
+        node.args.some((arg) => arg.type === NodeType.Div)
     ) {
         const numFactors: Semantic.types.NumericNode[] = [];
         const denFactors: Semantic.types.NumericNode[] = [];
 
-        for (const factor of before.args) {
+        for (const factor of node.args) {
             if (factor.type === NodeType.Div) {
                 const [num, den] = factor.args;
                 numFactors.push(...Semantic.util.getFactors(num));
@@ -31,11 +33,11 @@ export const mulFraction: Transform = (before) => {
             // TODO: customize the message depending on whether there are one
             // or more factors that are fractions.
             message: "multiply fraction(s)",
-            before,
+            before: node,
             after,
             substeps: [],
         };
     }
 
     return undefined;
-};
+}

--- a/packages/solver/src/simplify/transforms/mul-to-pow.ts
+++ b/packages/solver/src/simplify/transforms/mul-to-pow.ts
@@ -1,8 +1,10 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
-export const mulToPow: Transform = (node) => {
+export function mulToPow(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (!Semantic.util.isNumeric(node)) {
         return;
     }
@@ -58,4 +60,4 @@ export const mulToPow: Transform = (node) => {
         after: Semantic.builders.mul(newFactors, true),
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/transforms/reduce-fraction.ts
+++ b/packages/solver/src/simplify/transforms/reduce-fraction.ts
@@ -2,14 +2,16 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {isNegative} from "../util";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
 // TODO:
 // - powers
 // - negative factors
-export const reduceFraction: Transform = (node) => {
+export function reduceFraction(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
     if (node.type !== NodeType.Div) {
         return undefined;
     }
@@ -73,4 +75,4 @@ export const reduceFraction: Transform = (node) => {
         after,
         substeps: [],
     };
-};
+}

--- a/packages/solver/src/simplify/types.ts
+++ b/packages/solver/src/simplify/types.ts
@@ -1,7 +1,0 @@
-import * as Semantic from "@math-blocks/semantic";
-import {Step} from "../types";
-
-export type Transform = (
-    node: Semantic.types.Node,
-    path: readonly Semantic.types.Node[],
-) => Step | undefined;

--- a/packages/solver/src/solve/solve.ts
+++ b/packages/solver/src/solve/solve.ts
@@ -6,7 +6,6 @@ import {moveTermsToOneSide} from "./transforms/move-terms-to-one-side";
 import {simplifyBothSides} from "./transforms/simplify-both-sides";
 
 import type {Step} from "../types";
-import type {Transform} from "./types";
 
 const {NodeType} = Semantic;
 
@@ -23,18 +22,15 @@ const {NodeType} = Semantic;
  * @param node the equation (or system of equations) being solved
  * @param ident the variable being solved for
  */
-export const solve: Transform = (node, ident) => {
-    if (node.type !== NodeType.Equals) {
-        return undefined;
-    }
-
+export function solve(
+    node: Semantic.types.Eq,
+    ident: Semantic.types.Identifier,
+): Step | void {
     // NOTE: We simplify both sides before and after every other transform.
     // This is so that we don't jump from something like 2x = 10 - 5 to 2x / 2 = 5 / 2.
-    const transforms: Transform[] = [
-        moveTermsToOneSide,
-        divBothSides,
-        mulBothSides,
-    ].flatMap((transform) => [simplifyBothSides, transform]);
+    const transforms = [moveTermsToOneSide, divBothSides, mulBothSides].flatMap(
+        (transform) => [simplifyBothSides, transform],
+    );
     transforms.push(simplifyBothSides);
 
     const substeps: Step[] = [];
@@ -57,7 +53,7 @@ export const solve: Transform = (node, ident) => {
     // If there are no steps, `solve` doesn't know how to solve this particular
     // equation yet.
     if (substeps.length === 0) {
-        return undefined;
+        return;
     }
 
     const after = current;
@@ -76,6 +72,4 @@ export const solve: Transform = (node, ident) => {
             };
         }
     }
-
-    return undefined;
-};
+}

--- a/packages/solver/src/solve/transforms/__tests__/simplify-both-sides.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/simplify-both-sides.test.ts
@@ -9,11 +9,8 @@ const parseEq = (input: string): Semantic.types.Eq => {
     return Testing.parse(input) as Semantic.types.Eq;
 };
 
-const simplify = (
-    node: Semantic.types.Eq,
-    ident: Semantic.types.Identifier,
-): Step => {
-    const result = simplifyBothSides(node, ident);
+const simplify = (node: Semantic.types.Eq): Step => {
+    const result = simplifyBothSides(node);
     if (!result) {
         throw new Error("no step returned");
     }
@@ -24,7 +21,7 @@ describe("simplify both sides", () => {
     test("2x + 5 - 5 = 10 - 5", () => {
         const before = parseEq("2x + 5 - 5 = 10 - 5");
 
-        const step = simplify(before, Semantic.builders.identifier("x"));
+        const step = simplify(before);
 
         expect(Testing.print(step.after)).toEqual("2x = 5");
     });

--- a/packages/solver/src/solve/transforms/div-both-sides.ts
+++ b/packages/solver/src/solve/transforms/div-both-sides.ts
@@ -2,13 +2,17 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {getCoeff, isTermOfIdent} from "../util";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
-export const divBothSides: Transform = (before, ident) => {
+export function divBothSides(
+    before: Semantic.types.Eq,
+    ident: Semantic.types.Identifier,
+): Step<Semantic.types.Eq> | void {
     const [left, right] = before.args as readonly Semantic.types.NumericNode[];
 
+    // Prevent an infinite loop between these two transforms
     if (left.source === "mulBothSides" || right.source === "mulBothSides") {
         return undefined;
     }
@@ -33,11 +37,11 @@ export const divBothSides: Transform = (before, ident) => {
     if (leftIdentTerms.length === 1 && leftNonIdentTerms.length === 0) {
         const coeff = getCoeff(leftIdentTerms[0]);
         if (coeff.type === NodeType.Div) {
-            return undefined;
+            return;
         }
 
         if (Semantic.util.deepEquals(coeff, Semantic.builders.number("1"))) {
-            return undefined;
+            return;
         }
 
         // TODO: add a check to make sure this is true
@@ -93,6 +97,4 @@ export const divBothSides: Transform = (before, ident) => {
             substeps: [],
         };
     }
-
-    return undefined;
-};
+}

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -2,7 +2,7 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {isTermOfIdent, flipSign, convertSubTermToNeg} from "../util";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
@@ -19,7 +19,10 @@ const {NodeType} = Semantic;
  *   - the case where we're moving both matching and non-matching terms in
  *     opposite directions
  */
-export const moveTermsToOneSide: Transform = (before, ident) => {
+export function moveTermsToOneSide(
+    before: Semantic.types.Eq,
+    ident: Semantic.types.Identifier,
+): Step<Semantic.types.Eq> | void {
     const [left, right] = before.args as readonly Semantic.types.NumericNode[];
 
     const leftTerms = Semantic.util.getTerms(left);
@@ -133,4 +136,4 @@ export const moveTermsToOneSide: Transform = (before, ident) => {
     }
 
     return undefined;
-};
+}

--- a/packages/solver/src/solve/transforms/mul-both-sides.ts
+++ b/packages/solver/src/solve/transforms/mul-both-sides.ts
@@ -2,15 +2,18 @@ import * as Semantic from "@math-blocks/semantic";
 
 import {isTermOfIdent} from "../util";
 
-import type {Transform} from "../types";
+import type {Step} from "../../types";
 
 const {NodeType} = Semantic;
 
-export const mulBothSides: Transform = (before, ident) => {
+export function mulBothSides(
+    before: Semantic.types.Eq,
+    ident: Semantic.types.Identifier,
+): Step<Semantic.types.Eq> | void {
     const [left, right] = before.args as readonly Semantic.types.NumericNode[];
 
     if (left.source === "divBothSides" || right.source === "divBothSides") {
-        return undefined;
+        return;
     }
 
     const leftTerms = Semantic.util.getTerms(left);
@@ -57,5 +60,5 @@ export const mulBothSides: Transform = (before, ident) => {
         }
     }
 
-    return undefined;
-};
+    return;
+}

--- a/packages/solver/src/solve/transforms/simplify-both-sides.ts
+++ b/packages/solver/src/solve/transforms/simplify-both-sides.ts
@@ -1,13 +1,12 @@
 import * as Semantic from "@math-blocks/semantic";
 
 import {simplify} from "../../simplify/simplify";
+import type {Step} from "../../types";
 
-import type {Transform} from "../types";
-
-export const simplifyBothSides: Transform = (before, ident) => {
+export function simplifyBothSides(before: Semantic.types.Eq): Step | void {
     const args = before.args as TwoOrMore<Semantic.types.NumericNode>;
-    const left = simplify(args[0], []);
-    const right = simplify(args[1], []);
+    const left = simplify(args[0]);
+    const right = simplify(args[1]);
 
     if (left && right) {
         // TODO: parameterize Step based on the return type of that step
@@ -49,5 +48,5 @@ export const simplifyBothSides: Transform = (before, ident) => {
         };
     }
 
-    return undefined;
-};
+    return;
+}

--- a/packages/solver/src/solve/types.ts
+++ b/packages/solver/src/solve/types.ts
@@ -1,7 +1,0 @@
-import * as Semantic from "@math-blocks/semantic";
-import {Step} from "../types";
-
-export type Transform = (
-    node: Semantic.types.Eq,
-    ident: Semantic.types.Identifier,
-) => Step | undefined;

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -1,8 +1,8 @@
 import * as Semantic from "@math-blocks/semantic";
 
-export type Step = {
+export type Step<T extends Semantic.types.Node = Semantic.types.Node> = {
     readonly message: string;
-    readonly before: Semantic.types.Node;
-    readonly after: Semantic.types.Node;
-    readonly substeps: readonly Step[];
+    readonly before: T;
+    readonly after: T;
+    readonly substeps: readonly Step<T>[];
 };

--- a/packages/tutor/src/help/get-hint.ts
+++ b/packages/tutor/src/help/get-hint.ts
@@ -16,8 +16,8 @@ export const getHint = (
             // math statement that the user has entered.
             return solution.substeps[0];
         }
-    } else {
-        const solution = Solver.simplify(ast, []);
+    } else if (Semantic.util.isNumeric(ast)) {
+        const solution = Solver.simplify(ast);
 
         if (solution && solution.substeps.length > 0) {
             // Grab the first step of the solution and apply it to the previous


### PR DESCRIPTION
Dropping the `Transform` types results in more explicit typing of functions.  I also decided to use `function` instead of `const` arrow functions because I think it's a little easier to parse by humans.  It's an experiment, we'll see if it's worth doing this elsewhere or not.