### PR TITLE
Move one term at a time

### DIFF
--- a/demo/src/solver/substeps.tsx
+++ b/demo/src/solver/substeps.tsx
@@ -31,13 +31,17 @@ const Substeps: React.FunctionComponent<Props> = ({prefix, start, step}) => {
         // colorMap: props.colorMap,
     };
 
+    const beforeRow = Editor.print(step.before);
+    const beforeScene = Typesetter.typeset(beforeRow, context);
+
     return (
         <div style={{display: "flex", flexDirection: "column"}}>
+            <MathRenderer scene={beforeScene} style={{marginBottom: 32}} />
             {step.substeps.map((substep, index) => {
                 const before = current;
 
                 const after = Solver.applyStep(before, substep);
-                const afterRow = Editor.print(after);
+                const afterRow = Editor.print(substep.after);
                 const afterScene = Typesetter.typeset(afterRow, context);
 
                 current = after;
@@ -59,12 +63,12 @@ const Substeps: React.FunctionComponent<Props> = ({prefix, start, step}) => {
                                 />
                             </div>
                         )}
-                        {substep.substeps.length === 0 && (
+                        {
                             <MathRenderer
                                 scene={afterScene}
                                 style={{marginBottom: 32}}
                             />
-                        )}
+                        }
                     </React.Fragment>
                 );
             })}

--- a/packages/solver/src/simplify/__tests__/simplify.test.ts
+++ b/packages/solver/src/simplify/__tests__/simplify.test.ts
@@ -1035,4 +1035,18 @@ describe("simplify", () => {
             expect(Testing.print(step.after)).toEqual("-a");
         });
     });
+
+    describe("multiplication by zero", () => {
+        test("(a)(0)", () => {
+            const ast = Testing.parse("(a)(0)");
+
+            const step = simplify(ast);
+
+            expect(step.message).toEqual("simplify expression");
+            expect(step.substeps.map((substep) => substep.message)).toEqual([
+                "multiplying by zero is equivalent to zero",
+            ]);
+            expect(Testing.print(step.after)).toEqual("0");
+        });
+    });
 });

--- a/packages/solver/src/simplify/simplify.ts
+++ b/packages/solver/src/simplify/simplify.ts
@@ -13,6 +13,7 @@ import {reduceFraction} from "./transforms/reduce-fraction";
 import {mulFraction} from "./transforms/mul-fraction";
 import {mulToPow} from "./transforms/mul-to-pow";
 import {simplifyMul} from "./transforms/simplify-mul";
+import {mulByZeroIsZero} from "./transforms/mul-by-zero-is-zero";
 
 export function simplify(
     node: Semantic.types.NumericNode,
@@ -21,6 +22,7 @@ export function simplify(
         dropAddIdentity,
 
         simplifyMul, // We do this first so that we don't repeat what it does in other transforms
+        mulByZeroIsZero,
 
         distribute,
         distributeDiv,

--- a/packages/solver/src/simplify/transforms/__tests__/collect-like-terms.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/collect-like-terms.test.ts
@@ -444,7 +444,7 @@ describe("collect like terms", () => {
 
             expect(step.message).toEqual("collect like terms");
             // TODO: have the output use -x instead of -1x
-            expect(Testing.print(step.after)).toEqual("2 - x");
+            expect(Testing.print(step.after)).toEqual("2 - 1x");
         });
 
         test("3 - x - 1 -> -x + 2", () => {

--- a/packages/solver/src/simplify/transforms/mul-by-zero-is-zero.ts
+++ b/packages/solver/src/simplify/transforms/mul-by-zero-is-zero.ts
@@ -1,0 +1,29 @@
+import * as Semantic from "@math-blocks/semantic";
+
+import type {Step} from "../../types";
+
+const {NodeType} = Semantic;
+
+const isZero = (node: Semantic.types.Node): boolean => {
+    if (node.type === NodeType.Number && node.value === "0") {
+        return true;
+    } else if (node.type === NodeType.Neg) {
+        return isZero(node.arg);
+    } else {
+        return false;
+    }
+};
+
+export function mulByZeroIsZero(
+    node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
+    const factors = Semantic.util.getFactors(node);
+    if (factors.length > 1 && factors.some(isZero)) {
+        return {
+            message: "multiplying by zero is equivalent to zero",
+            before: node,
+            after: Semantic.builders.number("0"),
+            substeps: [],
+        };
+    }
+}

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -333,11 +333,10 @@ describe("solve", () => {
 
             const result = solve(ast, Semantic.builders.identifier("x"));
 
-            expect(Testing.print(result.after)).toEqual("x = 3 / 2");
+            expect(Testing.print(result.after)).toEqual("3 / 2 = x");
             expect(result.substeps.map((step) => step.message)).toEqual([
-                "move terms to one side",
                 "divide both sides",
-                "simplify both sides",
+                "simplify the right hand side",
             ]);
         });
 
@@ -358,7 +357,7 @@ describe("solve", () => {
             });
         });
 
-        test.skip("1 = x / 4", () => {
+        test("1 = x / 4", () => {
             const ast = parseEq("1 = x / 4");
 
             const result = solve(ast, Semantic.builders.identifier("x"));

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -33,7 +33,6 @@ describe("solve", () => {
 
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify the left hand side",
             ]);
@@ -42,7 +41,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "2x + 5 = 10",
-                    "2x + 5 - 5 = 10 - 5",
                     "2x = 5",
                     "2x / 2 = 5 / 2",
                     "x = 5 / 2",
@@ -115,7 +113,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -7");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify the left hand side",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -140,7 +137,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -7");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify the left hand side",
             ]);
         });
 
@@ -152,7 +148,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -2");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -166,7 +161,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = 3");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -175,7 +169,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "2x + 1 = 7",
-                    "2x + 1 - 1 = 7 - 1",
                     "2x = 6",
                     "2x / 2 = 6 / 2",
                     "x = 3",
@@ -188,10 +181,9 @@ describe("solve", () => {
 
             const result = solve(ast, Semantic.builders.identifier("x"));
 
-            expect(Testing.print(result.after)).toEqual("3 = x");
+            expect(Testing.print(result.after)).toEqual("x = 3");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify the left hand side",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -200,10 +192,9 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "7 = 2x + 1",
-                    "7 - 1 = 2x",
-                    "6 = 2x",
-                    "6 / 2 = 2x / 2",
-                    "3 = x",
+                    "-2x = -6",
+                    "-2x / -2 = -6 / -2",
+                    "x = 3",
                 ],
             });
         });
@@ -216,7 +207,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = 4 / 3");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify the left hand side",
             ]);
@@ -225,7 +215,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "x + 1 = -2x + 5",
-                    "x + 2x = 5 - 1",
                     "3x = 4",
                     "3x / 3 = 4 / 3",
                     "x = 4 / 3",
@@ -241,7 +230,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = 4");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
             ]);
         });
 
@@ -253,7 +241,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -3");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -267,7 +254,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -(3 / 2)");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -276,7 +262,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "2 - 2x = 5",
-                    "-2x + 2 - 2 = 5 - 2",
                     "-2x = 3",
                     "-2x / -2 = 3 / -2",
                     "x = -(3 / 2)",
@@ -292,7 +277,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = 3 / 2");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify the left hand side",
             ]);
@@ -301,7 +285,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "2 - x = 5 - 3x",
-                    "-x + 3x = 5 - 2", // TODO: this step should use implicit multiplication
                     "2x = 3",
                     "2x / 2 = 3 / 2",
                     "x = 3 / 2",
@@ -330,7 +313,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = 0");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "divide both sides",
                 "simplify both sides",
             ]);
@@ -339,7 +321,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "2x + 3 = 3",
-                    "2x + 3 - 3 = 3 - 3",
                     "2x = 0",
                     "2x / 2 = 0 / 2",
                     "x = 0",
@@ -352,10 +333,11 @@ describe("solve", () => {
 
             const result = solve(ast, Semantic.builders.identifier("x"));
 
-            expect(Testing.print(result.after)).toEqual("3 / 2 = x");
+            expect(Testing.print(result.after)).toEqual("x = 3 / 2");
             expect(result.substeps.map((step) => step.message)).toEqual([
+                "move terms to one side",
                 "divide both sides",
-                "simplify the right hand side",
+                "simplify both sides",
             ]);
         });
 
@@ -376,7 +358,7 @@ describe("solve", () => {
             });
         });
 
-        test("1 = x / 4", () => {
+        test.skip("1 = x / 4", () => {
             const ast = parseEq("1 = x / 4");
 
             const result = solve(ast, Semantic.builders.identifier("x"));
@@ -420,7 +402,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -6");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify the left hand side",
                 "multiply both sides",
                 "simplify both sides",
             ]);
@@ -434,7 +415,6 @@ describe("solve", () => {
             expect(Testing.print(result.after)).toEqual("x = -1");
             expect(result.substeps.map((step) => step.message)).toEqual([
                 "move terms to one side",
-                "simplify both sides",
                 "multiply both sides",
                 "simplify both sides",
             ]);
@@ -443,7 +423,6 @@ describe("solve", () => {
                 steps: result.substeps,
                 expressions: [
                     "x / 2 + 1 / 2 = x / 3 + 1 / 3",
-                    "x / 2 - x / 3 = 1 / 3 - 1 / 2",
                     "x / 6 = -(1 / 6)",
                     "x / 6 * 6 = -(1 / 6) * 6",
                     "x = -1",

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -118,7 +118,6 @@ export function moveTermsToOneSide(
             before = newAfter;
             /* istanbul ignore */
         } else {
-            //
             left = newLeft;
             right = newRight;
             before = after;

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -29,6 +29,19 @@ export function moveTermsToOneSide(
     const leftTerms = Semantic.util.getTerms(left);
     const rightTerms = Semantic.util.getTerms(right);
 
+    const leftIdentTerms = leftTerms.filter((term) =>
+        isTermOfIdent(term, ident),
+    );
+
+    const rightNonIdentTerms = rightTerms.filter(
+        (term) => !isTermOfIdent(term, ident),
+    );
+
+    if (leftIdentTerms.length === 0 && rightNonIdentTerms.length === 0) {
+        // Terms have already been separated.
+        return undefined;
+    }
+
     const rightIdentTerms = rightTerms.filter((term) =>
         isTermOfIdent(term, ident),
     );
@@ -38,6 +51,7 @@ export function moveTermsToOneSide(
     );
 
     if (rightIdentTerms.length === 0 && leftNonIdentTerms.length === 0) {
+        // Terms have already been separated.
         return undefined;
     }
 

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -1,10 +1,9 @@
 import * as Semantic from "@math-blocks/semantic";
 
-import {isTermOfIdent, flipSign, convertSubTermToNeg} from "../util";
+import {isTermOfIdent, flipSign} from "../util";
+import {simplifyBothSides} from "./simplify-both-sides";
 
 import type {Step} from "../../types";
-
-const {NodeType} = Semantic;
 
 /**
  * Moves all terms matching `ident` to one side and those that don't to the
@@ -23,14 +22,13 @@ export function moveTermsToOneSide(
     before: Semantic.types.Eq,
     ident: Semantic.types.Identifier,
 ): Step<Semantic.types.Eq> | void {
-    const [left, right] = before.args as readonly Semantic.types.NumericNode[];
+    const originalBefore = before;
+
+    let [left, right] = before.args as readonly Semantic.types.NumericNode[];
 
     const leftTerms = Semantic.util.getTerms(left);
     const rightTerms = Semantic.util.getTerms(right);
 
-    const leftIdentTerms = leftTerms.filter((term) =>
-        isTermOfIdent(term, ident),
-    );
     const rightIdentTerms = rightTerms.filter((term) =>
         isTermOfIdent(term, ident),
     );
@@ -38,102 +36,97 @@ export function moveTermsToOneSide(
     const leftNonIdentTerms = leftTerms.filter(
         (term) => !isTermOfIdent(term, ident),
     );
-    const rightNonIdentTerms = rightTerms.filter(
-        (term) => !isTermOfIdent(term, ident),
-    );
 
-    if (leftIdentTerms.length > 1 || rightIdentTerms.length > 1) {
-        // One (or both) of the sides hasn't been simplified
+    if (rightIdentTerms.length === 0 && leftNonIdentTerms.length === 0) {
         return undefined;
     }
 
-    if (leftIdentTerms.length === 1 && rightIdentTerms.length === 1) {
-        // There's a term with the identifier we're trying to solve for on both sides
+    let newLeft;
+    let newRight;
 
-        // TODO: create two sub-steps for each of these moves
-        // Move identifiers to the left
-        const left =
-            leftIdentTerms[0].type === NodeType.Neg
-                ? Semantic.builders.add([
-                      convertSubTermToNeg(leftIdentTerms[0]),
-                      ...leftIdentTerms.slice(1),
-                      ...rightIdentTerms.map(flipSign),
-                  ])
-                : Semantic.builders.add([
-                      ...leftIdentTerms,
-                      ...rightIdentTerms.map(flipSign),
-                  ]);
+    const substeps: Step<Semantic.types.Eq<Semantic.types.Node>>[] = [];
 
-        // Move non-identifiers to the right
-        const right = Semantic.builders.add([
-            ...rightNonIdentTerms,
-            ...leftNonIdentTerms.map(flipSign),
+    for (const leftNonIdentTerm of leftNonIdentTerms) {
+        newLeft = Semantic.builders.add([
+            ...Semantic.util.getTerms(left),
+            flipSign(leftNonIdentTerm),
         ]);
-
-        const after = Semantic.builders.eq([left, right]);
-        return {
-            message: "move terms to one side",
-            before,
-            after,
+        newRight = Semantic.builders.add([
+            ...Semantic.util.getTerms(right),
+            flipSign(leftNonIdentTerm),
+        ]);
+        const after = Semantic.builders.eq([newLeft, newRight]);
+        substeps.push({
+            message: "subtract term from both sides",
+            before: before,
+            after: after,
             substeps: [],
-        };
-    }
-
-    if (
-        leftIdentTerms.length === 1 &&
-        rightIdentTerms.length === 0 &&
-        leftNonIdentTerms.length > 0
-    ) {
-        let left = Semantic.builders.add([
-            leftIdentTerms[0],
-            ...leftNonIdentTerms,
-            ...leftNonIdentTerms.map(flipSign),
-        ]);
-
-        // TODO: run this check on leftIdentTerms[0]
-        if (left.type === NodeType.Neg) {
-            left = convertSubTermToNeg(left);
+        });
+        const step = simplifyBothSides(after) as void | Step<
+            Semantic.types.Eq<Semantic.types.NumericNode>
+        >;
+        if (step) {
+            before = after;
+            const newAfter = step.after;
+            substeps.push({
+                message: "simplify both sides",
+                before: before,
+                after: newAfter,
+                substeps: step.substeps,
+            });
+            left = newAfter.args[0];
+            right = newAfter.args[1];
+            before = newAfter;
+        } else {
+            left = newLeft;
+            right = newRight;
+            before = after;
         }
-
-        // Move non-identifiers to the right.
-        const right = Semantic.builders.add([
-            ...rightNonIdentTerms,
-            ...leftNonIdentTerms.map(flipSign),
-        ]);
-
-        const after = Semantic.builders.eq([left, right]);
-        return {
-            message: "move terms to one side",
-            before,
-            after,
-            substeps: [],
-        };
     }
 
-    if (
-        leftIdentTerms.length === 0 &&
-        rightIdentTerms.length === 1 &&
-        rightNonIdentTerms.length > 0
-    ) {
-        // Move non-identifiers to the left.
-        const left = Semantic.builders.add([
-            ...leftNonIdentTerms,
-            ...rightNonIdentTerms.map(flipSign),
+    for (const rightIdentTerm of rightIdentTerms) {
+        newLeft = Semantic.builders.add([
+            ...Semantic.util.getTerms(left),
+            flipSign(rightIdentTerm),
         ]);
-
-        let right = rightIdentTerms[0];
-        if (right.type === NodeType.Neg) {
-            right = convertSubTermToNeg(right);
+        newRight = Semantic.builders.add([
+            ...Semantic.util.getTerms(right),
+            flipSign(rightIdentTerm),
+        ]);
+        const after = Semantic.builders.eq([newLeft, newRight]);
+        substeps.push({
+            message: "subtract term from both sides",
+            before: before,
+            after: after,
+            substeps: [],
+        });
+        const step = simplifyBothSides(after) as void | Step<
+            Semantic.types.Eq<Semantic.types.NumericNode>
+        >;
+        if (step) {
+            before = after;
+            const newAfter = step.after;
+            substeps.push({
+                message: "simplify both sides",
+                before: before,
+                after: newAfter,
+                substeps: step.substeps,
+            });
+            left = newAfter.args[0];
+            right = newAfter.args[1];
+            before = newAfter;
+        } else {
+            left = newLeft;
+            right = newRight;
+            before = after;
         }
-
-        const after = Semantic.builders.eq([left, right]);
-        return {
-            message: "move terms to one side",
-            before,
-            after,
-            substeps: [],
-        };
     }
 
-    return undefined;
+    // TODO: determine if there were any changes between before and after
+    return {
+        message: "move terms to one side",
+        before: originalBefore,
+        after: substeps[substeps.length - 1].after,
+        substeps: substeps,
+    };
 }

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -77,6 +77,7 @@ export function moveTermsToOneSide(
             left = newAfter.args[0];
             right = newAfter.args[1];
             before = newAfter;
+            /* istanbul ignore */
         } else {
             left = newLeft;
             right = newRight;
@@ -115,7 +116,9 @@ export function moveTermsToOneSide(
             left = newAfter.args[0];
             right = newAfter.args[1];
             before = newAfter;
+            /* istanbul ignore */
         } else {
+            //
             left = newLeft;
             right = newRight;
             before = after;

--- a/packages/tutor/src/help/__tests__/show-me-how.test.ts
+++ b/packages/tutor/src/help/__tests__/show-me-how.test.ts
@@ -18,9 +18,7 @@ describe("#showMeHow", () => {
 
         const result = showMeHow(problem);
 
-        expect(Testing.print(result)).toMatchInlineSnapshot(
-            `"2x + 5 - 5 = 10 - 5"`,
-        );
+        expect(Testing.print(result)).toMatchInlineSnapshot(`"2x = 5"`);
     });
 
     it("should work with expressions", () => {


### PR DESCRIPTION
This PR also changes how steps are displayed by the solver demo.  Now we who before/after for each step it's scoped to the expression that's being modified, i.e. if we're simplifying the left side of an equation we only show the left side instead of the whole equation.