### PR TITLE
Make some of the more future facing packages private

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,75 +9,11 @@
 
 A set of tools, components, and libraries for building interactive math applications.
 
-## Main Packages
+## Packages
 
-### [@math-blocks/grader](packages/grader/README.md)
-
-Provides feedback on a single step that user might show when solving a math
-problem.  The feedback can be either "correct" or "incorrect".  In some situations,
-when the step is "incorrect", the solver may also provide additional feedback
-such as why the step is incorrect.  In a subset of those cases, it can also fix
-the mistake for the user.
-
-### [@math-blocks/react](packages/react/README.md)
-
-A set of React components for rendering and editing math expressions.
-
-- `MathRenderer`
-- `ZipperEditor`
-
-### [@math-blocks/solver](packages/solver/README.md)
-
-Is able to solve basic equations and simplify basic expressions using steps that
-are similar to what a human would do.  This can then be used by intelligent tutors
-to provide suggestions to users when they don't know what step to take next or
-provide a complete worked solution.
-
-## Supporting Packages
-
-### [@math-blocks/core](package/core/README.md)
-
-A collection of utility functions and types used in most of the other packages.
-
-- `getId`: function that returns unique, ascending, integer identifiers
-- `UnreachableCaseError`: used for exhaustiveness checks in `switch` statements.
-
-### [@math-blocks/editor](packages/editor/README.md)
-
-Provides a bunch of related parts for building interactive math editors.
-
-- `reducer`: updates an editor tree based on various editing actions.
-- `parse`: converts an editor tree into a semantic tree.
-- `print`: converts a semantic tree to an editor tree.
-- `builders`: builders for each of the editor node types
-- `utils`: other helpers
-
-### [@math-blocks/opentype](packages/opentype/README.md)
-
-Library for parsing OpenType font files that contain a MATH table.
-
-### [@math-blocks/parser](packages/parser/README.md)
-
-Defines a `parserFactory` function is used by `@math-blocks/testing` and
-`@math-blocks/editor-parser` to define Pratt (top-down precedence) parsers.  It
-also exports common `types` used by the parsers and a set of `builders` for
-constructing nodes in the output of each parser.
-
-### [@math-blocks/semantic](packages/semantic/README.md)
-
-Provides `types`, `builders`, and `utils` for working with semantic nodes.  The
-`types` are almost the same as those from `@math-block/parser`, but are
-more constrained to avoid invalid semantic trees.
-
-### [@math-blocks/testing](packages/typesetter/README.md)
-
-Implements its own text-only parser which is used for writing tests.  It's more
-convenient then having to create editor trees for each test.
-
-### [@math-blocks/typesetter](packages/typesetter/README.md)
-
-The typesetter converts a semantic tree to a layout tree and finally a scene
-graph.  The layout tree comprizes typesetting primitives while the scene graph
-is more closely maps to SVG or HTML Canvas primitives.  The reason for doing
-this is multiple passes is that it makes converting from one representation to
-another easier to understand.
+- [@math-blocks/core](package/core/README.md) - A collection of utility functions and types used in most of the other packages.
+- [@math-blocks/editor](packages/editor/README.md) - Provides a bunch of related parts for building interactive math editors.
+- [@math-blocks/opentype](packages/opentype/README.md) - Library for parsing OpenType font files that contain a MATH table.
+- [@math-blocks/parser](packages/parser/README.md) - Provides a `parserFactory` function for creating TDOP parsers and related utils.
+- [@math-blocks/react](packages/react/README.md) - A set of React components for rendering and editing math expressions.
+- [@math-blocks/typesetter](packages/typesetter/README.md) – Converts editor tree to a renderer independent scene graph.

--- a/packages/opentype/README.md
+++ b/packages/opentype/README.md
@@ -1,3 +1,3 @@
 # @math-blocks/opentype
 
-TODO
+Library for parsing OpenType font files that contain a MATH table.

--- a/packages/semantic/package.json
+++ b/packages/semantic/package.json
@@ -2,12 +2,10 @@
     "name": "@math-blocks/semantic",
     "version": "0.0.5",
     "main": "./dist/index.js",
+    "private": true,
     "files": [
         "dist"
     ],
-    "publishConfig": {
-        "access": "public"
-    },
     "dependencies": {
         "@math-blocks/core": "^0.0.5",
         "fraction.js": "^4.0.12"

--- a/packages/solver/package.json
+++ b/packages/solver/package.json
@@ -2,12 +2,10 @@
     "name": "@math-blocks/solver",
     "version": "0.0.5",
     "main": "./dist/index.js",
+    "private": true,
     "files": [
         "dist"
     ],
-    "publishConfig": {
-        "access": "public"
-    },
     "dependencies": {
         "@math-blocks/core": "^0.0.5",
         "@math-blocks/semantic": "^0.0.5"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -2,12 +2,7 @@
     "name": "@math-blocks/testing",
     "version": "0.0.5",
     "main": "./dist/index.js",
-    "files": [
-        "dist"
-    ],
-    "publishConfig": {
-        "access": "public"
-    },
+    "private": true,
     "dependencies": {
         "@math-blocks/core": "^0.0.5",
         "@math-blocks/parser": "^0.0.5",

--- a/packages/tutor/package.json
+++ b/packages/tutor/package.json
@@ -2,12 +2,10 @@
     "name": "@math-blocks/tutor",
     "version": "0.0.5",
     "main": "./dist/index.js",
+    "private": true,
     "files": [
         "dist"
     ],
-    "publishConfig": {
-        "access": "public"
-    },
     "dependencies": {
         "@math-blocks/core": "^0.0.5",
         "@math-blocks/editor": "^0.0.5",


### PR DESCRIPTION
This PR also makes `@math-blocks/testing` private since it only appears a dev dependency.  I've also updated the PR to only list public packages.