### PR TITLE
Update 'Step' type to be a union of object types

### DIFF
--- a/packages/solver/src/simplify/__tests__/simplify.test.ts
+++ b/packages/solver/src/simplify/__tests__/simplify.test.ts
@@ -442,12 +442,12 @@ describe('simplify', () => {
       expect(
         step.substeps[0].substeps.map((substep) => substep.message),
       ).toEqual([
-        'negation is the same as multipyling by one',
+        'negation is the same as multiplying by negative one',
         'multiply each term',
         'multiplying a negative by a positive is negative',
         'multiplying a negative by a positive is negative',
-        'adding the negative is the same as subtraction',
-        'adding the negative is the same as subtraction',
+        'adding the inverse is the same as subtraction',
+        'adding the inverse is the same as subtraction',
       ]);
       expect(Testing.print(step.substeps[0].substeps[0].before)).toEqual(
         '-(x + 1)',
@@ -485,11 +485,11 @@ describe('simplify', () => {
       expect(
         step.substeps[2].substeps.map((substep) => substep.message),
       ).toEqual([
-        'subtraction is the same as adding the negative',
+        'subtraction is the same as adding the inverse',
         'multiply each term',
         'multiply monomials',
         'multiplying a negative by a positive is negative',
-        'adding the negative is the same as subtraction',
+        'adding the inverse is the same as subtraction',
       ]);
       expect(Testing.print(step.after)).toEqual('9x - 6');
     });
@@ -520,7 +520,7 @@ describe('simplify', () => {
       expect(
         step.substeps[0].substeps.map((substep) => substep.message),
       ).toEqual([
-        'subtraction is the same as adding the negative',
+        'subtraction is the same as adding the inverse',
         'multiply each term',
         'multiplying a negative by a positive is negative',
         'multiplying two negatives is a positive',
@@ -613,10 +613,10 @@ describe('simplify', () => {
       expect(
         step.substeps[0].substeps.map((substep) => substep.message),
       ).toEqual([
-        'subtraction is the same as adding the negative',
+        'subtraction is the same as adding the inverse',
         'multiply each term',
         'multiplying a negative by a positive is negative',
-        'adding the negative is the same as subtraction',
+        'adding the inverse is the same as subtraction',
       ]);
     });
 
@@ -986,7 +986,7 @@ describe('simplify', () => {
 
       expect(step.message).toEqual('simplify expression');
       expect(step.substeps.map((substep) => substep.message)).toEqual([
-        'drop adding zero (additive identity)',
+        'drop adding zero',
       ]);
       expect(Testing.print(step.after)).toEqual('a');
     });
@@ -998,7 +998,7 @@ describe('simplify', () => {
 
       expect(step.message).toEqual('simplify expression');
       expect(step.substeps.map((substep) => substep.message)).toEqual([
-        'drop adding zero (additive identity)',
+        'drop adding zero',
       ]);
       expect(Testing.print(step.after)).toEqual('a + b');
     });
@@ -1010,7 +1010,7 @@ describe('simplify', () => {
 
       expect(step.message).toEqual('simplify expression');
       expect(step.substeps.map((substep) => substep.message)).toEqual([
-        'drop adding zero (additive identity)',
+        'drop adding zero',
       ]);
       expect(Testing.print(step.after)).toEqual('a');
     });
@@ -1022,7 +1022,7 @@ describe('simplify', () => {
 
       expect(step.message).toEqual('simplify expression');
       expect(step.substeps.map((substep) => substep.message)).toEqual([
-        'drop adding zero (additive identity)',
+        'drop adding zero',
       ]);
       expect(Testing.print(step.after)).toEqual('-a');
     });

--- a/packages/solver/src/simplify/transforms/__tests__/distribute.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/distribute.test.ts
@@ -106,11 +106,11 @@ describe('distribution', () => {
     expect(Testing.print(applySteps(ast, step.substeps))).toEqual('3x - 3');
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'subtraction is the same as adding the negative',
+      'subtraction is the same as adding the inverse',
       'multiply each term',
       'multiply monomials',
       'multiplying a negative by a positive is negative',
-      'adding the negative is the same as subtraction',
+      'adding the inverse is the same as subtraction',
     ]);
     expect(step).toHaveSubstepsLike([
       ['-1', '-1'], // subtraction -> add inverse
@@ -184,7 +184,7 @@ describe('distribution', () => {
     expect(Testing.print(applySteps(ast, step.substeps))).toEqual('-2x + 6');
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'subtraction is the same as adding the negative',
+      'subtraction is the same as adding the inverse',
       'multiply each term',
       'multiplying a negative by a positive is negative',
       'multiplying two negatives is a positive',
@@ -228,12 +228,12 @@ describe('distribution', () => {
     expect(Testing.print(applySteps(ast, step.substeps))).toEqual('3 - x - 1');
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'negation is the same as multipyling by one',
+      'negation is the same as multiplying by negative one',
       'multiply each term',
       'multiplying a negative by a positive is negative',
       'multiplying a negative by a positive is negative',
-      'adding the negative is the same as subtraction',
-      'adding the negative is the same as subtraction',
+      'adding the inverse is the same as subtraction',
+      'adding the inverse is the same as subtraction',
     ]);
 
     expect(step).toHaveSubstepsLike([
@@ -271,11 +271,11 @@ describe('distribution', () => {
     );
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'subtraction is the same as adding the negative',
+      'subtraction is the same as adding the inverse',
       'multiply each term',
       'multiply monomials',
       'multiplying a negative by a positive is negative',
-      'adding the negative is the same as subtraction',
+      'adding the inverse is the same as subtraction',
     ]);
 
     expect(step).toHaveSubstepsLike([
@@ -311,7 +311,7 @@ describe('distribution', () => {
     );
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'subtraction is the same as adding the negative',
+      'subtraction is the same as adding the inverse',
       'multiply each term',
       'multiplying a negative by a positive is negative',
       'multiplying two negatives is a positive',
@@ -375,10 +375,10 @@ describe('distribution', () => {
     expect(Testing.print(applySteps(ast, step.substeps))).toEqual('xx - x');
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'subtraction is the same as adding the negative',
+      'subtraction is the same as adding the inverse',
       'multiply each term',
       'multiplying a negative by a positive is negative',
-      'adding the negative is the same as subtraction',
+      'adding the inverse is the same as subtraction',
     ]);
 
     expect(step).toHaveSubstepsLike([
@@ -410,12 +410,12 @@ describe('distribution', () => {
     expect(Testing.print(applySteps(ast, step.substeps))).toEqual('0 - 2x - 5');
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'negation is the same as multipyling by one',
+      'negation is the same as multiplying by negative one',
       'multiply each term',
       'multiplying a negative by a positive is negative',
       'multiplying a negative by a positive is negative',
-      'adding the negative is the same as subtraction',
-      'adding the negative is the same as subtraction',
+      'adding the inverse is the same as subtraction',
+      'adding the inverse is the same as subtraction',
     ]);
 
     expect(step).toHaveSubstepsLike([
@@ -453,11 +453,11 @@ describe('distribution', () => {
     expect(Testing.print(applySteps(ast, step.substeps))).toEqual('-2x - 5');
 
     expect(step.substeps.map((substep) => substep.message)).toEqual([
-      'negation is the same as multipyling by one',
+      'negation is the same as multiplying by negative one',
       'multiply each term',
       'multiplying a negative by a positive is negative',
       'multiplying a negative by a positive is negative',
-      'adding the negative is the same as subtraction',
+      'adding the inverse is the same as subtraction',
     ]);
 
     expect(step).toHaveSubstepsLike([

--- a/packages/solver/src/simplify/transforms/distribute.ts
+++ b/packages/solver/src/simplify/transforms/distribute.ts
@@ -19,7 +19,7 @@ const distSub = (
   ) as Semantic.types.Mul;
   // TODO: return new steps instead of mutating
   substeps.push({
-    message: 'negation is the same as multipyling by one',
+    message: 'negation is the same as multiplying by negative one',
     before: node,
     after: mulNegOne,
     substeps: [],
@@ -36,7 +36,7 @@ const subToNeg = (
     const after = Semantic.builders.neg(before.arg, false);
     // TODO: return new steps instead of mutating
     substeps.push({
-      message: 'subtraction is the same as adding the negative',
+      message: 'subtraction is the same as adding the inverse',
       before,
       after,
       substeps: [],
@@ -56,7 +56,7 @@ const negToSub = (
     const after = Semantic.builders.neg(before.arg, true);
     // TODO: return new steps instead of mutating
     substeps.push({
-      message: 'adding the negative is the same as subtraction',
+      message: 'adding the inverse is the same as subtraction',
       before,
       after,
       substeps: [],

--- a/packages/solver/src/simplify/transforms/drop-add-identity.ts
+++ b/packages/solver/src/simplify/transforms/drop-add-identity.ts
@@ -33,7 +33,7 @@ export function dropAddIdentity(
     return;
   }
   return {
-    message: 'drop adding zero (additive identity)',
+    message: 'drop adding zero',
     before: node,
     after: Semantic.builders.add(newTerms),
     substeps: [],

--- a/packages/solver/src/simplify/util.ts
+++ b/packages/solver/src/simplify/util.ts
@@ -100,7 +100,7 @@ export const simplifyMul = (
     return node;
   }
 
-  let message: string;
+  let message: Step['message'];
   if (a.type === NodeType.Neg && b.type === NodeType.Neg) {
     message = 'multiplying two negatives is a positive';
   } else if (resultIsNeg) {

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -18,6 +18,15 @@ const solve = (
   return result;
 };
 
+const printStep = (step: Step) => {
+  switch (step.message) {
+    case 'do the same operation to both sides':
+      return `${step.message}:${step.operation}:${Testing.print(step.value)}`;
+    default:
+      return step.message;
+  }
+};
+
 const parseEq = (input: string): Semantic.types.Eq => {
   return Testing.parse(input) as Semantic.types.Eq;
 };
@@ -31,9 +40,9 @@ describe('solve', () => {
 
       expect(Testing.print(result.after)).toEqual('x = 5 / 2');
 
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify the left hand side',
       ]);
 
@@ -51,9 +60,9 @@ describe('solve', () => {
 
       expect(Testing.print(result.after)).toEqual('x = 5 / 2');
 
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'simplify the left hand side',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify the left hand side',
       ]);
 
@@ -69,22 +78,22 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 3 / 5');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'simplify both sides',
-        'divide both sides',
+        'do the same operation to both sides:div:5',
         'simplify the left hand side',
       ]);
-      expect(result.substeps[0].substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps[0].substeps.map(printStep)).toEqual([
         'simplify the left hand side',
         'simplify the right hand side',
       ]);
-      expect(
-        result.substeps[0].substeps[0].substeps.map((step) => step.message),
-      ).toEqual(['collect like terms']);
-      expect(
-        result.substeps[0].substeps[1].substeps.map((step) => step.message),
-      ).toEqual(['evaluate addition']);
-      expect(result.substeps[2].substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps[0].substeps[0].substeps.map(printStep)).toEqual([
+        'collect like terms',
+      ]);
+      expect(result.substeps[0].substeps[1].substeps.map(printStep)).toEqual([
+        'evaluate addition',
+      ]);
+      expect(result.substeps[2].substeps.map(printStep)).toEqual([
         'reduce fraction',
       ]);
     });
@@ -95,9 +104,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -7');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:-1',
         'simplify both sides',
       ]);
     });
@@ -108,7 +117,7 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -7');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'simplify the left hand side',
       ]);
     });
@@ -119,7 +128,7 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -7');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
       ]);
     });
@@ -130,9 +139,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -2');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:-1',
         'simplify both sides',
       ]);
     });
@@ -143,9 +152,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 3');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify both sides',
       ]);
 
@@ -161,9 +170,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 3');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:-2',
         'simplify both sides',
       ]);
 
@@ -179,9 +188,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 4 / 3');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:3',
         'simplify the left hand side',
       ]);
 
@@ -202,7 +211,7 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 4');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
       ]);
     });
@@ -213,9 +222,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -3');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:-1',
         'simplify both sides',
       ]);
     });
@@ -226,9 +235,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -(3 / 2)');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:-2',
         'simplify both sides',
       ]);
 
@@ -249,9 +258,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 3 / 2');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify the left hand side',
       ]);
 
@@ -272,9 +281,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 3 / 2');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'simplify the left hand side',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify the left hand side',
       ]);
     });
@@ -285,9 +294,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 0');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify both sides',
       ]);
 
@@ -303,8 +312,8 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('3 / 2 = x');
-      expect(result.substeps.map((step) => step.message)).toEqual([
-        'divide both sides',
+      expect(result.substeps.map(printStep)).toEqual([
+        'do the same operation to both sides:div:2',
         'simplify the right hand side',
       ]);
     });
@@ -315,8 +324,8 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       // expect(Testing.print(result.after)).toEqual("x = 4");
-      expect(result.substeps.map((step) => step.message)).toEqual([
-        'multiply both sides',
+      expect(result.substeps.map(printStep)).toEqual([
+        'do the same operation to both sides:mul:4',
         'simplify both sides',
       ]);
 
@@ -332,8 +341,8 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('4 = x');
-      expect(result.substeps.map((step) => step.message)).toEqual([
-        'multiply both sides',
+      expect(result.substeps.map(printStep)).toEqual([
+        'do the same operation to both sides:mul:4',
         'simplify both sides',
       ]);
     });
@@ -344,10 +353,10 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = 3 / 2');
-      expect(result.substeps.map((step) => step.message)).toEqual([
-        'multiply both sides',
+      expect(result.substeps.map(printStep)).toEqual([
+        'do the same operation to both sides:mul:3',
         'simplify both sides',
-        'divide both sides',
+        'do the same operation to both sides:div:2',
         'simplify the left hand side',
       ]);
       expect(Testing.print(result.substeps[0].after)).toEqual(
@@ -364,9 +373,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -6');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'multiply both sides',
+        'do the same operation to both sides:mul:6',
         'simplify both sides',
       ]);
     });
@@ -377,9 +386,9 @@ describe('solve', () => {
       const result = solve(ast, Semantic.builders.identifier('x'));
 
       expect(Testing.print(result.after)).toEqual('x = -1');
-      expect(result.substeps.map((step) => step.message)).toEqual([
+      expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'multiply both sides',
+        'do the same operation to both sides:mul:6',
         'simplify both sides',
       ]);
 

--- a/packages/solver/src/solve/transforms/__tests__/div-both-sides.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/div-both-sides.test.ts
@@ -1,0 +1,54 @@
+import * as Semantic from '@math-blocks/semantic';
+import * as Testing from '@math-blocks/testing';
+
+import { divBothSides } from '../div-both-sides';
+
+import type { Step } from '../../../types';
+
+const parseEq = (input: string): Semantic.types.Eq => {
+  return Testing.parse(input) as Semantic.types.Eq;
+};
+
+const transform = (node: Semantic.types.Eq): Step => {
+  const ident = Semantic.builders.identifier('x');
+  const result = divBothSides(node, ident);
+  if (!result) {
+    throw new Error('no step returned');
+  }
+  return result;
+};
+
+describe('mulBothSides', () => {
+  it('should multiple both sides (variable on left)', () => {
+    const before = parseEq('2x = 5');
+    const step = transform(before);
+
+    if (step.message !== 'do the same operation to both sides') {
+      throw new Error(
+        "expected step.message to be 'do the same operation to both sides'",
+      );
+    }
+    expect(step.operation).toEqual('div');
+    expect(Testing.print(step.value)).toEqual('2');
+  });
+
+  it('should multiple both sides (variable on right)', () => {
+    const before = parseEq('5 = 2x');
+    const step = transform(before);
+
+    if (step.message !== 'do the same operation to both sides') {
+      throw new Error(
+        "expected step.message to be 'do the same operation to both sides'",
+      );
+    }
+    expect(step.operation).toEqual('div');
+    expect(Testing.print(step.value)).toEqual('2');
+  });
+
+  it('should multiple all terms', () => {
+    const before = parseEq('2x = a + b');
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('2x / 2 = (a + b) / 2');
+  });
+});

--- a/packages/solver/src/solve/transforms/__tests__/move-terms-to-one-side.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/move-terms-to-one-side.test.ts
@@ -1,0 +1,83 @@
+import * as Semantic from '@math-blocks/semantic';
+import * as Testing from '@math-blocks/testing';
+
+import { moveTermsToOneSide } from '../move-terms-to-one-side';
+
+import type { Step } from '../../../types';
+
+const parseEq = (input: string): Semantic.types.Eq => {
+  return Testing.parse(input) as Semantic.types.Eq;
+};
+
+const transform = (node: Semantic.types.Eq): Step => {
+  const ident = Semantic.builders.identifier('x');
+  const result = moveTermsToOneSide(node, ident);
+  if (!result) {
+    throw new Error('no step returned');
+  }
+  return result;
+};
+
+describe('move constants from left to right', () => {
+  test('2x + 5 = 10', () => {
+    const before = parseEq('2x + 5 = 10');
+
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('2x = 5');
+    const doSameOpSteps = step.substeps.filter(
+      (step) => step.message === 'do the same operation to both sides',
+    );
+    const operations = doSameOpSteps.map((step) => step.operation);
+    expect(operations).toEqual(['sub']);
+    const terms = doSameOpSteps.map((step) => Testing.print(step.value));
+    expect(terms).toEqual(['5']);
+  });
+
+  test('2x - 5 = 10', () => {
+    const before = parseEq('2x - 5 = 10');
+
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('2x = 15');
+    const doSameOpSteps = step.substeps.filter(
+      (step) => step.message === 'do the same operation to both sides',
+    );
+    const operations = doSameOpSteps.map((step) => step.operation);
+    expect(operations).toEqual(['add']);
+    const terms = doSameOpSteps.map((step) => Testing.print(step.value));
+    expect(terms).toEqual(['5']);
+  });
+
+  // TODO: Only move `+ 5` to the left side
+  test('10 = 2x + 5', () => {
+    const before = parseEq('10 = 2x + 5');
+
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('-2x = -5');
+    const doSameOpSteps = step.substeps.filter(
+      (step) => step.message === 'do the same operation to both sides',
+    );
+    const operations = doSameOpSteps.map((step) => step.operation);
+    expect(operations).toEqual(['sub', 'sub']);
+    const terms = doSameOpSteps.map((step) => Testing.print(step.value));
+    expect(terms).toEqual(['10', '2x']);
+  });
+
+  // TODO: Only move `- 5` to the left side
+  test('10 = 2x - 5', () => {
+    const before = parseEq('10 = 2x - 5');
+
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('-2x = -15');
+    const doSameOpSteps = step.substeps.filter(
+      (step) => step.message === 'do the same operation to both sides',
+    );
+    const operations = doSameOpSteps.map((step) => step.operation);
+    expect(operations).toEqual(['sub', 'sub']);
+    const terms = doSameOpSteps.map((step) => Testing.print(step.value));
+    expect(terms).toEqual(['10', '2x']);
+  });
+});

--- a/packages/solver/src/solve/transforms/__tests__/mul-both-sides.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/mul-both-sides.test.ts
@@ -1,0 +1,54 @@
+import * as Semantic from '@math-blocks/semantic';
+import * as Testing from '@math-blocks/testing';
+
+import { mulBothSides } from '../mul-both-sides';
+
+import type { Step } from '../../../types';
+
+const parseEq = (input: string): Semantic.types.Eq => {
+  return Testing.parse(input) as Semantic.types.Eq;
+};
+
+const transform = (node: Semantic.types.Eq): Step => {
+  const ident = Semantic.builders.identifier('x');
+  const result = mulBothSides(node, ident);
+  if (!result) {
+    throw new Error('no step returned');
+  }
+  return result;
+};
+
+describe('mulBothSides', () => {
+  it('should multiple both sides (variable on left)', () => {
+    const before = parseEq('x/2 = 5');
+    const step = transform(before);
+
+    if (step.message !== 'do the same operation to both sides') {
+      throw new Error(
+        "expected step.message to be 'do the same operation to both sides'",
+      );
+    }
+    expect(step.operation).toEqual('mul');
+    expect(Testing.print(step.value)).toEqual('2');
+  });
+
+  it('should multiple both sides (variable on right)', () => {
+    const before = parseEq('5 = x/2');
+    const step = transform(before);
+
+    if (step.message !== 'do the same operation to both sides') {
+      throw new Error(
+        "expected step.message to be 'do the same operation to both sides'",
+      );
+    }
+    expect(step.operation).toEqual('mul');
+    expect(Testing.print(step.value)).toEqual('2');
+  });
+
+  it('should multiple all terms', () => {
+    const before = parseEq('x / 2 = a + b');
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('x / 2 * 2 = (a + b) * 2');
+  });
+});

--- a/packages/solver/src/solve/transforms/div-both-sides.ts
+++ b/packages/solver/src/solve/transforms/div-both-sides.ts
@@ -57,10 +57,12 @@ export function divBothSides(
     );
 
     return {
-      message: 'divide both sides',
+      message: 'do the same operation to both sides',
       before,
       after,
       substeps: [],
+      operation: 'div',
+      value: coeff,
     };
   }
 
@@ -89,10 +91,12 @@ export function divBothSides(
     );
 
     return {
-      message: 'divide both sides',
+      message: 'do the same operation to both sides',
       before,
       after,
       substeps: [],
+      operation: 'div',
+      value: coeff,
     };
   }
 }

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -69,10 +69,16 @@ export function moveTermsToOneSide(
     ]);
     const after = Semantic.builders.eq([newLeft, newRight]);
     substeps.push({
-      message: 'subtract term from both sides',
+      message: 'do the same operation to both sides',
       before: before,
       after: after,
       substeps: [],
+      operation:
+        leftNonIdentTerm.type === Semantic.NodeType.Neg ? 'add' : 'sub',
+      value:
+        leftNonIdentTerm.type === Semantic.NodeType.Neg
+          ? leftNonIdentTerm.arg
+          : leftNonIdentTerm,
     });
     const step = simplifyBothSides(after) as void | Step<
       Semantic.types.Eq<Semantic.types.NumericNode>
@@ -108,10 +114,15 @@ export function moveTermsToOneSide(
     ]);
     const after = Semantic.builders.eq([newLeft, newRight]);
     substeps.push({
-      message: 'subtract term from both sides',
+      message: 'do the same operation to both sides',
       before: before,
       after: after,
       substeps: [],
+      operation: rightIdentTerm.type === Semantic.NodeType.Neg ? 'add' : 'sub',
+      value:
+        rightIdentTerm.type === Semantic.NodeType.Neg
+          ? rightIdentTerm.arg
+          : rightIdentTerm,
     });
     const step = simplifyBothSides(after) as void | Step<
       Semantic.types.Eq<Semantic.types.NumericNode>

--- a/packages/solver/src/solve/transforms/mul-both-sides.ts
+++ b/packages/solver/src/solve/transforms/mul-both-sides.ts
@@ -30,10 +30,12 @@ export function mulBothSides(
       const after = Semantic.builders.eq([newLeft, newRight]);
 
       return {
-        message: 'multiply both sides',
+        message: 'do the same operation to both sides',
         before,
         after,
         substeps: [],
+        operation: 'mul',
+        value: den,
       };
     }
   }
@@ -52,10 +54,12 @@ export function mulBothSides(
       const after = Semantic.builders.eq([newLeft, newRight]);
 
       return {
-        message: 'multiply both sides',
+        message: 'do the same operation to both sides',
         before,
         after,
         substeps: [],
+        operation: 'mul',
+        value: den,
       };
     }
   }

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -1,11 +1,16 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import * as Semantic from '@math-blocks/semantic';
 
-type StepType<TMessage extends string, TNode extends Semantic.types.Node> = {
+type StepType<
+  TMessage extends string,
+  TNode extends Semantic.types.Node,
+  Options extends Record<string, unknown> = {},
+> = {
   readonly message: TMessage;
   readonly before: TNode;
   readonly after: TNode;
   readonly substeps: readonly Step<TNode>[];
-};
+} & Options;
 
 export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'simplify expression', TNode>
@@ -34,9 +39,15 @@ export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'reduce fraction', TNode>
   | StepType<'simplify multiplication', TNode>
   | StepType<'solve for variable', TNode>
-  | StepType<'divide both sides', TNode>
-  | StepType<'multiply both sides', TNode>
-  | StepType<'subtract term from both sides', TNode>
+  // TODO: combine all of these into a single step type
+  | StepType<
+      'do the same operation to both sides',
+      TNode,
+      {
+        readonly operation: 'add' | 'sub' | 'mul' | 'div';
+        readonly value: Semantic.types.NumericNode;
+      }
+    >
   | StepType<'move terms to one side', TNode>
   | StepType<'simplify both sides', TNode>
   | StepType<'simplify the left hand side', TNode>

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -1,11 +1,122 @@
 import * as Semantic from '@math-blocks/semantic';
 
-export type Step<T extends Semantic.types.Node = Semantic.types.Node> = {
-  readonly message: string;
-  readonly before: T;
-  readonly after: T;
-  readonly substeps: readonly Step<T>[];
+type StepType<TMessage extends string, TNode extends Semantic.types.Node> = {
+  readonly message: TMessage;
+  readonly before: TNode;
+  readonly after: TNode;
+  readonly substeps: readonly Step<TNode>[];
 };
+
+export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
+  | StepType<'simplify expression', TNode>
+  | StepType<'adding the inverse is the same as subtraction', TNode>
+  | StepType<'collect like terms', TNode>
+  | StepType<'subtraction is the same as adding the inverse', TNode>
+  | StepType<'reorder terms so that like terms are beside each other', TNode>
+  | StepType<'factor variable part of like terms', TNode>
+  | StepType<'compute new coefficients', TNode>
+  | StepType<'simplify terms', TNode>
+  | StepType<'distribute division', TNode>
+  | StepType<'negation is the same as multiplying by negative one', TNode>
+  | StepType<'multiply each term', TNode>
+  | StepType<'distribute', TNode>
+  | StepType<'drop adding zero', TNode> // additive identity
+  | StepType<'drop parentheses', TNode>
+  | StepType<'evaluate multiplication', TNode>
+  | StepType<'evaluate addition', TNode>
+  | StepType<'evaluate division', TNode>
+  | StepType<'multiplying by zero is equivalent to zero', TNode>
+  | StepType<'multiplying two negatives is a positive', TNode>
+  | StepType<'multiplying a negative by a positive is negative', TNode>
+  | StepType<'multiply fraction(s)', TNode>
+  | StepType<'multiply monomials', TNode>
+  | StepType<'repeated multiplication can be written as a power', TNode>
+  | StepType<'reduce fraction', TNode>
+  | StepType<'simplify multiplication', TNode>
+  | StepType<'solve for variable', TNode>
+  | StepType<'divide both sides', TNode>
+  | StepType<'multiply both sides', TNode>
+  | StepType<'subtract term from both sides', TNode>
+  | StepType<'move terms to one side', TNode>
+  | StepType<'simplify both sides', TNode>
+  | StepType<'simplify the left hand side', TNode>
+  | StepType<'simplify the right hand side', TNode>
+  | StepType<'multiplication of fractions', TNode> // @math-blocks/tutor
+  | StepType<'fraction decomposition', TNode> // @math-blocks/tutor
+  | StepType<'cancelling in fractions', TNode> // @math-blocks/tutor
+  | StepType<'division by one', TNode> // @math-blocks/tutor
+  | StepType<'multiplying the inverse', TNode> // @math-blocks/tutor
+  | StepType<'division is multiplication by a fraction', TNode> // @math-blocks/tutor
+  | StepType<
+      'dividing by a fraction is the same as multiplying by the reciprocal',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<'negative of a negative is positive', TNode> // @math-blocks/tutor
+  | StepType<'subtracting is the same as adding the inverse', TNode> // @math-blocks/tutor
+  | StepType<'negation is the same as multipling by negative one', TNode> // @math-blocks/tutor
+  | StepType<'a positive is the same as multiplying two negatives', TNode> // @math-blocks/tutor
+  | StepType<'move negative to first factor', TNode> // @math-blocks/tutor
+  | StepType<'move negation inside multiplication', TNode> // @math-blocks/tutor
+  | StepType<'move negation out of multiplication', TNode> // @math-blocks/tutor
+  | StepType<'adding inverse', TNode> // @math-blocks/tutor
+  | StepType<'addition with identity', TNode> // @math-blocks/tutor
+  | StepType<'multiplication with identity', TNode> // @math-blocks/tutor
+  | StepType<'multiplication by zero', TNode> // @math-blocks/tutor
+  | StepType<'commutative property', TNode> // @math-blocks/tutor
+  | StepType<'associative property of multiplication', TNode> // @math-blocks/tutor
+  | StepType<'associative property of addition', TNode> // @math-blocks/tutor
+  | StepType<'multiplying a factor n-times is an exponent', TNode> // @math-blocks/tutor
+  | StepType<'a power is the same as multiplying the base n times', TNode> // @math-blocks/tutor
+  | StepType<'multiplying powers adds their exponents', TNode> // @math-blocks/tutor
+  | StepType<'dividing powers subtracts their exponents', TNode> // @math-blocks/tutor
+  | StepType<
+      'One over the power is the same a power with same base but the negative of the same exponent',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<
+      'raising a power to another exponent is the same raising the power once an multiplying the exponents',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<
+      'A product raised to a exponent is the same as raising each factor to that exponent',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<
+      'A product of powers raised to the same exponent are equal to the product of bases raised to that exponent',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<
+      'A fraction raised to a exponent is the same a fraction with the numerator and denominator each raised to that exponent',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<
+      'A quotient of powers raised to the same exponent are equal to the quotient of bases raised to that exponent',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<'anything raised to 0 is equal to 1', TNode> // @math-blocks/tutor
+  | StepType<'raising something to the 1st power is a no-op', TNode> // @math-blocks/tutor
+  | StepType<'1 raised to any power is equal to 1', TNode> // @math-blocks/tutor
+  | StepType<'0 raised to any power (except for 0) is 0', TNode> // @math-blocks/tutor
+  | StepType<'symmetric property', TNode> // @math-blocks/tutor
+  | StepType<'decompose sum', TNode> // @math-blocks/tutor
+  | StepType<'decompose product', TNode> // @math-blocks/tutor
+  | StepType<'distribution', TNode> // @math-blocks/tutor
+  | StepType<'factoring', TNode> // @math-blocks/tutor
+  | StepType<'evaluation of addition', TNode> // @math-blocks/tutor
+  | StepType<'evaluation of multiplication', TNode> // @math-blocks/tutor
+  | StepType<'evaluate sum', TNode> // @math-blocks/tutor
+  | StepType<'evaluate coefficient', TNode> // @math-blocks/tutor
+  | StepType<
+      'A power with a negative exponent is the same as one over the power with the positive exponent',
+      TNode
+    > // @math-blocks/tutor
+  | StepType<'adding the same value to both sides', TNode> // @math-blocks/tutor
+  | StepType<'removing adding the same value to both sides', TNode> // @math-blocks/tutor
+  | StepType<'multiply both sides by the same value', TNode> // @math-blocks/tutor
+  | StepType<'remove multiplication from both sides', TNode> // @math-blocks/tutor
+  | StepType<'divide both sides by the same value', TNode> // @math-blocks/tutor
+  | StepType<'remove division by the same amount', TNode> // @math-blocks/tutor
+  | StepType<'test', TNode>; // this last one is only used in tests
 
 export type Solution<T extends Semantic.types.Node = Semantic.types.Node> = {
   readonly steps: readonly Step<Semantic.types.Node>[];

--- a/packages/tutor/src/grader/checks/test-util.ts
+++ b/packages/tutor/src/grader/checks/test-util.ts
@@ -1,6 +1,7 @@
 import * as Editor from '@math-blocks/editor';
 import * as Semantic from '@math-blocks/semantic';
 import * as Testing from '@math-blocks/testing';
+import * as Solver from '@math-blocks/solver';
 
 import { checkStep as _checkStep } from '../step-checker';
 import type { Result, Mistake } from '../types';
@@ -61,15 +62,24 @@ export const toParseLike = (
   };
 };
 
+const printStep = (step: Solver.Step) => {
+  switch (step.message) {
+    case 'do the same operation to both sides':
+      return `${step.message}:${step.operation}:${Testing.print(step.value)}`;
+    default:
+      return step.message;
+  }
+};
+
 export function toHaveMessages(
   this: any,
   received: Result,
   expected: readonly string[],
 ): { readonly message: () => string; readonly pass: boolean } {
   if (this.isNot) {
-    expect(received.steps.map((step) => step.message)).not.toEqual(expected);
+    expect(received.steps.map(printStep)).not.toEqual(expected);
   } else {
-    expect(received.steps.map((step) => step.message)).toEqual(expected);
+    expect(received.steps.map(printStep)).toEqual(expected);
   }
 
   // This point is reached when the above assertion was successful.

--- a/packages/tutor/src/grader/checks/util.ts
+++ b/packages/tutor/src/grader/checks/util.ts
@@ -142,8 +142,8 @@ export const correctResult = (
   reversed: boolean,
   beforeSteps: readonly Solver.Step[],
   afterSteps: readonly Solver.Step[],
-  forwardMessage: string,
-  reverseMessage: string = forwardMessage,
+  forwardMessage: Solver.Step['message'],
+  reverseMessage: Solver.Step['message'] = forwardMessage,
 ): Result => {
   const newPrev = beforeSteps
     ? reversed
@@ -171,6 +171,8 @@ export const correctResult = (
   // }
 
   return {
+    // @ts-expect-error: TypeScript doesn't like how the `message` fields are
+    // being assigned here.
     steps: reversed
       ? [
           ...afterSteps,


### PR DESCRIPTION
This PR also merges a number of step types into a single `do the same operation to both sides` step.  This step includes two new fields: `operation` and `value`.