### PR TITLE
Simplify dividing by a fraction by multiplying by the reciprocal instead

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,6 @@
         "titleBar.inactiveBackground": "#8faed599",
         "titleBar.inactiveForeground": "#15202b99"
     },
-    "peacock.color": "#8faed5"
+    "peacock.color": "#8faed5",
+    "editor.tabSize": 2
 }

--- a/packages/solver/src/simplify/simplify.ts
+++ b/packages/solver/src/simplify/simplify.ts
@@ -16,13 +16,15 @@ import { simplifyMul } from './transforms/simplify-mul';
 import { mulByZeroIsZero } from './transforms/mul-by-zero-is-zero';
 import { simplifyDivByFrac } from './transforms/simplify-div-by-frac';
 
+// TODO:
+// - negOfNegIsPos
+
 export function simplify(
   node: Semantic.types.NumericNode,
 ): Step<Semantic.types.NumericNode> | void {
   const tranforms = [
     dropAddIdentity,
 
-    // TODO: add a transform to convert division of fractions to multiplication
     simplifyDivByFrac,
     simplifyMul, // We do this first so that we don't repeat what it does in other transforms
     mulByZeroIsZero,

--- a/packages/solver/src/simplify/simplify.ts
+++ b/packages/solver/src/simplify/simplify.ts
@@ -14,6 +14,7 @@ import { mulFraction } from './transforms/mul-fraction';
 import { mulToPow } from './transforms/mul-to-pow';
 import { simplifyMul } from './transforms/simplify-mul';
 import { mulByZeroIsZero } from './transforms/mul-by-zero-is-zero';
+import { simplifyDivByFrac } from './transforms/simplify-div-by-frac';
 
 export function simplify(
   node: Semantic.types.NumericNode,
@@ -21,6 +22,8 @@ export function simplify(
   const tranforms = [
     dropAddIdentity,
 
+    // TODO: add a transform to convert division of fractions to multiplication
+    simplifyDivByFrac,
     simplifyMul, // We do this first so that we don't repeat what it does in other transforms
     mulByZeroIsZero,
 

--- a/packages/solver/src/simplify/transforms/__tests__/simplify-div-by-frac.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/simplify-div-by-frac.test.ts
@@ -1,0 +1,24 @@
+import * as Semantic from '@math-blocks/semantic';
+import * as Testing from '@math-blocks/testing';
+
+import { simplifyDivByFrac } from '../simplify-div-by-frac';
+
+const parse = (str: string): Semantic.types.NumericNode =>
+  Testing.parse(str) as Semantic.types.NumericNode;
+
+describe('simplify division by fraction', () => {
+  test.each`
+    input              | output
+    ${'(1/x)/(1/y)'}   | ${'(1 / x)(y / 1)'}
+    ${'-(1/x)/-(1/y)'} | ${'(-(1 / x))(-(y / 1))'}
+    ${'(1/x)/-(1/y)'}  | ${'(1 / x)(-(y / 1))'}
+    ${'-(1/x)/(1/y)'}  | ${'(-(1 / x))(y / 1)'}
+    ${'2/(1/y)'}       | ${'(2)(y / 1)'}
+    ${'-2/(1/y)'}      | ${'(-2)(y / 1)'}
+    ${'2/-(1/y)'}      | ${'(2)(-(y / 1))'}
+    ${'-2/-(1/y)'}     | ${'(-2)(-(y / 1))'}
+  `('isNegative($input) -> $output', ({ input, output }) => {
+    const result = simplifyDivByFrac(parse(input))!;
+    expect(Testing.print(result.after)).toEqual(output);
+  });
+});

--- a/packages/solver/src/simplify/transforms/simplify-div-by-frac.ts
+++ b/packages/solver/src/simplify/transforms/simplify-div-by-frac.ts
@@ -2,6 +2,19 @@ import * as Semantic from '@math-blocks/semantic';
 
 import type { Step } from '../../types';
 
+const getReciprocal = (
+  node: Semantic.types.NumericNode,
+): Semantic.types.NumericNode | undefined => {
+  if (node.type === Semantic.NodeType.Neg) {
+    const reciprocal = getReciprocal(node.arg);
+    return reciprocal ? Semantic.builders.neg(reciprocal) : undefined;
+  } else if (node.type === Semantic.NodeType.Div) {
+    return Semantic.builders.div(node.args[1], node.args[0]);
+  } else {
+    return undefined;
+  }
+};
+
 export function simplifyDivByFrac(
   node: Semantic.types.NumericNode,
 ): Step<Semantic.types.NumericNode> | void {
@@ -10,41 +23,13 @@ export function simplifyDivByFrac(
   }
 
   const [num, den] = node.args;
+  const reciprocal = getReciprocal(den);
 
-  // TODO: handle the cases where either the numerator or denominator are
-  // negative but not both.
-  if (
-    node.args[0].type === Semantic.NodeType.Neg &&
-    node.args[1].type === Semantic.NodeType.Neg
-  ) {
-    const den = node.args[1].arg;
-    if (den.type !== Semantic.NodeType.Div) {
-      return undefined;
-    }
-    const reciprocal = Semantic.builders.div(den.args[1], den.args[0]);
-    const after = Semantic.builders.mul(
-      [num, Semantic.builders.neg(reciprocal)],
-      true, // implicit
-    );
-    return {
-      message:
-        'dividing by a fraction is the same as multiplyin by the reciprocal',
-      before: node,
-      after,
-      substeps: [],
-    };
-  }
-
-  // TODO: handle case where numerator isn't a div node
-  if (
-    num.type !== Semantic.NodeType.Div ||
-    den.type !== Semantic.NodeType.Div
-  ) {
+  if (!reciprocal) {
     return undefined;
   }
 
-  const reciprocal = Semantic.builders.div(den.args[1], den.args[0]);
-  const after = Semantic.builders.mul([num, reciprocal]);
+  const after = Semantic.builders.mul([num, reciprocal], true /* implicit */);
 
   return {
     message:

--- a/packages/solver/src/simplify/transforms/simplify-div-by-frac.ts
+++ b/packages/solver/src/simplify/transforms/simplify-div-by-frac.ts
@@ -1,0 +1,56 @@
+import * as Semantic from '@math-blocks/semantic';
+
+import type { Step } from '../../types';
+
+export function simplifyDivByFrac(
+  node: Semantic.types.NumericNode,
+): Step<Semantic.types.NumericNode> | void {
+  if (node.type !== Semantic.NodeType.Div) {
+    return undefined;
+  }
+
+  const [num, den] = node.args;
+
+  // TODO: handle the cases where either the numerator or denominator are
+  // negative but not both.
+  if (
+    node.args[0].type === Semantic.NodeType.Neg &&
+    node.args[1].type === Semantic.NodeType.Neg
+  ) {
+    const den = node.args[1].arg;
+    if (den.type !== Semantic.NodeType.Div) {
+      return undefined;
+    }
+    const reciprocal = Semantic.builders.div(den.args[1], den.args[0]);
+    const after = Semantic.builders.mul(
+      [num, Semantic.builders.neg(reciprocal)],
+      true, // implicit
+    );
+    return {
+      message:
+        'dividing by a fraction is the same as multiplyin by the reciprocal',
+      before: node,
+      after,
+      substeps: [],
+    };
+  }
+
+  // TODO: handle case where numerator isn't a div node
+  if (
+    num.type !== Semantic.NodeType.Div ||
+    den.type !== Semantic.NodeType.Div
+  ) {
+    return undefined;
+  }
+
+  const reciprocal = Semantic.builders.div(den.args[1], den.args[0]);
+  const after = Semantic.builders.mul([num, reciprocal]);
+
+  return {
+    message:
+      'dividing by a fraction is the same as multiplyin by the reciprocal',
+    before: node,
+    after,
+    substeps: [],
+  };
+}

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -414,5 +414,48 @@ describe('solve', () => {
       expect(Testing.print(result.after)).toEqual('x = 5 / 2');
       expect(result.substeps).toHaveLength(0);
     });
+
+    test('4 = b', () => {
+      // Arrange
+      const ast = parseEq('4 = b');
+
+      // Act
+      const result = solve(ast, Semantic.builders.identifier('b'));
+
+      // Assert
+      expect(Testing.print(result.after)).toEqual('4 = b');
+      expect(result.substeps).toHaveLength(0);
+    });
+
+    test('b = 4', () => {
+      // Arrange
+      const ast = parseEq('b = 4');
+
+      // Act
+      const result = solve(ast, Semantic.builders.identifier('b'));
+
+      // Assert
+      expect(Testing.print(result.after)).toEqual('b = 4');
+      expect(result.substeps).toHaveLength(0);
+    });
+
+    test('1 - n = 3/2 n + 17/2', () => {
+      // Arrange
+      const ast = parseEq('1 - n = (3/2)(n) + 17/2');
+
+      // Act
+      const result = solve(ast, Semantic.builders.identifier('n'));
+
+      // Assert
+      const steps = result.substeps.map((step) => Testing.print(step.after));
+      expect(steps).toMatchInlineSnapshot(`
+        Array [
+          "1 - n = 3n / 2 + 17 / 2",
+          "-(5n / 2) = 15 / 2",
+          "-(5n / 2) / -(5 / 2) = (15 / 2) / -(5 / 2)",
+          "n = -3",
+        ]
+      `);
+    });
   });
 });

--- a/packages/solver/src/solve/solve.ts
+++ b/packages/solver/src/solve/solve.ts
@@ -39,6 +39,19 @@ export function solve(
     };
   }
 
+  if (
+    node.type === NodeType.Equals &&
+    node.args[1].type === NodeType.Identifier &&
+    Semantic.util.isNumber(node.args[0])
+  ) {
+    return {
+      message: 'solve for variable', // TODO: include variable in message
+      before: node,
+      after: node,
+      substeps: [],
+    };
+  }
+
   // NOTE: We simplify both sides before and after every other transform.
   // This is so that we don't jump from something like 2x = 10 - 5 to 2x / 2 = 5 / 2.
   const transforms = [moveTermsToOneSide, divBothSides, mulBothSides].flatMap(

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -30,6 +30,10 @@ export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'evaluate multiplication', TNode>
   | StepType<'evaluate addition', TNode>
   | StepType<'evaluate division', TNode>
+  | StepType<
+      'dividing by a fraction is the same as multiplyin by the reciprocal',
+      TNode
+    >
   | StepType<'multiplying by zero is equivalent to zero', TNode>
   | StepType<'multiplying two negatives is a positive', TNode>
   | StepType<'multiplying a negative by a positive is negative', TNode>


### PR DESCRIPTION
This PR also updates `solve()` to check for `... = x` as an end state where `x` is the variable being solved for.

TODO:
- [x] handle the cases where either the numerator or denominator are negative but not both
- [x] handle case where numerator isn't a div node
- [x] write tests