### PR TITLE
Refactor moveTermsToOneSide

### DIFF
--- a/packages/solver/src/simplify/transforms/__tests__/simplify-div-by-frac.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/simplify-div-by-frac.test.ts
@@ -17,7 +17,7 @@ describe('simplify division by fraction', () => {
     ${'-2/(1/y)'}      | ${'(-2)(y / 1)'}
     ${'2/-(1/y)'}      | ${'(2)(-(y / 1))'}
     ${'-2/-(1/y)'}     | ${'(-2)(-(y / 1))'}
-  `('isNegative($input) -> $output', ({ input, output }) => {
+  `('simplifyDivByFrac($input) -> $output', ({ input, output }) => {
     const result = simplifyDivByFrac(parse(input))!;
     expect(Testing.print(result.after)).toEqual(output);
   });

--- a/packages/solver/src/solve/__tests__/solve.test.ts
+++ b/packages/solver/src/solve/__tests__/solve.test.ts
@@ -169,16 +169,16 @@ describe('solve', () => {
 
       const result = solve(ast, Semantic.builders.identifier('x'));
 
-      expect(Testing.print(result.after)).toEqual('x = 3');
+      expect(Testing.print(result.after)).toEqual('3 = x');
       expect(result.substeps.map(printStep)).toEqual([
         'move terms to one side',
-        'do the same operation to both sides:div:-2',
+        'do the same operation to both sides:div:2',
         'simplify both sides',
       ]);
 
       expect(ast).toHaveFullStepsLike({
         steps: result.substeps,
-        expressions: ['7 = 2x + 1', '-2x = -6', '-2x / -2 = -6 / -2', 'x = 3'],
+        expressions: ['7 = 2x + 1', '6 = 2x', '6 / 2 = 2x / 2', '3 = x'],
       });
     });
 

--- a/packages/solver/src/solve/transforms/__tests__/move-matching-variable-terms-to-one-side.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/move-matching-variable-terms-to-one-side.test.ts
@@ -1,0 +1,33 @@
+import * as Semantic from '@math-blocks/semantic';
+import * as Testing from '@math-blocks/testing';
+
+import { moveMatchingVariableTermsToOneSide } from '../move-matching-variable-terms-to-one-side';
+
+const parseEq = (input: string): Semantic.types.Eq => {
+  return Testing.parse(input) as Semantic.types.Eq;
+};
+
+describe('move constants from left to right', () => {
+  test.each`
+    input                            | output                      | substeps
+    ${'2x + 5 = 10'}                 | ${'2x + 5 = 10'}            | ${0}
+    ${'10 = 2x + 5'}                 | ${'10 = 2x + 5'}            | ${0}
+    ${'2x + 5 = 10 - 3x'}            | ${'5x + 5 = 10'}            | ${2}
+    ${'2x + 5 = 10 + 3x'}            | ${'-x + 5 = 10'}            | ${2}
+    ${'2x + 5 = 10 - 3x + x'}        | ${'4x + 5 = 10'}            | ${4}
+    ${'2x - x + 5 = 10 + 3x'}        | ${'-2x + 5 = 10'}           | ${2}
+    ${'2x + 5y - 1 = -3y + 10 - 3x'} | ${'5x + 5y - 1 = -3y + 10'} | ${2}
+  `(
+    'moveVariableToOneSide($input) -> $output',
+    ({ input, output, substeps }) => {
+      const ident = Semantic.builders.identifier('x');
+      const result = moveMatchingVariableTermsToOneSide(parseEq(input), ident)!;
+      if (result === undefined) {
+        expect(input).toEqual(output);
+      } else {
+        expect(Testing.print(result.after)).toEqual(output);
+        expect(result.substeps.length).toEqual(substeps);
+      }
+    },
+  );
+});

--- a/packages/solver/src/solve/transforms/__tests__/move-other-terms-to-the-other-side.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/move-other-terms-to-the-other-side.test.ts
@@ -1,0 +1,35 @@
+import * as Semantic from '@math-blocks/semantic';
+import * as Testing from '@math-blocks/testing';
+
+import { moveOtherTermsToOneSide } from '../move-other-terms-to-the-other-side';
+
+const parseEq = (input: string): Semantic.types.Eq => {
+  return Testing.parse(input) as Semantic.types.Eq;
+};
+
+describe('move other terms to the other side', () => {
+  test.each`
+    input                    | output           | substeps
+    ${'y = z'}               | ${'y = z'}       | ${0}
+    ${'x = x + 1'}           | ${'x = x + 1'}   | ${0}
+    ${'2x = 5'}              | ${'2x = 5'}      | ${0}
+    ${'5 = 2x'}              | ${'5 = 2x'}      | ${0}
+    ${'2x + 5 = 10'}         | ${'2x = 5'}      | ${2}
+    ${'10 = 2x + 5'}         | ${'5 = 2x'}      | ${2}
+    ${'2x - y + 5 = 10'}     | ${'2x = 5 + y'}  | ${4}
+    ${'2x - y + 5 = 10 + y'} | ${'2x = 5 + 2y'} | ${4}
+    ${'10 + y = 2x - y + 5'} | ${'5 + 2y = 2x'} | ${4}
+  `(
+    'moveVariableToOneSide($input) -> $output',
+    ({ input, output, substeps }) => {
+      const ident = Semantic.builders.identifier('x');
+      const result = moveOtherTermsToOneSide(parseEq(input), ident)!;
+      if (result === undefined) {
+        expect(input).toEqual(output);
+      } else {
+        expect(Testing.print(result.after)).toEqual(output);
+        expect(result.substeps.length).toEqual(substeps);
+      }
+    },
+  );
+});

--- a/packages/solver/src/solve/transforms/__tests__/move-terms-to-one-side.test.ts
+++ b/packages/solver/src/solve/transforms/__tests__/move-terms-to-one-side.test.ts
@@ -25,7 +25,7 @@ describe('move constants from left to right', () => {
     const step = transform(before);
 
     expect(Testing.print(step.after)).toEqual('2x = 5');
-    const doSameOpSteps = step.substeps.filter(
+    const doSameOpSteps = step.substeps[0].substeps.filter(
       (step) => step.message === 'do the same operation to both sides',
     );
     const operations = doSameOpSteps.map((step) => step.operation);
@@ -40,7 +40,7 @@ describe('move constants from left to right', () => {
     const step = transform(before);
 
     expect(Testing.print(step.after)).toEqual('2x = 15');
-    const doSameOpSteps = step.substeps.filter(
+    const doSameOpSteps = step.substeps[0].substeps.filter(
       (step) => step.message === 'do the same operation to both sides',
     );
     const operations = doSameOpSteps.map((step) => step.operation);
@@ -49,35 +49,64 @@ describe('move constants from left to right', () => {
     expect(terms).toEqual(['5']);
   });
 
+  test('2x + -5 = 10', () => {
+    const before = parseEq('2x + -5 = 10');
+
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('2x = 15');
+    const doSameOpSteps = step.substeps[0].substeps.filter(
+      (step) => step.message === 'do the same operation to both sides',
+    );
+    const operations = doSameOpSteps.map((step) => step.operation);
+    expect(operations).toEqual(['sub']);
+    const terms = doSameOpSteps.map((step) => Testing.print(step.value));
+    expect(terms).toEqual(['-5']);
+  });
+
   // TODO: Only move `+ 5` to the left side
   test('10 = 2x + 5', () => {
     const before = parseEq('10 = 2x + 5');
 
     const step = transform(before);
 
-    expect(Testing.print(step.after)).toEqual('-2x = -5');
-    const doSameOpSteps = step.substeps.filter(
+    expect(Testing.print(step.after)).toEqual('5 = 2x');
+    const doSameOpSteps = step.substeps[0].substeps.filter(
       (step) => step.message === 'do the same operation to both sides',
     );
     const operations = doSameOpSteps.map((step) => step.operation);
-    expect(operations).toEqual(['sub', 'sub']);
+    expect(operations).toEqual(['sub']);
     const terms = doSameOpSteps.map((step) => Testing.print(step.value));
-    expect(terms).toEqual(['10', '2x']);
+    expect(terms).toEqual(['5']);
   });
 
-  // TODO: Only move `- 5` to the left side
   test('10 = 2x - 5', () => {
     const before = parseEq('10 = 2x - 5');
 
     const step = transform(before);
 
-    expect(Testing.print(step.after)).toEqual('-2x = -15');
-    const doSameOpSteps = step.substeps.filter(
+    expect(Testing.print(step.after)).toEqual('15 = 2x');
+    const doSameOpSteps = step.substeps[0].substeps.filter(
       (step) => step.message === 'do the same operation to both sides',
     );
     const operations = doSameOpSteps.map((step) => step.operation);
-    expect(operations).toEqual(['sub', 'sub']);
+    expect(operations).toEqual(['add']);
     const terms = doSameOpSteps.map((step) => Testing.print(step.value));
-    expect(terms).toEqual(['10', '2x']);
+    expect(terms).toEqual(['5']);
+  });
+
+  test('10 = 2x + -5', () => {
+    const before = parseEq('10 = 2x + -5');
+
+    const step = transform(before);
+
+    expect(Testing.print(step.after)).toEqual('15 = 2x');
+    const doSameOpSteps = step.substeps[0].substeps.filter(
+      (step) => step.message === 'do the same operation to both sides',
+    );
+    const operations = doSameOpSteps.map((step) => step.operation);
+    expect(operations).toEqual(['sub']);
+    const terms = doSameOpSteps.map((step) => Testing.print(step.value));
+    expect(terms).toEqual(['-5']);
   });
 });

--- a/packages/solver/src/solve/transforms/move-matching-variable-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-matching-variable-terms-to-one-side.ts
@@ -1,0 +1,86 @@
+import * as Semantic from '@math-blocks/semantic';
+
+import { isTermOfIdent, flipSign } from '../util';
+import { simplifyBothSides } from './simplify-both-sides';
+
+import type { Step } from '../../types';
+
+export function moveMatchingVariableTermsToOneSide(
+  before: Semantic.types.Eq,
+  variable: Semantic.types.Identifier,
+): Step<Semantic.types.Eq> | void {
+  const originalBefore = before;
+  let [left, right] = before.args as readonly Semantic.types.NumericNode[];
+
+  const leftTerms = Semantic.util.getTerms(left);
+  const rightTerms = Semantic.util.getTerms(right);
+
+  const leftMatchingTerms = leftTerms.filter((term) =>
+    isTermOfIdent(term, variable),
+  );
+  const rightMatchingTerms = rightTerms.filter((term) =>
+    isTermOfIdent(term, variable),
+  );
+
+  if (leftMatchingTerms.length === 0 && rightMatchingTerms.length === 0) {
+    // There is no terms with the variable on either side.
+    return;
+  }
+
+  if (leftMatchingTerms.length > 0 && rightMatchingTerms.length > 0) {
+    const substeps: Step<Semantic.types.Eq>[] = [];
+    let after: Semantic.types.Node | null = null;
+
+    // NOTE: In theory, there should only be one matching term since the terms
+    // on each side should have already be simplified by collecting like terms.
+    for (const matchingTerm of rightMatchingTerms) {
+      const leftTerms = Semantic.util.getTerms(left);
+      const rightTerms = Semantic.util.getTerms(right);
+
+      const newLeftTerms = [...leftTerms, flipSign(matchingTerm)];
+      const newRightTerms = [...rightTerms, flipSign(matchingTerm)];
+
+      left = Semantic.builders.add(newLeftTerms);
+      right = Semantic.builders.add(newRightTerms);
+      after = Semantic.builders.eq([left, right]);
+
+      substeps.push({
+        message: 'do the same operation to both sides',
+        before,
+        after,
+        substeps: [],
+        operation: matchingTerm.type === Semantic.NodeType.Neg ? 'add' : 'sub',
+        value: matchingTerm,
+      });
+      before = after;
+
+      // TODO: show the cancelling of terms after the addition/subtraction
+      const step = simplifyBothSides(after) as void | Step<
+        Semantic.types.Eq<Semantic.types.NumericNode>
+      >;
+      if (step) {
+        after = step.after;
+        substeps.push({
+          message: 'simplify both sides',
+          before: before,
+          after: step.after,
+          substeps: step.substeps,
+        });
+        before = after;
+      }
+    }
+
+    if (!after) return;
+
+    return {
+      message: 'move matching variable terms to one side',
+      before: originalBefore,
+      after,
+      substeps,
+      side: 'left',
+    };
+  }
+
+  // The variable terms are already on one side.
+  return;
+}

--- a/packages/solver/src/solve/transforms/move-matching-variable-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-matching-variable-terms-to-one-side.ts
@@ -27,6 +27,7 @@ export function moveMatchingVariableTermsToOneSide(
     return;
   }
 
+  // TODO: dedupe with `moveTermToSide` in move-other-terms-to-the-other-side.ts
   if (leftMatchingTerms.length > 0 && rightMatchingTerms.length > 0) {
     const substeps: Step<Semantic.types.Eq>[] = [];
     let after: Semantic.types.Node | null = null;

--- a/packages/solver/src/solve/transforms/move-other-terms-to-the-other-side.ts
+++ b/packages/solver/src/solve/transforms/move-other-terms-to-the-other-side.ts
@@ -1,0 +1,153 @@
+import * as Semantic from '@math-blocks/semantic';
+
+import { isTermOfIdent, flipSign } from '../util';
+import { simplifyBothSides } from './simplify-both-sides';
+
+import type { Step } from '../../types';
+
+const isSubtraction = Semantic.util.isSubtraction;
+
+export function moveOtherTermsToOneSide(
+  before: Semantic.types.Eq,
+  variable: Semantic.types.Identifier,
+): Step<Semantic.types.Eq> | void {
+  const originalBefore = before;
+  let [left, right] = before.args as readonly Semantic.types.NumericNode[];
+
+  const leftTerms = Semantic.util.getTerms(left);
+  const rightTerms = Semantic.util.getTerms(right);
+
+  const leftMatchingTerms = leftTerms.filter((term) =>
+    isTermOfIdent(term, variable),
+  );
+  const leftNonMatchingTerms = leftTerms.filter(
+    (term) => !isTermOfIdent(term, variable),
+  );
+  const rightMatchingTerms = rightTerms.filter((term) =>
+    isTermOfIdent(term, variable),
+  );
+  const rightNonMatchingTerms = rightTerms.filter(
+    (term) => !isTermOfIdent(term, variable),
+  );
+
+  if (leftMatchingTerms.length === 0 && rightMatchingTerms.length === 0) {
+    // There are no macthing terms on either side.
+    return;
+  }
+
+  if (leftMatchingTerms.length > 0 && rightMatchingTerms.length > 0) {
+    // Matching terms haven't been separated yet.
+    return;
+  }
+
+  if (leftMatchingTerms.length === 0 && rightMatchingTerms.length > 0) {
+    const substeps: Step<Semantic.types.Eq>[] = [];
+    let after: Semantic.types.Node | null = null;
+
+    for (const nonMatchingTerm of rightNonMatchingTerms) {
+      const leftTerms = Semantic.util.getTerms(left);
+      const rightTerms = Semantic.util.getTerms(right);
+
+      const newLeftTerms = [...leftTerms, flipSign(nonMatchingTerm)];
+      const newRightTerms = [...rightTerms, flipSign(nonMatchingTerm)];
+
+      left = Semantic.builders.add(newLeftTerms);
+      right = Semantic.builders.add(newRightTerms);
+      after = Semantic.builders.eq([left, right]);
+
+      substeps.push({
+        message: 'do the same operation to both sides',
+        before,
+        after,
+        substeps: [],
+        operation: isSubtraction(nonMatchingTerm) ? 'add' : 'sub',
+        value: isSubtraction(nonMatchingTerm)
+          ? nonMatchingTerm.arg
+          : nonMatchingTerm,
+      });
+      before = after;
+
+      // TODO: show the cancelling of terms after the addition/subtraction
+      const step = simplifyBothSides(after) as void | Step<
+        Semantic.types.Eq<Semantic.types.NumericNode>
+      >;
+      if (step) {
+        after = step.after;
+        substeps.push({
+          message: 'simplify both sides',
+          before: before,
+          after: step.after,
+          substeps: step.substeps,
+        });
+        before = after;
+      }
+    }
+
+    if (!after) return;
+
+    return {
+      message: 'move other terms to the other side',
+      before: originalBefore,
+      after,
+      substeps,
+      side: 'left',
+    };
+  }
+
+  if (leftMatchingTerms.length > 0 && rightMatchingTerms.length === 0) {
+    const substeps: Step<Semantic.types.Eq>[] = [];
+    let after: Semantic.types.Node | null = null;
+
+    for (const nonMatchingTerm of leftNonMatchingTerms) {
+      const leftTerms = Semantic.util.getTerms(left);
+      const rightTerms = Semantic.util.getTerms(right);
+
+      const newLeftTerms = [...leftTerms, flipSign(nonMatchingTerm)];
+      const newRightTerms = [...rightTerms, flipSign(nonMatchingTerm)];
+
+      left = Semantic.builders.add(newLeftTerms);
+      right = Semantic.builders.add(newRightTerms);
+      after = Semantic.builders.eq([left, right]);
+
+      substeps.push({
+        message: 'do the same operation to both sides',
+        before,
+        after,
+        substeps: [],
+        operation: isSubtraction(nonMatchingTerm) ? 'add' : 'sub',
+        value: isSubtraction(nonMatchingTerm)
+          ? nonMatchingTerm.arg
+          : nonMatchingTerm,
+      });
+      before = after;
+
+      // TODO: show the cancelling of terms after the addition/subtraction
+      const step = simplifyBothSides(after) as void | Step<
+        Semantic.types.Eq<Semantic.types.NumericNode>
+      >;
+      if (step) {
+        after = step.after;
+        substeps.push({
+          message: 'simplify both sides',
+          before: before,
+          after: step.after,
+          substeps: step.substeps,
+        });
+        before = after;
+      }
+    }
+
+    if (!after) return;
+
+    return {
+      message: 'move other terms to the other side',
+      before: originalBefore,
+      after,
+      substeps,
+      side: 'right',
+    };
+  }
+
+  // The variable terms are already on one side.
+  return;
+}

--- a/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
+++ b/packages/solver/src/solve/transforms/move-terms-to-one-side.ts
@@ -1,22 +1,13 @@
 import * as Semantic from '@math-blocks/semantic';
 
-import { isTermOfIdent, flipSign } from '../util';
-import { simplifyBothSides } from './simplify-both-sides';
+import { moveMatchingVariableTermsToOneSide } from './move-matching-variable-terms-to-one-side';
+import { moveOtherTermsToOneSide } from './move-other-terms-to-the-other-side';
 
 import type { Step } from '../../types';
 
 /**
  * Moves all terms matching `ident` to one side and those that don't to the
  * other side.
- *
- * TODO:
- * - customize messages in steps
- * - add sub-steps for:
- *   - the addition/subtraction that needs to be done to both sides to
- *     move something
- *   - showing the cancelling of terms after the addition/subtraction
- *   - the case where we're moving both matching and non-matching terms in
- *     opposite directions
  */
 export function moveTermsToOneSide(
   before: Semantic.types.Eq,
@@ -24,130 +15,22 @@ export function moveTermsToOneSide(
 ): Step<Semantic.types.Eq> | void {
   const originalBefore = before;
 
-  let [left, right] = before.args as readonly Semantic.types.NumericNode[];
-
-  const leftTerms = Semantic.util.getTerms(left);
-  const rightTerms = Semantic.util.getTerms(right);
-
-  const leftIdentTerms = leftTerms.filter((term) => isTermOfIdent(term, ident));
-
-  const rightNonIdentTerms = rightTerms.filter(
-    (term) => !isTermOfIdent(term, ident),
-  );
-
-  if (leftIdentTerms.length === 0 && rightNonIdentTerms.length === 0) {
-    // Terms have already been separated.
-    return undefined;
+  const substeps: Step<Semantic.types.Eq>[] = [];
+  const step1 = moveMatchingVariableTermsToOneSide(before, ident);
+  if (step1) {
+    substeps.push(step1);
+    before = step1.after;
   }
 
-  const rightIdentTerms = rightTerms.filter((term) =>
-    isTermOfIdent(term, ident),
-  );
-
-  const leftNonIdentTerms = leftTerms.filter(
-    (term) => !isTermOfIdent(term, ident),
-  );
-
-  if (rightIdentTerms.length === 0 && leftNonIdentTerms.length === 0) {
-    // Terms have already been separated.
-    return undefined;
+  const step2 = moveOtherTermsToOneSide(before, ident);
+  if (step2) {
+    substeps.push(step2);
   }
 
-  let newLeft;
-  let newRight;
-
-  const substeps: Step<Semantic.types.Eq<Semantic.types.Node>>[] = [];
-
-  for (const leftNonIdentTerm of leftNonIdentTerms) {
-    newLeft = Semantic.builders.add([
-      ...Semantic.util.getTerms(left),
-      flipSign(leftNonIdentTerm),
-    ]);
-    newRight = Semantic.builders.add([
-      ...Semantic.util.getTerms(right),
-      flipSign(leftNonIdentTerm),
-    ]);
-    const after = Semantic.builders.eq([newLeft, newRight]);
-    substeps.push({
-      message: 'do the same operation to both sides',
-      before: before,
-      after: after,
-      substeps: [],
-      operation:
-        leftNonIdentTerm.type === Semantic.NodeType.Neg ? 'add' : 'sub',
-      value:
-        leftNonIdentTerm.type === Semantic.NodeType.Neg
-          ? leftNonIdentTerm.arg
-          : leftNonIdentTerm,
-    });
-    const step = simplifyBothSides(after) as void | Step<
-      Semantic.types.Eq<Semantic.types.NumericNode>
-    >;
-    if (step) {
-      before = after;
-      const newAfter = step.after;
-      substeps.push({
-        message: 'simplify both sides',
-        before: before,
-        after: newAfter,
-        substeps: step.substeps,
-      });
-      left = newAfter.args[0];
-      right = newAfter.args[1];
-      before = newAfter;
-      /* istanbul ignore */
-    } else {
-      left = newLeft;
-      right = newRight;
-      before = after;
-    }
+  if (substeps.length === 0) {
+    return;
   }
 
-  for (const rightIdentTerm of rightIdentTerms) {
-    newLeft = Semantic.builders.add([
-      ...Semantic.util.getTerms(left),
-      flipSign(rightIdentTerm),
-    ]);
-    newRight = Semantic.builders.add([
-      ...Semantic.util.getTerms(right),
-      flipSign(rightIdentTerm),
-    ]);
-    const after = Semantic.builders.eq([newLeft, newRight]);
-    substeps.push({
-      message: 'do the same operation to both sides',
-      before: before,
-      after: after,
-      substeps: [],
-      operation: rightIdentTerm.type === Semantic.NodeType.Neg ? 'add' : 'sub',
-      value:
-        rightIdentTerm.type === Semantic.NodeType.Neg
-          ? rightIdentTerm.arg
-          : rightIdentTerm,
-    });
-    const step = simplifyBothSides(after) as void | Step<
-      Semantic.types.Eq<Semantic.types.NumericNode>
-    >;
-    if (step) {
-      before = after;
-      const newAfter = step.after;
-      substeps.push({
-        message: 'simplify both sides',
-        before: before,
-        after: newAfter,
-        substeps: step.substeps,
-      });
-      left = newAfter.args[0];
-      right = newAfter.args[1];
-      before = newAfter;
-      /* istanbul ignore */
-    } else {
-      left = newLeft;
-      right = newRight;
-      before = after;
-    }
-  }
-
-  // TODO: determine if there were any changes between before and after
   return {
     message: 'move terms to one side',
     before: originalBefore,

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -12,6 +12,8 @@ type StepType<
   readonly substeps: readonly Step<TNode>[];
 } & Options;
 
+export type Side = 'left' | 'right';
+
 export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'simplify expression', TNode>
   | StepType<'adding the inverse is the same as subtraction', TNode>
@@ -53,6 +55,16 @@ export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
       }
     >
   | StepType<'move terms to one side', TNode>
+  | StepType<
+      'move matching variable terms to one side',
+      TNode,
+      { readonly side: Side }
+    >
+  | StepType<
+      'move other terms to the other side',
+      TNode,
+      { readonly side: Side }
+    >
   | StepType<'simplify both sides', TNode>
   | StepType<'simplify the left hand side', TNode>
   | StepType<'simplify the right hand side', TNode>


### PR DESCRIPTION
This PR makes the following changes:
- instead of moving terms the match the variable we're trying to isolate at the same time as other terms, we move them separately
- we only add/sub one term at a time
- can solve things with the variable we're solving for on the right instead without moving the variable to the left, e.g. `10 = 2x + 5` will be solved as `5/2 = x`