### PR TITLE
Update simple-reducer to handle canceling

### DIFF
--- a/packages/editor/src/simple-reducer/reducers/__tests__/cancel.test.ts
+++ b/packages/editor/src/simple-reducer/reducers/__tests__/cancel.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable jest-dom/prefer-to-have-style */
+import * as b from '../../../char/builders';
+
+import { toEqualEditorNode } from '../../../test-util';
+import * as SelectionUtils from '../../selection-utils';
+import { reducer } from '../../reducer';
+
+import type { Action, State } from '../../types';
+
+expect.extend({ toEqualEditorNode });
+
+describe('cancel', () => {
+  it('should cancel the selected range', () => {
+    // Arrange
+    const state: State = {
+      row: b.row([b.char('x'), b.char('+'), b.char('y')]),
+      selection: SelectionUtils.makeSelection2([], 1, [], 3),
+      selecting: false,
+    };
+    const action: Action = { type: 'Cancel' };
+
+    // Act
+    const newState = reducer(state, action);
+
+    // Assert
+    expect(newState.row.children[0].style.cancel).toBeUndefined();
+    expect(newState.row.children[1].style.cancel).toEqual(expect.any(Number));
+    expect(newState.row.children[2].style.cancel).toEqual(expect.any(Number));
+  });
+
+  it('should override existing cancel selections', () => {
+    // Arrange
+    let state: State = {
+      row: b.row([b.char('x'), b.char('+'), b.char('y')]),
+      selection: SelectionUtils.makeSelection2([], 0, [], 3),
+      selecting: false,
+    };
+    state = reducer(state, { type: 'Cancel' });
+    state = {
+      ...state,
+      selection: SelectionUtils.makeSelection2([], 1, [], 2),
+    };
+
+    // Act
+    state = reducer(state, { type: 'Cancel' });
+
+    // Assert
+    expect(state.row.children[0].style.cancel).toEqual(expect.any(Number));
+    expect(state.row.children[1].style.cancel).toEqual(expect.any(Number));
+    expect(state.row.children[2].style.cancel).toEqual(expect.any(Number));
+    expect(state.row.children[0].style.cancel).toEqual(
+      state.row.children[2].style.cancel,
+    );
+    expect(state.row.children[1].style.cancel).not.toEqual(
+      state.row.children[2].style.cancel,
+    );
+  });
+
+  it('should uncancel', () => {
+    // Arrange
+    let state: State = {
+      row: b.row([b.char('x'), b.char('+'), b.char('y')]),
+      selection: SelectionUtils.makeSelection2([], 0, [], 3),
+      selecting: false,
+    };
+    state = reducer(state, { type: 'Cancel' });
+    state = {
+      ...state,
+      selection: SelectionUtils.makeSelection2([], 1, [], 2),
+    };
+
+    // Act
+    state = reducer(state, { type: 'Uncancel' });
+
+    // Assert
+    expect(state.row.children[0].style.cancel).toEqual(expect.any(Number));
+    expect(state.row.children[1].style.cancel).toBeUndefined();
+    expect(state.row.children[2].style.cancel).toEqual(expect.any(Number));
+  });
+
+  it('should not cancel all descendents', () => {
+    // Arrange
+    const state: State = {
+      row: b.row([b.frac([b.char('x')], [b.char('y')])]),
+      selection: SelectionUtils.makeSelection2([], 0, [], 1),
+      selecting: false,
+    };
+    const action: Action = { type: 'Cancel' };
+
+    // Act
+    const newState = reducer(state, action);
+
+    // Assert
+    if (newState.row.children[0].type !== 'frac') {
+      throw new Error('Expected frac');
+    }
+    expect(newState.row.children[0].style.cancel).toEqual(expect.any(Number));
+    expect(newState.row.children[0].children[0].style.cancel).toBeUndefined();
+    expect(newState.row.children[0].children[1].style.cancel).toBeUndefined();
+  });
+
+  it('should not cancel anything if nothing is selected', () => {
+    // Arrange
+    const state: State = {
+      row: b.row([b.char('x'), b.char('+'), b.char('y')]),
+      selection: SelectionUtils.makeSelection([], 1),
+      selecting: false,
+    };
+    const action: Action = { type: 'Cancel' };
+
+    // Act
+    const newState = reducer(state, action);
+
+    // Assert
+    expect(newState).toBe(state);
+  });
+});

--- a/packages/editor/src/simple-reducer/reducers/cancel.ts
+++ b/packages/editor/src/simple-reducer/reducers/cancel.ts
@@ -1,5 +1,42 @@
+import * as transforms from '../../char/transforms';
 import type { State } from '../types';
 
-export const cancel = (state: State, id?: number): State => {
+import { isPrefix } from '../path-utils';
+import { getPathAndRange } from '../selection-utils';
+
+export const cancel = (state: State, cancelId?: number): State => {
+  const { selection } = state;
+  const { path, start, end } = getPathAndRange(selection);
+
+  if (end - start > 0) {
+    const newRow = transforms.traverseNode(
+      state.row,
+      {
+        exit: (node, nodePath) => {
+          if (isPrefix(path, nodePath)) {
+            const remainder = nodePath.slice(path.length);
+            const head = remainder[0];
+            if (head >= start && head < end && remainder.length === 1) {
+              return {
+                ...node,
+                style: {
+                  ...node.style,
+                  cancel: cancelId,
+                },
+              };
+            }
+          }
+          return node;
+        },
+      },
+      [],
+    );
+
+    return {
+      ...state,
+      row: newRow,
+    };
+  }
+
   return state;
 };


### PR DESCRIPTION
This is the last bit of functionality that was missing (aside from the vertically stacked equations which I'm going to be deprecating).  Once this PR lands I can start work on removing the zipper-based editor reducer.