### PR TITLE
Add support for accent macros

### DIFF
--- a/packages/editor/src/char/util.ts
+++ b/packages/editor/src/char/util.ts
@@ -221,8 +221,6 @@ export const hasChildren = (node: types.CharNode): node is HasChildren => {
 export const isOperator = (atom: types.CharAtom): boolean => {
   const char = atom.value;
 
-  // We don't include unary +/- in the numerator.  This mimic's mathquill's
-  // behavior.
   const operators = [
     '+',
     '\u2212', // \minus

--- a/packages/editor/src/reducer/reducers/__tests__/macro.test.ts
+++ b/packages/editor/src/reducer/reducers/__tests__/macro.test.ts
@@ -3,6 +3,7 @@ import * as b from '../../../char/builders';
 import { toEqualEditorNode } from '../../../test-util';
 import { getReducer } from '../../reducer';
 import * as SelectionUtils from '../../selection-utils';
+import { AccentType } from '../../../shared-types';
 
 import type { Action, State } from '../../types';
 
@@ -10,6 +11,7 @@ expect.extend({ toEqualEditorNode });
 
 const reducer = getReducer({
   pi: '\u03C0',
+  vec: '\u20D7',
 });
 
 describe('#startMacro', () => {
@@ -97,5 +99,31 @@ describe('#completeMacro', () => {
     expect(newState.row).toEqualEditorNode(
       b.row([b.char('x'), b.char('+'), b.char('y')]),
     );
+  });
+
+  it('space should complete a valid accent macro', () => {
+    // Arrange
+    const state: State = {
+      row: b.row([
+        b.char('x'),
+        b.char('+'),
+        b.macro([b.char('v'), b.char('e'), b.char('c')]),
+      ]),
+      selection: SelectionUtils.makeSelection([2, 0], 2),
+      selecting: false,
+    };
+    const action: Action = { type: 'Space' };
+
+    // Act
+    const newState = reducer(state, action);
+
+    // Assert
+    expect(newState.row).toEqualEditorNode(
+      b.row([b.char('x'), b.char('+'), b.accent([], AccentType.Vec)]),
+    );
+    expect(newState.selection).toEqual({
+      anchor: { path: [2, 0], offset: 0 },
+      focus: { path: [2, 0], offset: 0 },
+    });
   });
 });

--- a/packages/editor/src/reducer/reducers/macro.ts
+++ b/packages/editor/src/reducer/reducers/macro.ts
@@ -1,5 +1,6 @@
 import * as b from '../../char/builders';
 import * as t from '../../char/types';
+import { isAccentType } from '../../shared-types';
 
 import * as PathUtils from '../path-utils';
 import * as SelectionUtils from '../selection-utils';
@@ -95,7 +96,9 @@ export const completeMacro = (
           state.row,
           grandparentPath,
           (node) => {
-            const newNode = b.char(macroValue);
+            const newNode = isAccentType(macroString)
+              ? b.accent([], macroString)
+              : b.char(macroValue);
             const beforeMacro = node.children.slice(0, index);
             const afterMacro = node.children.slice(index + 1);
             return {
@@ -106,10 +109,15 @@ export const completeMacro = (
         );
 
         if (newRow !== state.row) {
-          const newFocus = {
-            path: grandparentPath,
-            offset: index + 1,
-          };
+          const newFocus = isAccentType(macroString)
+            ? {
+                path: [...grandparentPath, index, 0],
+                offset: 0,
+              }
+            : {
+                path: grandparentPath,
+                offset: index + 1,
+              };
 
           return {
             ...state,

--- a/packages/tex/src/macros.ts
+++ b/packages/tex/src/macros.ts
@@ -80,6 +80,16 @@ export const macros: Record<string, string> = {
   uparrow: '\u2191',
   downarrow: '\u2193',
 
+  // accents
+  vec: '\u20d7',
+  hat: '\u0302',
+  bar: '\u0304',
+  acute: '\u0301',
+  grave: '\u0300',
+  tilde: '\u0303',
+  dot: '\u0307',
+  ddot: '\u0308',
+
   // trig functions
   sin: 'sin',
   cos: 'cos',


### PR DESCRIPTION
Before this PR there was no way to enter `\vec{a}` in the editor.  Now there is.