### PR TITLE
Add function to produce a normalized string representation of the Semantic AST

### DIFF
--- a/packages/editor/src/reducer/reducers/macro.ts
+++ b/packages/editor/src/reducer/reducers/macro.ts
@@ -42,7 +42,6 @@ export const startMacro = (state: State): State => {
     path: [...focus.path, start, 0],
     offset: 0,
   };
-  console.log(newFocus);
 
   return {
     ...state,

--- a/packages/react/src/mathml-renderer.tsx
+++ b/packages/react/src/mathml-renderer.tsx
@@ -17,7 +17,7 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
       for (const arg of math.args) {
         if (arg.type === NodeType.Neg && arg.subtraction) {
           children.push(<mo>-</mo>);
-        } else if (arg.type === NodeType.PlusMinus && arg.arity === 'binary') {
+        } else if (arg.type === NodeType.PlusMinus && arg.args.length === 2) {
           children.push(<mo>±</mo>);
         } else {
           children.push(<mo>+</mo>);
@@ -79,13 +79,16 @@ const print = (math: Semantic.types.Node): React.ReactElement | null => {
       );
     }
     case NodeType.PlusMinus: {
-      const arg = print(math.arg);
-      return math.arity === 'binary' ? (
-        arg
+      return math.args.length === 2 ? (
+        <mrow>
+          {print(math.args[0])}
+          <mo>±</mo>
+          {print(math.args[1])}
+        </mrow>
       ) : (
         <mrow>
           <mo>±</mo>
-          {arg}
+          {print(math.args[0])}
         </mrow>
       );
     }

--- a/packages/semantic/src/__tests__/normalize.test.ts
+++ b/packages/semantic/src/__tests__/normalize.test.ts
@@ -1,0 +1,231 @@
+import { builders } from '..';
+import { print } from '../normalize';
+import { Node } from '../types';
+import { NodeType } from '../enums';
+import { getId } from '@math-blocks/core';
+
+describe('normalize', () => {
+  test('3 + 2 + 1', () => {
+    const ast = builders.add([
+      builders.number('3'),
+      builders.number('2'),
+      builders.number('1'),
+    ]);
+    expect(print(ast)).toEqual('(Add 1 2 3)');
+  });
+
+  test('c + b + a', () => {
+    const ast = builders.add([
+      builders.identifier('c'),
+      builders.identifier('b'),
+      builders.identifier('a'),
+    ]);
+    expect(print(ast)).toEqual('(Add a b c)');
+  });
+
+  test('1 + a + 2 + b', () => {
+    const ast = builders.add([
+      builders.number('1'),
+      builders.identifier('a'),
+      builders.number('2'),
+      builders.identifier('b'),
+    ]);
+    expect(print(ast)).toEqual('(Add 1 2 a b)');
+  });
+
+  test('a - b + -c', () => {
+    const ast = builders.add([
+      builders.number('a'),
+      builders.neg(builders.identifier('b'), true),
+      builders.neg(builders.identifier('b'), false),
+    ]);
+    expect(print(ast)).toMatchInlineSnapshot(`"(Add (neg b) (neg.sub b) a)"`);
+  });
+
+  test('a^2 + b^2 + ab + a^2b + ab^2', () => {
+    const ast = builders.add([
+      builders.pow(builders.identifier('a'), builders.number('2')),
+      builders.pow(builders.identifier('b'), builders.number('2')),
+      builders.mul([builders.identifier('a'), builders.identifier('b')]),
+      builders.mul([
+        builders.pow(builders.identifier('a'), builders.number('2')),
+        builders.identifier('b'),
+      ]),
+      builders.mul([
+        builders.identifier('a'),
+        builders.pow(builders.identifier('b'), builders.number('2')),
+      ]),
+    ]);
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(Add (Power :base a :exp 2) (Power :base b :exp 2) (mul.exp (Power :base a :exp 2),b) (mul.exp a,(Power :base b :exp 2)) (mul.exp a,b))"`,
+    );
+  });
+
+  test('1/a', () => {
+    const ast = builders.div(builders.number('1'), builders.identifier('a'));
+    expect(print(ast)).toEqual('(Div 1 a)');
+  });
+
+  test('(1+a)/(1+a)', () => {
+    const ast = builders.div(
+      builders.add([builders.number('1'), builders.identifier('a')]),
+      builders.add([builders.number('1'), builders.identifier('a')]),
+    );
+    expect(print(ast)).toEqual('1');
+  });
+
+  test('n mod m', () => {
+    const ast: Node = {
+      type: NodeType.Modulo,
+      id: getId(),
+      args: [builders.identifier('n'), builders.identifier('m')],
+    };
+    expect(print(ast)).toMatchInlineSnapshot(`"(Modulo n m)"`);
+  });
+
+  test('root[n]{x}', () => {
+    const ast = builders.root(builders.number('n'), builders.identifier('x'));
+    expect(print(ast)).toMatchInlineSnapshot(`"(Root :radicand n :index x)"`);
+  });
+
+  test('log_n{a}', () => {
+    const ast: Node = {
+      type: NodeType.Log,
+      id: getId(),
+      base: builders.identifier('n'),
+      arg: builders.identifier('a'),
+    };
+    expect(print(ast)).toEqual('(Log :base n :arg a)');
+  });
+
+  test('f(x)', () => {
+    const ast: Node = {
+      type: NodeType.Func,
+      id: getId(),
+      func: builders.identifier('f'),
+      args: [builders.identifier('x')],
+    };
+    expect(print(ast)).toEqual('(Func f x)');
+  });
+
+  test('Pi', () => {
+    const ast: Node = {
+      type: NodeType.Pi,
+      id: getId(),
+    };
+    expect(print(ast)).toMatchInlineSnapshot(`"Pi"`);
+  });
+
+  test('Reals', () => {
+    const ast: Node = {
+      type: NodeType.Reals,
+      id: getId(),
+    };
+    expect(print(ast)).toMatchInlineSnapshot(`"Reals"`);
+  });
+
+  test('Integral', () => {
+    const ast: Node = {
+      type: NodeType.Integral,
+      id: getId(),
+      arg: builders.identifier('x'),
+      bvar: builders.identifier('x'),
+      limits: {
+        lower: { value: builders.number('0'), inclusive: true },
+        upper: { value: builders.number('1'), inclusive: true },
+      },
+    };
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(Integral x :bvar x :limits [0, 1])"`,
+    );
+  });
+
+  test('Limit', () => {
+    const ast: Node = {
+      type: NodeType.Limit,
+      id: getId(),
+      arg: builders.div(builders.number('1'), builders.identifier('x')),
+      bvar: builders.identifier('x'),
+      value: builders.number('0'),
+    };
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(Limit (Div 1 x) :bvar x :value 0)"`,
+    );
+  });
+
+  test('Limit with direction', () => {
+    const ast: Node = {
+      type: NodeType.Limit,
+      id: getId(),
+      arg: builders.div(builders.number('1'), builders.identifier('x')),
+      bvar: builders.identifier('x'),
+      value: builders.number('0'),
+      dir: 'plus',
+    };
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(Limit (Div 1 x) :bvar x :value 0 :dir plus)"`,
+    );
+  });
+
+  test('Derivative', () => {
+    const ast: Node = {
+      type: NodeType.Derivative,
+      id: getId(),
+      arg: builders.pow(builders.identifier('x'), builders.number('2')),
+    };
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(Derivative (Power :base x :exp 2))"`,
+    );
+  });
+
+  test('Derivative with degree', () => {
+    const ast: Node = {
+      type: NodeType.Derivative,
+      id: getId(),
+      arg: builders.pow(builders.identifier('x'), builders.number('2')),
+      degree: 2,
+    };
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(Derivative (Power :base x :exp 2) :degree 2)"`,
+    );
+  });
+
+  test('PartialDerivative', () => {
+    const ast: Node = {
+      type: NodeType.PartialDerivative,
+      id: getId(),
+      arg: builders.mul([
+        builders.pow(builders.identifier('x'), builders.number('3')),
+        builders.pow(builders.identifier('y'), builders.number('2')),
+      ]),
+      degrees: [builders.number('2'), builders.number('1')],
+      variables: [builders.identifier('x'), builders.identifier('y')],
+    };
+    expect(print(ast)).toMatchInlineSnapshot(
+      `"(PartialDerivative (mul.exp (Power :base x :exp 3),(Power :base y :exp 2)) :variables (x y) :degrees (2 1))"`,
+    );
+  });
+
+  test('ElementOf', () => {
+    const ast: Node = {
+      type: NodeType.ElementOf,
+      id: getId(),
+      element: builders.identifier('x'),
+      set: builders.identifier('S'),
+    };
+    expect(print(ast)).toMatchInlineSnapshot(`"(ElementOf x S)"`);
+  });
+
+  test('LongAddition', () => {
+    const ast: Node = {
+      type: NodeType.LongAddition,
+      id: getId(),
+      terms: [],
+      sum: [],
+      carries: [],
+    };
+    expect(() => print(ast)).toThrowErrorMatchingInlineSnapshot(
+      `"we don't handle serializing 'LongAddition' nodes yet"`,
+    );
+  });
+});

--- a/packages/semantic/src/enums.ts
+++ b/packages/semantic/src/enums.ts
@@ -84,11 +84,11 @@ export enum NodeType {
   EmptySet = 'EmptySet',
 
   // Well-Kwown Number Theory Sets
-  Naturals = 'naturals',
-  Integers = 'integers',
-  Rationals = 'rationals',
-  Reals = 'reals',
-  Complexes = 'complexes',
+  Naturals = 'Naturals',
+  Integers = 'Integers',
+  Rationals = 'Rationals',
+  Reals = 'Reals',
+  Complexes = 'Complexes',
 
   // Linear Algebra
   Vector = 'vector',

--- a/packages/semantic/src/normalize.ts
+++ b/packages/semantic/src/normalize.ts
@@ -1,0 +1,152 @@
+import { UnreachableCaseError } from '@math-blocks/core';
+
+import { NodeType } from './enums';
+import { Node, Limits } from './types';
+
+const printLimits = (limits: Limits): string => {
+  const { lower, upper } = limits;
+  const left = lower.inclusive ? '[' : '(';
+  const right = upper.inclusive ? ']' : ')';
+  return `${left}${print(lower.value)}, ${print(upper.value)}${right}`;
+};
+
+// TODO: add an option to normalize the printed AST
+export const print = (ast: Node): string => {
+  switch (ast.type) {
+    case NodeType.Identifier:
+      return ast.name;
+    case NodeType.Number:
+      return `${ast.value}`;
+    case NodeType.Neg: {
+      const type = ast.subtraction ? 'neg.sub' : 'neg';
+      return `(${type} ${print(ast.arg)})`;
+    }
+    case NodeType.LogicalNot:
+    case NodeType.AbsoluteValue:
+    case NodeType.Parens:
+      return `(${ast.type} ${print(ast.arg)})`;
+    case NodeType.Mul: {
+      const type = ast.implicit ? 'mul.imp' : 'mul.exp';
+      return `(${type} ${ast.args.map(print)})`;
+    }
+    // These nodes are commutative
+    case NodeType.Add:
+    case NodeType.PlusMinus:
+    case NodeType.MinusPlus:
+    case NodeType.Union:
+    case NodeType.SetIntersection:
+    case NodeType.Equals:
+    case NodeType.NotEquals:
+    case NodeType.LogicalAnd:
+    case NodeType.LogicalOr:
+    case NodeType.ExclusiveOr:
+    case NodeType.Biconditional: {
+      const args = ast.args.map(print);
+      args.sort();
+      return `(${ast.type} ${args.join(' ')})`;
+    }
+    // These nodes are not commutative
+    case NodeType.Div: {
+      const num = print(ast.args[0]);
+      const den = print(ast.args[1]);
+      // We do this minimize the size of the normalized form
+      if (num === den) {
+        return '1';
+      }
+      return `(${ast.type} ${num} ${den})`;
+    }
+    case NodeType.Modulo:
+    case NodeType.Conditional:
+    case NodeType.LessThan:
+    case NodeType.LessThanOrEquals:
+    case NodeType.GreaterThan:
+    case NodeType.GreaterThanOrEquals:
+    case NodeType.Set:
+    case NodeType.SetDifference:
+    case NodeType.CartesianProduct:
+    case NodeType.Subset:
+    case NodeType.ProperSubset:
+    case NodeType.NotSubset:
+    case NodeType.NotProperSubset: {
+      const args = ast.args.map(print);
+      return `(${ast.type} ${args.join(' ')})`;
+    }
+    case NodeType.Root: {
+      const radicand = print(ast.radicand);
+      const index = print(ast.index);
+      return `(${ast.type} :radicand ${radicand} :index ${index})`;
+    }
+    case NodeType.Power: {
+      const base = print(ast.base);
+      const exp = print(ast.exp);
+      return `(${ast.type} :base ${base} :exp ${exp})`;
+    }
+    case NodeType.Log: {
+      const base = print(ast.base);
+      const arg = print(ast.arg);
+      return `(${ast.type} :base ${base} :arg ${arg})`;
+    }
+    case NodeType.Infinity:
+    case NodeType.Pi:
+    case NodeType.Ellipsis:
+    case NodeType.True:
+    case NodeType.False:
+    case NodeType.Naturals:
+    case NodeType.Integers:
+    case NodeType.Rationals:
+    case NodeType.Reals:
+    case NodeType.Complexes:
+    case NodeType.EmptySet:
+      return ast.type;
+    case NodeType.Func: {
+      const func = print(ast.func);
+      const args = ast.args.map(print);
+      return `(Func ${func} ${args.join(' ')})`;
+    }
+    case NodeType.Product:
+    case NodeType.Summation:
+    case NodeType.Integral: {
+      const arg = print(ast.arg);
+      const bvar = print(ast.bvar);
+      const limits = printLimits(ast.limits);
+      return `(${ast.type} ${arg} :bvar ${bvar} :limits ${limits})`;
+    }
+    case NodeType.Limit: {
+      const arg = print(ast.arg);
+      const bvar = print(ast.bvar);
+      const value = print(ast.value);
+      return ast.dir
+        ? `(${ast.type} ${arg} :bvar ${bvar} :value ${value} :dir ${ast.dir})`
+        : `(${ast.type} ${arg} :bvar ${bvar} :value ${value})`;
+    }
+    case NodeType.Derivative: {
+      const arg = print(ast.arg);
+      return ast.degree != undefined
+        ? `(${ast.type} ${arg} :degree ${ast.degree})`
+        : `(${ast.type} ${arg})`;
+    }
+    case NodeType.PartialDerivative: {
+      const arg = print(ast.arg);
+      // TODO: sort these
+      const variables = ast.variables.map(print).join(' ');
+      const degrees = ast.degrees.map(print).join(' ');
+      return `(${ast.type} ${arg} :variables (${variables}) :degrees (${degrees}))`;
+    }
+    case NodeType.ElementOf:
+    case NodeType.NotElementOf: {
+      const element = print(ast.element);
+      const set = print(ast.set);
+      return `(${ast.type} ${element} ${set})`;
+    }
+    case NodeType.LongAddition:
+    case NodeType.LongSubtraction:
+    case NodeType.LongMultiplication:
+    case NodeType.LongDivision:
+    case NodeType.VerticalAdditionToRelation: {
+      throw new Error(`we don't handle serializing '${ast.type}' nodes yet`);
+    }
+    default: {
+      throw new UnreachableCaseError(ast);
+    }
+  }
+};

--- a/packages/semantic/src/types.ts
+++ b/packages/semantic/src/types.ts
@@ -99,13 +99,11 @@ export type Neg = Common<NodeType.Neg> & {
 };
 
 export type PlusMinus = Common<NodeType.PlusMinus> & {
-  readonly arg: NumericNode;
-  readonly arity: 'unary' | 'binary';
+  readonly args: OneOrMore<NumericNode>;
 };
 
 export type MinusPlus = Common<NodeType.MinusPlus> & {
-  readonly arg: NumericNode;
-  readonly arity: 'unary' | 'binary';
+  readonly args: OneOrMore<NumericNode>;
 };
 
 /**
@@ -187,7 +185,7 @@ export type Parens = Common<NodeType.Parens> & {
   readonly arg: Node;
 };
 
-type Bound = {
+export type Bound = {
   readonly value: NumericNode;
   readonly inclusive: boolean; // NOTE: if `value` is +Infinity or -Infinity, this should be false
 };
@@ -196,7 +194,7 @@ type Bound = {
  * Used to represent the limits of an operation such as summation, integration,
  * etc.  Not a node itself and has no id.
  */
-type Limits = {
+export type Limits = {
   readonly lower: Bound;
   readonly upper: Bound;
 };
@@ -221,18 +219,14 @@ export type Product = Common<NodeType.Product> & {
   readonly limits: Limits;
 };
 
-type TendsTo = {
-  readonly value: NumericNode;
-  readonly from?: 'above' | 'below';
-};
-
 /**
  * Limit
  */
 export type Limit = Common<NodeType.Limit> & {
   readonly arg: NumericNode;
   readonly bvar: Identifier;
-  readonly tendsTo: TendsTo;
+  readonly value: NumericNode;
+  readonly dir?: 'plus' | 'minus';
 };
 
 /**
@@ -247,9 +241,9 @@ export type Derivative = Common<NodeType.Derivative> & {
  * Partial derivative
  */
 export type PartialDerivative = Common<NodeType.PartialDerivative> & {
-  // TODO: This is insufficient to model high degree partial derivatives
-  // https://www.w3.org/TR/MathML3/chapter4.html#contm.partialdiff
-  readonly args: readonly [NumericNode, NumericNode];
+  readonly arg: NumericNode;
+  readonly variables: readonly Identifier[];
+  readonly degrees: readonly NumericNode[];
 };
 
 /**

--- a/packages/testing/src/serializer.ts
+++ b/packages/testing/src/serializer.ts
@@ -1,4 +1,3 @@
-// import {UnreachableCaseError} from "@math-blocks/core";
 import * as Semantic from '@math-blocks/semantic';
 import { UnreachableCaseError } from '@math-blocks/core';
 


### PR DESCRIPTION
This will be used in various Solver rules in the future such as simplifying multiplication into exponents.