### PR TITLE
Update solver page to support factoring and solving quadratic equations

### DIFF
--- a/demo/src/solver/solver-page.tsx
+++ b/demo/src/solver/solver-page.tsx
@@ -5,6 +5,7 @@ import * as Editor from '@math-blocks/editor';
 import * as Semantic from '@math-blocks/semantic';
 import * as Solver from '@math-blocks/solver';
 import * as Typesetter from '@math-blocks/typesetter';
+import * as Tex from '@math-blocks/tex';
 import { MathEditor, MathRenderer, FontDataContext } from '@math-blocks/react';
 import { getFontData, parse } from '@math-blocks/opentype';
 import type { Font } from '@math-blocks/opentype';
@@ -16,18 +17,10 @@ import Substeps from './substeps';
 
 const operators = Object.keys(macros).filter((key) => key === macros[key]);
 
-const b = Editor.builders;
-const question: Editor.types.CharRow = b.row([
-  b.frac(
-    [
-      b.char('x'),
-      b.subsup(undefined, [b.char('2')]),
-      b.char('x'),
-      b.subsup(undefined, [b.char('4')]),
-    ],
-    [b.char('x'), b.subsup(undefined, [b.char('3')])],
-  ),
-]);
+// const parser = new Tex.Parser('x^2 + 5x + 6 = 0');
+// TODO: Update the TeX parser to convert dashes to the minus sign
+const parser = new Tex.Parser('2x + 3y \u2212 7 = x \u2212 y + 1');
+const question: Editor.types.CharRow = parser.parse();
 
 const safeParse = (input: Editor.types.CharRow): Semantic.types.Node | null => {
   try {
@@ -38,66 +31,106 @@ const safeParse = (input: Editor.types.CharRow): Semantic.types.Node | null => {
 };
 
 // TODO:
-// - show error messages in the UI
 // - provide a UI disclosing sub-steps
 // - use the colorMap option to highlight related nodes between steps
 //   e.g. 2(x + y) -> 2x + 2y the 2s would be the same color, etc.
-// - update MathRenderer to do the typesetting
 
 const SolverPage: React.FunctionComponent = () => {
   const [ast, setAst] = React.useState(safeParse(question));
   const [answer, setAnswer] = React.useState<Editor.types.CharRow | null>(null);
   const [step, setStep] = React.useState<Solver.Step | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [action, setAction] = React.useState<Solver.Problem['type']>(
+    'SolveLinearRelation',
+  );
 
-  const handleSimplify = React.useCallback((): void => {
+  const handleGo = React.useCallback(() => {
     if (!ast) {
       setError("Couldn't parse input");
       return;
     }
-    if (!Semantic.util.isNumeric(ast)) {
-      setError('ast is not a NumericNode');
-      return;
-    }
-    const problem: Solver.Problem = {
-      type: 'SimplifyExpression',
-      expression: ast,
-    };
-    const result = Solver.solveProblem(problem);
-    if (result) {
-      console.log(result);
-      setAnswer(Editor.print(result.answer));
-      setStep(result.steps[0]);
-      setError(null);
-    } else {
-      setError('no solution found');
-    }
-  }, [ast]);
-
-  const handleSolve = React.useCallback((): void => {
-    if (!ast) {
-      setError("Couldn't parse input");
-      return;
-    }
-    if (Semantic.util.isNumericRelation(ast)) {
-      const problem: Solver.Problem = {
-        type: 'SolveLinearRelation',
-        relation: ast,
-        variable: Semantic.builders.identifier('x'),
-      };
-      const result = Solver.solveProblem(problem);
-      if (result) {
-        console.log(result);
+    switch (action) {
+      case 'Factor': {
+        if (ast.type !== 'Add') {
+          setError('ast is not an Add node');
+          return;
+        }
+        const problem: Solver.Problem = {
+          type: 'Factor',
+          expression: ast,
+        };
+        const result = Solver.solveProblem(problem);
+        if (result) {
+          console.log(result);
+          setAnswer(Editor.print(result.answer));
+          setStep(result.steps[0]);
+          setError(null);
+        } else {
+          setError('Expression could not be factored');
+        }
+        break;
+      }
+      case 'SimplifyExpression': {
+        if (!Semantic.util.isNumeric(ast)) {
+          setError('ast is not a NumericNode');
+          return;
+        }
+        const problem: Solver.Problem = {
+          type: 'SimplifyExpression',
+          expression: ast,
+        };
+        const result = Solver.solveProblem(problem);
+        if (!result) {
+          setError('no solution found');
+          return;
+        }
         setAnswer(Editor.print(result.answer));
         setStep(result.steps[0]);
         setError(null);
-      } else {
-        setError('no solution found');
+        break;
       }
-    } else {
-      setError("can't solve something that isn't an equation");
+      case 'SolveLinearRelation': {
+        if (!Semantic.util.isNumericRelation(ast)) {
+          setError("can't solve something that isn't an relation");
+          return;
+        }
+        const problem: Solver.Problem = {
+          type: 'SolveLinearRelation',
+          relation: ast,
+          variable: Semantic.builders.identifier('x'),
+        };
+        const result = Solver.solveProblem(problem);
+        if (!result) {
+          setError('no solution found');
+          return;
+        }
+        setAnswer(Editor.print(result.answer));
+        setStep(result.steps[0]);
+        setError(null);
+        break;
+      }
+      case 'SolveQuadraticEquation': {
+        if (ast.type !== 'Equals') {
+          setError("can't solve something that isn't an equation");
+          return;
+        }
+        const problem: Solver.Problem = {
+          type: 'SolveQuadraticEquation',
+          relation: ast,
+          variable: Semantic.builders.identifier('x'),
+        };
+        const result = Solver.solveProblem(problem);
+        if (!result) {
+          setError('no solution found');
+          return;
+        }
+        setAnswer(Editor.print(result.answer));
+        setStep(result.steps[0]);
+        setError(null);
+        break;
+      }
     }
-  }, [ast]);
+  }, [action, ast]);
 
   const [font, setFont] = React.useState<Font | null>(null);
 
@@ -117,7 +150,7 @@ const SolverPage: React.FunctionComponent = () => {
     return null;
   }
 
-  const fontSize = 64;
+  const fontSize = 24;
   const context: Typesetter.Context = {
     fontData: getFontData(font, 'STIX2'),
     baseFontSize: fontSize,
@@ -130,51 +163,69 @@ const SolverPage: React.FunctionComponent = () => {
 
   const maybeRenderSolution = (): React.ReactNode => {
     if (answer != null) {
-      return <MathRenderer row={answer} />;
+      return <MathRenderer row={answer} fontSize={24} />;
     }
     return null;
   };
 
   const showSolution = answer != null && !error;
 
-  const canSimplify = ast && Semantic.util.isNumeric(ast);
-  const canSolve = ast && Semantic.util.isNumericRelation(ast);
-
   return (
     <FontDataContext.Provider value={context.fontData}>
-      <div style={styles.container}>
-        <div>
-          <div style={styles.label}>Question:</div>
-          {canSimplify && <button onClick={handleSimplify}>Simplify</button>}
-          {canSolve && <button onClick={handleSolve}>Solve</button>}
+      <div style={styles.outer}>
+        <div style={styles.inner}>
+          <h1 style={{ fontFamily: 'sans-serif' }}>Math Blocks: Solver</h1>
+          <div>
+            <MathEditor
+              readonly={false}
+              row={question}
+              onChange={(state) => setAst(safeParse(state.row))}
+              style={{ minWidth: '100%' }}
+              fontSize={24}
+            />
+          </div>
+          <div style={{ marginTop: 8 }}>
+            <select
+              style={{ marginRight: 8 }}
+              value={action}
+              onChange={(event) =>
+                setAction(event.target.value as Solver.Problem['type'])
+              }
+            >
+              <option value="Factor">Factor</option>
+              <option value="SimplifyExpression">Simplify Expression</option>
+              <option value="SolveLinearRelation">Solve Linear Relation</option>
+              <option value="SolveQuadraticEquation">
+                Solve Quadratic Equation
+              </option>
+            </select>
+            <button onClick={handleGo}>Go</button>
+          </div>
+          <div style={styles.gap}></div>
+          {error && <h1>Error</h1>}
+          {error && <h1>{error}</h1>}
+          {showSolution && <div style={styles.label}>Steps:</div>}
+          {showSolution && step && <Substeps start={step.before} step={step} />}
+          {showSolution && <div style={styles.label}>Answer:</div>}
+          {showSolution && maybeRenderSolution()}
         </div>
-        <div>
-          <MathEditor
-            readonly={false}
-            row={question}
-            onChange={(state) => setAst(safeParse(state.row))}
-          />
-        </div>
-        <div style={styles.gap}></div>
-        <div style={styles.gap}></div>
-        {error && <h1>Error</h1>}
-        {error && <h1>{error}</h1>}
-        {showSolution && <div style={styles.label}>Steps:</div>}
-        {showSolution && step && <Substeps start={step.before} step={step} />}
-        {showSolution && <div style={styles.label}>Answer:</div>}
-        {showSolution && maybeRenderSolution()}
       </div>
     </FontDataContext.Provider>
   );
 };
 
 const styles: Record<string, React.CSSProperties> = {
-  container: {
-    display: 'grid',
-    gridTemplateColumns: '200px auto',
+  outer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  inner: {
+    width: 800,
   },
   label: {
     paddingTop: 16,
+    paddingBottom: 12,
     fontSize: 32,
     fontFamily: 'sans-serif',
   },

--- a/demo/src/solver/substeps.tsx
+++ b/demo/src/solver/substeps.tsx
@@ -4,6 +4,7 @@ import * as Editor from '@math-blocks/editor';
 import * as Semantic from '@math-blocks/semantic';
 import * as Solver from '@math-blocks/solver';
 import { MathRenderer } from '@math-blocks/react';
+import { MathStyle } from '@math-blocks/typesetter';
 
 type Props = {
   // Prefix to start numbering from, e.g. 1.2.3
@@ -16,35 +17,40 @@ type Props = {
 };
 
 const Substeps: React.FunctionComponent<Props> = ({ prefix, start, step }) => {
-  let current = start;
-
-  const beforeRow = Editor.print(step.before);
+  const marginBottom = 8;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <MathRenderer row={beforeRow} style={{ marginBottom: 32 }} />
       {step.substeps.map((substep, index) => {
-        const before = current;
-
-        const after = Solver.applyStep(before, substep);
+        const before = substep.before;
+        const beforeRow = Editor.print(substep.before);
         const afterRow = Editor.print(substep.after);
-
-        current = after;
 
         const num = prefix ? `${prefix}.${index + 1}` : `${index + 1}`;
 
         return (
           <React.Fragment key={index + 1}>
-            <div>
-              {num}: {substep.message}
+            <div style={{ paddingBottom: 4, fontFamily: 'sans-serif' }}>
+              {num}: {printStep(substep)}
             </div>
+            <MathRenderer
+              row={beforeRow}
+              style={{ marginBottom: marginBottom }}
+              fontSize={24}
+            />
             {/* TODO: special case substeps.length === 1 */}
             {substep.substeps.length > 0 && (
               <div style={{ paddingLeft: 64 }}>
                 <Substeps prefix={num} start={before} step={substep} />
               </div>
             )}
-            {<MathRenderer row={afterRow} style={{ marginBottom: 32 }} />}
+            {
+              <MathRenderer
+                row={afterRow}
+                style={{ marginBottom: marginBottom }}
+                fontSize={24}
+              />
+            }
           </React.Fragment>
         );
       })}
@@ -53,3 +59,39 @@ const Substeps: React.FunctionComponent<Props> = ({ prefix, start, step }) => {
 };
 
 export default Substeps;
+
+const printStep = (step: Solver.Step): React.ReactNode => {
+  switch (step.message) {
+    case 'do the same operation to both sides': {
+      const { operation, value } = step;
+      const renderedValue = (
+        <MathRenderer
+          row={Editor.print(value)}
+          fontSize={18}
+          mathStyle={MathStyle.Display}
+        />
+      );
+      switch (operation) {
+        case 'add': {
+          return <span>Add {renderedValue} from both sides</span>;
+        }
+        case 'sub': {
+          return <span>Subtract {renderedValue} from both sides</span>;
+        }
+        case 'mul': {
+          return <span>Multiply both sides by {renderedValue}</span>;
+        }
+        case 'div': {
+          return <span>Divide both sides by {renderedValue}</span>;
+        }
+      }
+      break;
+    }
+    case 'move matching variable terms to one side': {
+      const { side } = step;
+      return <span>Move matching variable terms to the {side} side</span>;
+    }
+    default:
+      return <span>{step.message}</span>;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/testing-library__jest-dom": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^29.7.0",

--- a/packages/editor/src/printer/printer.ts
+++ b/packages/editor/src/printer/printer.ts
@@ -26,6 +26,15 @@ const getChildren = (
   return children;
 };
 
+const separators = {
+  [Semantic.NodeType.Equals]: '=',
+  [Semantic.NodeType.LessThan]: '<',
+  [Semantic.NodeType.GreaterThan]: '>',
+  [Semantic.NodeType.LessThanOrEquals]: '\u2264',
+  [Semantic.NodeType.GreaterThanOrEquals]: '\u2265',
+  ['Sequence']: ', ',
+};
+
 // TODO: write more tests for this
 const _print = (
   expr: Semantic.types.Node,
@@ -168,19 +177,17 @@ const _print = (
       );
     }
     case Semantic.NodeType.LessThan:
+    case Semantic.NodeType.LessThanOrEquals:
     case Semantic.NodeType.GreaterThan:
-    case Semantic.NodeType.Equals: {
+    case Semantic.NodeType.GreaterThanOrEquals:
+    case Semantic.NodeType.Equals:
+    case 'Sequence': {
       const children: types.CharNode[] = [];
+      const separator = separators[expr.type];
 
       for (const arg of expr.args) {
         children.push(...getChildren(arg, oneToOne));
-        if (expr.type === Semantic.NodeType.Equals) {
-          children.push(builders.char('='));
-        } else if (expr.type === Semantic.NodeType.LessThan) {
-          children.push(builders.char('<'));
-        } else if (expr.type === Semantic.NodeType.GreaterThan) {
-          children.push(builders.char('>'));
-        }
+        children.push(builders.char(separator));
       }
 
       children.pop(); // remove extra "="

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-accents-should-render-accents.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-accents-should-render-accents.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 386 78" width="386" height="78" style="vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 386 78" width="386" height="78" style="vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.12000000000000455)">
         <g transform="translate(0,64.08)" id="17">
             <g transform="translate(0,0)">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-accents-should-render-empty-accents.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-accents-should-render-empty-accents.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 227 82" width="227" height="82" style="vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 227 82" width="227" height="82" style="vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.21999999999999886)">
         <g transform="translate(0,67.98)" id="10">
             <g transform="translate(0,0)">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cancelling-multiple-selections-side-by-side,-frac,-radicand.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cancelling-multiple-selections-side-by-side,-frac,-radicand.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 439 143" width="439" height="143" style="background:white;vertical-align:-56px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 439 143" width="439" height="143" style="background:white;vertical-align:-55px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.9199999999999875)">
         <g transform="translate(0,86.52000000000001)" id="14">
             <g transform="translate(64.14,0)" id="2"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-front-of-operator.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-front-of-operator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 139 60" width="139" height="60" style="vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 139 60" width="139" height="60" style="vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,46.2)" id="3">
             <rect type="rect" x="29.2" y="-46.2" width="1" height="60" class="blink" stroke="none"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-cursor-cursor-in-the-middle.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 301 60" width="301" height="60" style="background:white;vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 301 60" width="301" height="60" style="background:white;vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,46.2)" id="7">
             <rect type="rect" x="29.2" y="-46.2" width="1" height="60" class="blink" stroke="none"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-equation.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 301 42" width="301" height="42" style="background:white;vertical-align:-3px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 301 42" width="301" height="42" style="background:white;vertical-align:-2px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.9600000000000009)">
         <g transform="translate(0,38.64)" id="7">
             <g transform="translate(63.239999999999995,0)" id="2"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-colorized.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 52 114" width="52" height="114" style="background:white;vertical-align:-49px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 52 114" width="52" height="114" style="background:white;vertical-align:-48px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.8100000000000023)">
         <g transform="translate(0,64.86)" id="8">
             <g transform="translate(0,-15.48)" id="5">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-fractions-quadratic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 530 133" width="530" height="133" style="background:white;vertical-align:-35px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 530 133" width="530" height="133" style="background:white;vertical-align:-34px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.339999999999975)">
         <g transform="translate(0,97.74000000000001)" id="20">
             <g transform="translate(33.54,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-latin-modern-equation.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-latin-modern-equation.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 310 45" width="310" height="45" style="background:white;vertical-align:-5px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 310 45" width="310" height="45" style="background:white;vertical-align:-4px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.060000000000002274)">
         <g transform="translate(0,39.96)" id="7">
             <g transform="translate(64.32,0)" id="2"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-latin-modern-tall-delimiters,-root,-and-fraction.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-latin-modern-tall-delimiters,-root,-and-fraction.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 505 111" width="505" height="111" style="background:white;vertical-align:-39px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 505 111" width="505" height="111" style="background:white;vertical-align:-38px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.47999999999998977)">
         <g transform="translate(0,71.76)" id="21">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-integral-(display).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-integral-(display).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 194 164" width="194" height="164" style="background:white;vertical-align:-66px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 194 164" width="194" height="164" style="background:white;vertical-align:-65px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.13999999999998636)">
         <g transform="translate(0,98.77799999999999)" id="13">
             <g transform="translate(0,0)">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-integral-(inline).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-integral-(inline).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 169 81" width="169" height="81" style="background:white;vertical-align:-24px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 169 81" width="169" height="81" style="background:white;vertical-align:-23px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7199999999999989)">
         <g transform="translate(0,56.658)" id="13">
             <g transform="translate(0,0)">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim-(display).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim-(display).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 131 106" width="131" height="106" style="background:white;vertical-align:-60px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 131 106" width="131" height="106" style="background:white;vertical-align:-59px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,46.2)" id="10">
             <g transform="translate(0,0)" id="7">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim-(inline).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-lim-(inline).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 213 80" width="213" height="80" style="background:white;vertical-align:-34px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 213 80" width="213" height="80" style="background:white;vertical-align:-33px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7400000000000091)">
         <g transform="translate(0,46.2)" id="10">
             <g transform="translate(0,0)">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum-(display).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum-(display).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 114 114" width="114" height="114" style="background:white;vertical-align:-49px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 114 114" width="114" height="114" style="background:white;vertical-align:-48px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.8100000000000023)">
         <g transform="translate(0,64.86)" id="16">
             <g transform="translate(0,0)" id="5">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum-(inline).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-limits-sum-(inline).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 139 79" width="139" height="79" style="background:white;vertical-align:-30px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 139 79" width="139" height="79" style="background:white;vertical-align:-29px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.5889999999999986)">
         <g transform="translate(0,48.438)" id="16">
             <g transform="translate(0,0)">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-macro-in-progress-macro.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-macro-in-progress-macro.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 285 60" width="285" height="60" style="background:white;vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 285 60" width="285" height="60" style="background:white;vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,46.2)" id="8">
             <g transform="translate(33.54,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-named-operators-should-not-include-trailing-padding-with-subscript.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-named-operators-should-not-include-trailing-padding-with-subscript.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 173 80" width="173" height="80" style="vertical-align:-34px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 173 80" width="173" height="80" style="vertical-align:-33px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.4399999999999977)">
         <g transform="translate(0,46.2)" id="8">
             <g transform="translate(29.7,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-named-operators-should-not-include-trailing-padding-with-superscript.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-named-operators-should-not-include-trailing-padding-with-superscript.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 172 69" width="172" height="69" style="vertical-align:-23px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 172 69" width="172" height="69" style="vertical-align:-22px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.539999999999992)">
         <g transform="translate(0,46.2)" id="8">
             <g transform="translate(29.7,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-named-operators-should-render-the-operator-with-space-before-after-it.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-named-operators-should-render-the-operator-with-space-before-after-it.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 163 61" width="163" height="61" style="vertical-align:-15px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 163 61" width="163" height="61" style="vertical-align:-14px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.6999999999999957)">
         <g transform="translate(0,46.2)" id="5">
             <g transform="translate(29.7,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-latin-modern-with-degree-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-latin-modern-with-degree-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 99 72" width="99" height="72" style="background:white;vertical-align:-19px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 99 72" width="99" height="72" style="background:white;vertical-align:-18px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,53.4)" id="5">
             <g transform="translate(0,0)" id="2">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-latin-modern-with-large-degree-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-latin-modern-with-large-degree-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 116 149" width="116" height="149" style="background:white;vertical-align:-66px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 116 149" width="116" height="149" style="background:white;vertical-align:-65px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.19999999999998863)">
         <g transform="translate(0,83.4)" id="11">
             <g transform="translate(0,-15)" id="8">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-stix-with-degree-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-stix-with-degree-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 88 72" width="88" height="72" style="background:white;vertical-align:-15px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 88 72" width="88" height="72" style="background:white;vertical-align:-14px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7800000000000011)">
         <g transform="translate(0,56.28)" id="5">
             <g transform="translate(0,0)" id="2">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-stix-with-large-degree-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-radicals-stix-with-large-degree-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 125 154" width="125" height="154" style="background:white;vertical-align:-67px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 125 154" width="125" height="154" style="background:white;vertical-align:-66px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.6999999999999886)">
         <g transform="translate(0,86.52000000000001)" id="11">
             <g transform="translate(0,-15.48)" id="8">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-selection-selection-in-the-middle.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 301 60" width="301" height="60" style="background:white;vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 301 60" width="301" height="60" style="background:white;vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,46.2)" id="7">
             <rect type="rect" x="166.14" y="-46.2" width="73.2" height="60" stroke="none" fill="Highlight"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-1-cursor-at-the-end.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-1-cursor-at-the-end.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-2-cursor-in-superscript.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-2-cursor-in-superscript.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-3-cursor-in-subscript.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-3-cursor-in-subscript.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-4-cursor-inside-delimited.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-cursor-with-tall-delimiters-4-cursor-inside-delimited.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-latin-modern-on-tall-delimiters-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-latin-modern-on-tall-delimiters-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 472 183" width="472" height="183" style="background:white;vertical-align:-80px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 472 183" width="472" height="183" style="background:white;vertical-align:-79px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.4800000000000182)">
         <g transform="translate(0,103.26)" id="20">
             <g transform="translate(34.32,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-latin-modern-stress-test-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-latin-modern-stress-test-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 228 109" width="228" height="109" style="background:white;vertical-align:-39px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 228 109" width="228" height="109" style="background:white;vertical-align:-38px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.652000000000001)">
         <g transform="translate(0,70.014)" id="25">
             <g transform="translate(34.32,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-1-selection-in-denominator.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-1-selection-in-denominator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-2-fraction-selected.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-2-fraction-selected.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-3-delimited-selected.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-3-delimited-selected.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <rect type="rect" x="0" y="-94.92" width="203.94" height="157.44" stroke="none" fill="Highlight"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-4-subsup-selected.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-selection-with-tall-delimiters-4-subsup-selected.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 230 196" width="230" height="196" style="vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="16">
             <rect type="rect" x="203.94" y="-113.46000000000001" width="23.73" height="195.24" stroke="none" fill="Highlight"></rect>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-stix-on-tall-delimiters-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-stix-on-tall-delimiters-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 440 196" width="440" height="196" style="background:white;vertical-align:-82px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 440 196" width="440" height="196" style="background:white;vertical-align:-81px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.7599999999999909)">
         <g transform="translate(0,113.46000000000001)" id="20">
             <g transform="translate(33.54,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-stix-stress-test-(dynamic).svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-stix-stress-test-(dynamic).svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 223 110" width="223" height="110" style="background:white;vertical-align:-37px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 223 110" width="223" height="110" style="background:white;vertical-align:-36px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.6200000000000045)">
         <g transform="translate(0,72.99)" id="25">
             <g transform="translate(33.54,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-subsup-consistency.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subscript-and-superscripts-subsup-consistency.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 187 93" width="187" height="93" style="vertical-align:-29px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 187 93" width="187" height="93" style="vertical-align:-28px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0)">
         <g transform="translate(0,64.8)" id="16">
             <g transform="translate(33.54,0)" id="2">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-pythagoras.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 300 58" width="300" height="58" style="background:white;vertical-align:-3px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 300 58" width="300" height="58" style="background:white;vertical-align:-2px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.05200000000000671)">
         <g transform="translate(0,55.547999999999995)" id="14">
             <g transform="translate(33.3,0)" id="2">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-subsup-subscripts.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 422 55" width="422" height="55" style="background:white;vertical-align:-14px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 422 55" width="422" height="55" style="background:white;vertical-align:-13px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.26200000000000045)">
         <g transform="translate(0,41.717999999999996)" id="18">
             <g transform="translate(33.3,0)" id="2">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tables-3x3-bracket-matrix.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 478 187" width="478" height="187" style="background:white;vertical-align:-77px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 478 187" width="478" height="187" style="background:white;vertical-align:-76px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.9399999999999977)">
         <g transform="translate(0,109.2)" id="25">
             <g transform="translate(43.08,0)" id="1"></g>

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-no-cursor,-no-selection.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-no-cursor,-no-selection.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 485 116" width="485" height="116" style="background:white;vertical-align:-41px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 485 116" width="485" height="116" style="background:white;vertical-align:-40px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.0800000000000125)">
         <g transform="translate(0,74.94)" id="21">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-cursor.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-cursor.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 502 160" width="502" height="160" style="background:white;vertical-align:-63px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 502 160" width="502" height="160" style="background:white;vertical-align:-62px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.8799999999999955)">
         <g transform="translate(0,96.60000000000001)" id="21">
             <g transform="translate(0,0)" id="9">

--- a/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-selection.svg
+++ b/packages/react/src/__tests__/__snapshots__/renderer.test.tsx-renderer-tall-delimiters-with-selection.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 502 160" width="502" height="160" style="background:white;vertical-align:-63px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 502 160" width="502" height="160" style="background:white;vertical-align:-62px">
     <g fill="currentColor" stroke="currentColor" transform="translate(0,0.8799999999999955)">
         <g transform="translate(0,96.60000000000001)" id="21">
             <rect type="rect" x="206.88" y="-46.2" width="73.2" height="60" stroke="none" fill="Highlight"></rect>

--- a/packages/react/src/math-renderer.tsx
+++ b/packages/react/src/math-renderer.tsx
@@ -65,7 +65,7 @@ export const MathRenderer = React.forwardRef<SVGSVGElement, Props>(
         showHitboxes={showHitboxes}
         style={{
           ...style,
-          verticalAlign: -Math.ceil(depth),
+          verticalAlign: 1 - Math.ceil(depth),
         }}
       />
     );

--- a/packages/react/src/math-renderer.tsx
+++ b/packages/react/src/math-renderer.tsx
@@ -65,7 +65,7 @@ export const MathRenderer = React.forwardRef<SVGSVGElement, Props>(
         showHitboxes={showHitboxes}
         style={{
           ...style,
-          verticalAlign: 1 - Math.ceil(depth),
+          verticalAlign: -Math.floor(depth),
         }}
       />
     );

--- a/packages/solver/src/__tests__/solve-problem.test.ts
+++ b/packages/solver/src/__tests__/solve-problem.test.ts
@@ -47,7 +47,7 @@ describe('solveProblem', () => {
     const ast = parseNumRel('x^2 + 5x + 6 = 0');
 
     const problem: Problem = {
-      type: 'SolveQuadraticRelation',
+      type: 'SolveQuadraticEquation',
       relation: ast,
       variable: Semantic.builders.identifier('x'),
     };

--- a/packages/solver/src/solve-problem.ts
+++ b/packages/solver/src/solve-problem.ts
@@ -39,7 +39,7 @@ export function solveProblem(problem: Problem): Solution | void {
     return;
   }
 
-  if (problem.type === 'SolveQuadraticRelation') {
+  if (problem.type === 'SolveQuadraticEquation') {
     const step = solveQuadratic(problem.relation, problem.variable);
     if (step) {
       return {

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -47,7 +47,6 @@ export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'reduce fraction', TNode>
   | StepType<'simplify multiplication', TNode>
   | StepType<'solve for variable', TNode>
-  // TODO: combine all of these into a single step type
   | StepType<
       'do the same operation to both sides',
       TNode,
@@ -100,8 +99,8 @@ type SolveLinearRelation = {
   readonly variable: Semantic.types.Identifier;
 };
 
-type SolveQuadraticRelation = {
-  readonly type: 'SolveQuadraticRelation';
+type SolveQuadraticEquation = {
+  readonly type: 'SolveQuadraticEquation';
   readonly relation: Semantic.types.NumericRelation;
   readonly variable: Semantic.types.Identifier;
 };
@@ -110,7 +109,7 @@ export type Problem =
   | Factor
   | SimplifyExpression
   | SolveLinearRelation
-  | SolveQuadraticRelation;
+  | SolveQuadraticEquation;
 
 export type Transform = (
   node: Semantic.types.Node,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,9 @@
 import path from 'path';
 import { defineConfig } from 'vite';
-import reactRefresh from '@vitejs/plugin-react-refresh';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [reactRefresh()],
+  plugins: [react()],
   resolve: {
     alias: [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,14 +869,14 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.25.9"
 
-"@babel/plugin-transform-react-jsx-self@^7.14.5":
+"@babel/plugin-transform-react-jsx-self@^7.14.5", "@babel/plugin-transform-react-jsx-self@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz#c0b6cae9c1b73967f7f9eb2fca9536ba2fad2858"
   integrity sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-react-jsx-source@^7.14.5":
+"@babel/plugin-transform-react-jsx-source@^7.14.5", "@babel/plugin-transform-react-jsx-source@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz#4c6b8daa520b5f155b5fb55547d7c9fa91417503"
   integrity sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==
@@ -3944,7 +3944,7 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
   integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
-"@types/babel__core@^7.1.14":
+"@types/babel__core@^7.1.14", "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -4447,6 +4447,17 @@
     "@babel/plugin-transform-react-jsx-source" "^7.14.5"
     "@rollup/pluginutils" "^4.1.1"
     react-refresh "^0.10.0"
+
+"@vitejs/plugin-react@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz#c64be10b54c4640135a5b28a2432330e88ad7c20"
+  integrity sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==
+  dependencies:
+    "@babel/core" "^7.26.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.25.9"
+    "@babel/plugin-transform-react-jsx-source" "^7.25.9"
+    "@types/babel__core" "^7.20.5"
+    react-refresh "^0.14.2"
 
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
@@ -13998,6 +14009,11 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-refresh@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
+  integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
 react-router-dom@^6.28.0:
   version "6.28.0"


### PR DESCRIPTION
Users have to select what action they want to take from a dropdown.  We're still limited to only solving for `x` though.  I've also modified how the steps are rendered so that the font is smaller and so that the before and after expressions are rendered for each step.  In a future PR I'll make the steps collapsable.

<img width="1072" alt="Capture d’écran, le 2024-12-22 à 19 20 30" src="https://github.com/user-attachments/assets/579b7be6-1f0d-4bb9-b9cd-6c3fb054a7a4" />
