### PR TITLE
Include dropping zeros as part of collecting like terms

### DIFF
--- a/demo/src/solver/substeps.tsx
+++ b/demo/src/solver/substeps.tsx
@@ -38,8 +38,7 @@ const Substeps: React.FunctionComponent<Props> = ({ prefix, start, step }) => {
               style={{ marginBottom: marginBottom }}
               fontSize={24}
             />
-            {/* TODO: special case substeps.length === 1 */}
-            {substep.substeps.length > 0 && (
+            {substep.substeps.length > 1 && (
               <div style={{ paddingLeft: 64 }}>
                 <Substeps prefix={num} start={before} step={substep} />
               </div>
@@ -92,6 +91,16 @@ const printStep = (step: Solver.Step): React.ReactNode => {
       return <span>Move matching variable terms to the {side} side</span>;
     }
     default:
-      return <span>{step.message}</span>;
+      if (step.substeps.length === 1) {
+        if (step.message === 'simplify the left hand side') {
+          return <span>{step.substeps[0].message} on the left hand side</span>;
+        }
+        if (step.message === 'simplify the right hand side') {
+          return <span>{step.substeps[0].message} on the right hand side</span>;
+        }
+        return <span>{step.message}</span>;
+      } else {
+        return <span>{step.message}</span>;
+      }
   }
 };

--- a/packages/solver/src/simplify/transforms/__tests__/collect-like-terms.test.ts
+++ b/packages/solver/src/simplify/transforms/__tests__/collect-like-terms.test.ts
@@ -449,4 +449,70 @@ describe('collect like terms', () => {
       expect(Testing.print(step.after)).toEqual('2 - x');
     });
   });
+
+  describe('canceling terms', () => {
+    test('8 + 2x - 2x -> 8', () => {
+      const ast = Testing.parse('8 + 2x - 2x');
+
+      const step = collectLikeTerms(ast);
+
+      expect(step.message).toEqual('collect like terms');
+      expect(Testing.print(step.after)).toMatchInlineSnapshot(`"8"`);
+
+      expect(step.substeps.map((substep) => substep.message)).toEqual([
+        'subtraction is the same as adding the inverse',
+        'factor variable part of like terms', // substeps
+        'compute new coefficients', // substeps
+        'drop adding zero',
+      ]);
+
+      const substeps = [
+        Testing.print(step.before),
+        ...step.substeps.map((substep) => Testing.print(substep.after)),
+      ];
+
+      expect(substeps).toMatchInlineSnapshot(`
+        [
+          "8 + 2x - 2x",
+          "8 + 2x + -2x",
+          "8 + 0",
+          "8 + 0",
+          "8",
+        ]
+      `);
+    });
+
+    test('2x - 2x - 8 -> -8', () => {
+      const ast = Testing.parse('2x - 2x - 8');
+
+      const step = collectLikeTerms(ast);
+
+      expect(step.message).toEqual('collect like terms');
+      expect(Testing.print(step.after)).toMatchInlineSnapshot(`"-8"`);
+
+      expect(step.substeps.map((substep) => substep.message)).toEqual([
+        'subtraction is the same as adding the inverse',
+        'factor variable part of like terms', // substeps
+        'compute new coefficients', // substeps
+        'adding the inverse is the same as subtraction',
+        'drop adding zero',
+      ]);
+
+      const substeps = [
+        Testing.print(step.before),
+        ...step.substeps.map((substep) => Testing.print(substep.after)),
+      ];
+
+      expect(substeps).toMatchInlineSnapshot(`
+        [
+          "2x - 2x - 8",
+          "2x + -2x + -8",
+          "0 + -8",
+          "0 + -8",
+          "0 - 8",
+          "-8",
+        ]
+      `);
+    });
+  });
 });

--- a/packages/solver/src/simplify/transforms/collect-like-terms.ts
+++ b/packages/solver/src/simplify/transforms/collect-like-terms.ts
@@ -3,6 +3,7 @@ import * as Testing from '@math-blocks/testing';
 
 import { simplifyMul } from '../util';
 import { getCoeff } from '../../solve-linear/util';
+import { dropAddIdentity } from './drop-add-identity';
 
 import type { Step } from '../../types';
 
@@ -29,10 +30,19 @@ export function collectLikeTerms(
     return;
   }
 
+  // TODO: check if two terms are the same and if so, cancel them directly
+  // instead of subtracting and then dropping the zero.
+
   let newNode = groupTerms(orderedSum, groups, substeps);
   newNode = evaluteCoeffs(newNode, substeps);
   newNode = simplifyTerms(newNode, substeps);
   newNode = addNegToSub(newNode, substeps);
+
+  const step = dropAddIdentity(newNode);
+  if (step) {
+    substeps.push(step);
+    newNode = step.after;
+  }
 
   return {
     message: 'collect like terms',


### PR DESCRIPTION
This PR also simplifies the rendering of steps/substeps in SolverPage by collapsing a level of nesting when there's only a single substep.