### PR TITLE
add initial support for differentiation to @math-blocks/solver

### DIFF
--- a/.changeset/nasty-pants-fry.md
+++ b/.changeset/nasty-pants-fry.md
@@ -1,0 +1,5 @@
+---
+'@math-blocks/solver': patch
+---
+
+Initial support for differentiation

--- a/packages/solver/src/differentiate/__tests__/differentiate.test.ts
+++ b/packages/solver/src/differentiate/__tests__/differentiate.test.ts
@@ -1,0 +1,198 @@
+import * as Testing from '@math-blocks/testing';
+
+import { differentiate } from '../differentiate';
+import { Step } from '../../types';
+
+const printSteps = (result: Step): string[] => {
+  return [
+    Testing.print(result.before),
+    ...result.substeps.map(
+      (step) => `${Testing.print(step.after)} - ${step.message}`,
+    ),
+  ];
+};
+
+describe('differentiate', () => {
+  describe('power rule', () => {
+    test('x^3', () => {
+      const node = Testing.parse('x^3');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "x^3",
+          "3x^(3 - 1) - power rule",
+          "3x^2 - simplify expression",
+        ]
+      `);
+    });
+
+    test('x^n', () => {
+      const node = Testing.parse('x^n');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "x^n",
+          "nx^(n - 1) - power rule",
+        ]
+      `);
+    });
+
+    test('x^2 + x', () => {
+      const node = Testing.parse('x^2 + x');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "x^2 + x",
+          "2x + 1 - differentiate",
+        ]
+      `);
+      expect(printSteps(result.substeps[0])).toMatchInlineSnapshot(`
+        [
+          "x^2 + x",
+          "2x - differentiate",
+          "1 - differentiate",
+        ]
+      `);
+    });
+
+    test('x^-1', () => {
+      const node = Testing.parse('x^-1');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "x^(-1)",
+          "-1x^(-1 - 1) - power rule",
+          "-x^(-2) - simplify expression",
+        ]
+      `);
+    });
+
+    test('-x', () => {
+      const node = Testing.parse('-x');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "-x",
+          "-1 - differentiate",
+        ]
+      `);
+    });
+
+    test('3x^2', () => {
+      const node = Testing.parse('3x^2');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "3x^2",
+          "3(2x) - differentiate",
+        ]
+      `);
+    });
+
+    test('(x^2)(3)', () => {
+      const node = Testing.parse('(x^2)(3)');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "(x^2)(3)",
+          "3(2x) - differentiate",
+        ]
+      `);
+    });
+
+    test('x + 1', () => {
+      const node = Testing.parse('x + 1');
+      const result = differentiate(node)!;
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "x + 1",
+          "1 - differentiate",
+        ]
+      `);
+    });
+  });
+
+  describe('exponential functions', () => {
+    test('e^x', () => {
+      const node = Testing.parse('e^x');
+      const result = differentiate(node)!;
+
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "e^x",
+          "1e^x - chain rule",
+          "e^x - simplify expression",
+        ]
+      `);
+    });
+
+    test('e^(-x)', () => {
+      const node = Testing.parse('e^(-x)');
+      const result = differentiate(node)!;
+
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "e^(-x)",
+          "-1e^(-x) - chain rule",
+          "-e^(-x) - simplify expression",
+        ]
+      `);
+    });
+
+    test('e^(x^2)', () => {
+      const node = Testing.parse('e^(x^2)');
+      const result = differentiate(node)!;
+
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "e^(x^2)",
+          "(2x)e^(x^2) - chain rule",
+        ]
+      `);
+    });
+  });
+
+  describe('product rule', () => {
+    test('xe^x', () => {
+      const node = Testing.parse('xe^x');
+      const result = differentiate(node)!;
+
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "xe^x",
+          "e^x + xe^x - product rule",
+        ]
+      `);
+    });
+  });
+
+  describe('quotient rule', () => {
+    test('x/(1+x)', () => {
+      const node = Testing.parse('x/(1+x)');
+      const result = differentiate(node)!;
+
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "x / (1 + x)",
+          "(1(1 + x) - (x)(1)) / (1 + x)^2 - quotient rule",
+          "1 / (1 + x)^2 - simplify expression",
+        ]
+      `);
+    });
+
+    test('(1+x)/1', () => {
+      const node = Testing.parse('(1+x)/1');
+      const result = differentiate(node)!;
+
+      expect(printSteps(result)).toMatchInlineSnapshot(`
+        [
+          "(1 + x) / 1",
+          "1 / 1 - differentiate",
+          "1^0 - simplify expression",
+        ]
+      `);
+    });
+  });
+
+  describe.skip('trig functions', () => {});
+});

--- a/packages/solver/src/differentiate/differentiate.ts
+++ b/packages/solver/src/differentiate/differentiate.ts
@@ -1,0 +1,106 @@
+import { builders, types, util } from '@math-blocks/semantic';
+
+import type { Step } from '../types';
+
+import { powerRule } from './transforms/power';
+import { productRule } from './transforms/product';
+import { quotientRule } from './transforms/quotient';
+import { simplify } from '../simplify/simplify';
+
+// TODO: provide a way to specify which variable we're differentiating with respect to
+export function differentiate(node: types.Node): Step | void {
+  const substeps: Step[] = [];
+
+  switch (node.type) {
+    case 'Add': {
+      const termSteps = node.args
+        .map(differentiate)
+        .filter((step) => step !== undefined);
+      const after = builders.add(
+        termSteps
+          .map((step) => step.after)
+          .filter((node) => !util.deepEquals(node, builders.number('0'))),
+      );
+
+      substeps.push({
+        message: 'differentiate',
+        before: node,
+        after,
+        substeps: termSteps,
+      });
+      break;
+    }
+    case 'Power': {
+      const step = powerRule(differentiate, node);
+      if (step) {
+        substeps.push(step);
+      }
+      break;
+    }
+    case 'Mul': {
+      const step = productRule(differentiate, node);
+      if (step) {
+        substeps.push(step);
+      }
+      break;
+    }
+    case 'Div': {
+      const step = quotientRule(differentiate, node);
+      if (step) {
+        substeps.push(step);
+      }
+      break;
+    }
+    case 'Identifier': {
+      if (node.name === 'x') {
+        return {
+          message: 'differentiate',
+          before: node,
+          after: builders.number('1'),
+          substeps: [],
+        };
+      }
+      break;
+    }
+    case 'Neg': {
+      const argStep = differentiate(node.arg);
+      if (!argStep) {
+        return;
+      }
+      substeps.push({
+        message: 'differentiate',
+        before: node,
+        after: builders.neg(argStep.after),
+        substeps: [argStep],
+      });
+      break;
+    }
+    default: {
+      if (util.isNumber(node)) {
+        return {
+          message: 'differentiate',
+          before: node,
+          after: builders.number('0'),
+          substeps: [],
+        };
+      }
+    }
+  }
+
+  // TODO: simplify
+  let sol = substeps[substeps.length - 1].after;
+  const step = simplify(sol);
+  if (step) {
+    substeps.push(step);
+    sol = step.after;
+  }
+
+  if (substeps.length > 0) {
+    return {
+      message: 'differentiate',
+      before: node,
+      after: sol,
+      substeps,
+    };
+  }
+}

--- a/packages/solver/src/differentiate/transforms/power.ts
+++ b/packages/solver/src/differentiate/transforms/power.ts
@@ -1,0 +1,45 @@
+import { types, builders } from '@math-blocks/semantic';
+
+import type { Step } from '../../types';
+
+export const powerRule = (
+  differentiate: (node: types.Node) => Step | void,
+  node: types.Pow,
+): Step | void => {
+  if (node.base.type === 'Identifier') {
+    if (node.base.name === 'x') {
+      return {
+        message: 'power rule',
+        before: node,
+        after: builders.mul(
+          [
+            node.exp,
+            builders.pow(
+              node.base,
+              builders.add([
+                node.exp,
+                builders.neg(builders.number('1'), true),
+              ]),
+            ),
+          ],
+          true,
+        ),
+        substeps: [],
+      };
+    } else if (node.base.name === 'e') {
+      const step = differentiate(node.exp); // chain rule
+      if (!step) {
+        return;
+      }
+
+      return {
+        message: 'chain rule',
+        before: node,
+        after: builders.mul([step.after, node], true),
+        substeps: [step],
+      };
+    } else {
+      // treat the base as a constant
+    }
+  }
+};

--- a/packages/solver/src/differentiate/transforms/product.ts
+++ b/packages/solver/src/differentiate/transforms/product.ts
@@ -1,0 +1,61 @@
+import { types, builders, util } from '@math-blocks/semantic';
+
+import type { Step } from '../../types';
+
+export const productRule = (
+  differentiate: (node: types.Node) => Step | void,
+  node: types.Mul,
+): Step | void => {
+  const factors = util.getFactors(node);
+
+  const numFactors = factors.filter(util.isNumber);
+  const varFactors = factors.filter((node) => !util.isNumber(node));
+
+  if (numFactors.length > 0) {
+    const step = differentiate(builders.mul(varFactors, true));
+    if (!step) {
+      return;
+    }
+    const sol = builders.mul([...numFactors, step.after], true);
+    return {
+      message: 'differentiate',
+      before: node,
+      after: sol,
+      substeps: [step],
+    };
+  }
+
+  // TODO: handle more than two factors
+  if (factors.length === 2) {
+    const [left, right] = factors;
+
+    const leftStep = differentiate(left);
+    const rightStep = differentiate(right);
+
+    if (!leftStep || !rightStep) {
+      return;
+    }
+
+    const sol = builders.add([
+      builders.mul(
+        [leftStep.after, right].filter(
+          (node) => !util.deepEquals(node, builders.number('1')),
+        ),
+        true,
+      ),
+      builders.mul(
+        [left, rightStep.after].filter(
+          (node) => !util.deepEquals(node, builders.number('1')),
+        ),
+        true,
+      ),
+    ]);
+
+    return {
+      message: 'product rule',
+      before: node,
+      after: sol,
+      substeps: [leftStep, rightStep],
+    };
+  }
+};

--- a/packages/solver/src/differentiate/transforms/quotient.ts
+++ b/packages/solver/src/differentiate/transforms/quotient.ts
@@ -1,0 +1,46 @@
+import { types, builders, util } from '@math-blocks/semantic';
+
+import type { Step } from '../../types';
+
+export const quotientRule = (
+  differentiate: (node: types.Node) => Step | void,
+  node: types.Div,
+): Step | void => {
+  const [num, den] = node.args;
+
+  if (util.isNumber(den)) {
+    const step = differentiate(num);
+    if (!step) {
+      return;
+    }
+
+    return {
+      message: 'differentiate',
+      before: node,
+      after: builders.div(step.after, den),
+      substeps: [step],
+    };
+  }
+
+  const numStep = differentiate(num);
+  const denStep = differentiate(den);
+
+  if (!numStep || !denStep) {
+    return;
+  }
+
+  const after = builders.div(
+    builders.add([
+      builders.mul([numStep.after, den], true),
+      builders.neg(builders.mul([num, denStep.after], true), true),
+    ]),
+    builders.pow(den, builders.number('2')),
+  );
+
+  return {
+    message: 'quotient rule',
+    before: node,
+    after: after,
+    substeps: [numStep, denStep],
+  };
+};

--- a/packages/solver/src/factor/__tests__/factor.test.ts
+++ b/packages/solver/src/factor/__tests__/factor.test.ts
@@ -2,9 +2,6 @@ import * as Semantic from '@math-blocks/semantic';
 import * as Testing from '@math-blocks/testing';
 
 import { factor } from '../factor';
-import { toHaveSubstepsLike, toHaveFullStepsLike } from '../../test-util';
-
-expect.extend({ toHaveSubstepsLike, toHaveFullStepsLike });
 
 const parsePolynomial = (input: string): Semantic.types.Add => {
   return Testing.parse(input) as Semantic.types.Add;

--- a/packages/solver/src/simplify/simplify.ts
+++ b/packages/solver/src/simplify/simplify.ts
@@ -14,6 +14,7 @@ import { mulFraction } from './transforms/mul-fraction';
 import { simplifyMul } from './transforms/simplify-mul';
 import { mulByZeroIsZero } from './transforms/mul-by-zero-is-zero';
 import { simplifyDivByFrac } from './transforms/simplify-div-by-frac';
+import { removePowOne } from './transforms/remove-pow-one';
 
 import { mulToPow } from './transforms/mul-to-pow';
 import { multiplyPowers } from './transforms/multiply-powers';
@@ -47,6 +48,7 @@ export function simplify(
     mulToPow,
     multiplyPowers,
     dividePowers,
+    removePowOne,
 
     // We put this last so that we don't covert 3 + -(x + 1) to 3 - (x + 1)
     // before distributing.

--- a/packages/solver/src/simplify/transforms/remove-pow-one.ts
+++ b/packages/solver/src/simplify/transforms/remove-pow-one.ts
@@ -1,0 +1,18 @@
+import { types, util, builders, NodeType } from '@math-blocks/semantic';
+
+import type { Step } from '../../types';
+
+export function removePowOne(node: types.Node): Step<types.Node> | void {
+  if (node.type !== NodeType.Power) {
+    return;
+  }
+  const { base, exp } = node;
+  if (util.deepEquals(exp, builders.number('1'))) {
+    return {
+      message: 'drop power of one',
+      before: node,
+      after: base,
+      substeps: [],
+    };
+  }
+}

--- a/packages/solver/src/types.ts
+++ b/packages/solver/src/types.ts
@@ -35,6 +35,7 @@ export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'multiply each term', TNode>
   | StepType<'distribute', TNode>
   | StepType<'drop adding zero', TNode> // additive identity
+  | StepType<'drop power of one', TNode>
   | StepType<'drop parentheses', TNode>
   | StepType<'evaluate multiplication', TNode>
   | StepType<'evaluate addition', TNode>
@@ -95,6 +96,11 @@ export type Step<TNode extends Semantic.types.Node = Semantic.types.Node> =
   | StepType<'split factored equation', TNode>
   | StepType<'split linear term', TNode>
   | StepType<'factor', TNode> // TODO: update this to say what factor we're extract from an expression
+  | StepType<'differentiate', TNode>
+  | StepType<'power rule', TNode>
+  | StepType<'product rule', TNode>
+  | StepType<'quotient rule', TNode>
+  | StepType<'chain rule', TNode>
   | StepType<'test', TNode>; // this last one is only used in tests
 
 // TODO: update to support multiple parts


### PR DESCRIPTION
This PR implements a few different derivative rules.  I want to update the parser to be able to parse derivatives so that this notation can be used by the solver, but before I do that I want to update all of the tests to use TeX syntax instead of the testing parser.  This will remove one of the parsers we have to maintain.  I'll do that in a separate PR.